### PR TITLE
Conditional rendering to show results

### DIFF
--- a/__tests__/components/ActionButton.test.js
+++ b/__tests__/components/ActionButton.test.js
@@ -17,7 +17,7 @@ describe('ActionButton', () => {
     render(<ActionButton text="text" style="primary" />)
     const sut = screen.getByText('text')
     expect(sut).toHaveClass(
-      'border-blue-deep bg-blue-dark text-basic-white hover:bg-blue-normal'
+      'inline-block text-center align-middle rounded border py-2.5 px-3.5 focus:ring-2 focus:ring-offset-2border-blue-deep bg-blue-dark text-basic-white hover:bg-blue-normal'
     )
   })
 

--- a/__tests__/components/ActionButton.test.js
+++ b/__tests__/components/ActionButton.test.js
@@ -17,7 +17,7 @@ describe('ActionButton', () => {
     render(<ActionButton text="text" style="primary" />)
     const sut = screen.getByText('text')
     expect(sut).toHaveClass(
-      'inline-block text-center align-middle rounded border py-2.5 px-3.5 focus:ring-2 focus:ring-offset-2border-blue-deep bg-blue-dark text-basic-white hover:bg-blue-normal'
+      'border-blue-deep bg-blue-dark text-basic-white hover:bg-blue-normal'
     )
   })
 

--- a/components/ActionButton.js
+++ b/components/ActionButton.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types'
 
 export default function ActionButton(props) {
   let classStyle =
-    'inline-block text-center align-middle rounded border py-2.5 px-3.5 focus:ring-2 focus:ring-offset-2'
+    'inline-block text-center align-middle rounded border py-2.5 px-3.5 focus:ring-2 focus:ring-offset-2 '
   switch (props.style) {
     case 'primary':
       classStyle +=

--- a/components/ActionButton.js
+++ b/components/ActionButton.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types'
 
 export default function ActionButton(props) {
   let classStyle =
-    'inline-block text-center align-middle rounded border py-2.5 px-3.5 '
+    'inline-block text-center align-middle rounded border py-2.5 px-3.5 focus:ring-2 focus:ring-offset-2'
   switch (props.style) {
     case 'primary':
       classStyle +=

--- a/components/ErrorSummary.js
+++ b/components/ErrorSummary.js
@@ -6,7 +6,7 @@ export default function ErrorSummary(props) {
       id={props.id}
       className="border-l-6 border-accent-error mb-6 ml-2.5 pl-4"
     >
-      <h2 className="text-2xl pt-4 ml-4">{props.summary}</h2>
+      <h2 className="text-2xl pt-4">{props.summary}</h2>
       <ul className="list-disc pb-6 ml-4">
         {props.errors.map((error, index) => {
           return (

--- a/locales/home/en.js
+++ b/locales/home/en.js
@@ -34,9 +34,12 @@ export default {
   unableToFindStatus:
     'We are unable to determine the status of your application at this time using this service.',
   statusIs:
-    'The latest status of your application according to our reccords is: ',
+    'The latest status of your application according to our records is: ',
   status: {
     INPROGRESS: 'In Progress',
     MAILED: 'Mailed',
   },
+  checkAgain:
+    'To check the status of another application, click the button below:',
+  resetForm: 'Go Back',
 }

--- a/locales/home/fr.js
+++ b/locales/home/fr.js
@@ -35,4 +35,7 @@ export default {
     INPROGRESS: 'En cours',
     MAILED: 'Envoyé par la poste',
   },
+  checkAgain:
+    "Pour vérifier l'état d'une autre demande, cliquez sur le bouton ci-dessous:",
+  resetForm: 'Retourner',
 }

--- a/pages/home.js
+++ b/pages/home.js
@@ -25,9 +25,24 @@ export default function Home(props) {
     }
   }
 
+  const handleReset = async (e) => {
+    e.preventDefault()
+    //clear form data, errors & results
+    setErrorSummary()
+    setEsrfError()
+    setGivenNameError()
+    setSurnameError()
+    setBirthDateError()
+    setEsrf()
+    setGivenName()
+    setSurname()
+    setBirthDate()
+    setResponse()
+  }
+
   const handleSubmit = async (e) => {
     e.preventDefault()
-    //clear erros & results
+    //clear errors & results
     setErrorSummary()
     setEsrfError()
     setGivenNameError()
@@ -39,7 +54,7 @@ export default function Home(props) {
     //validate data
     if (!esrf) errors.push(setError('esrf', props.content.esrf.error.required))
     else if (esrf.length != 8)
-      errors.concat(setError('esrf', props.content.esrf.error.length))
+      errors.push(setError('esrf', props.content.esrf.error.length))
 
     if (!givenName)
       errors.push(setError('givenName', props.content.givenName.error.required))
@@ -92,23 +107,8 @@ export default function Home(props) {
 
   return (
     <>
-      <h1>{props.content.header}</h1>
-      <p>{props.content.description}</p>
-
-      {!response ? null : (
-        <div id="response">
-          {response.success ? (
-            <p className="border-l-6 border-accent-info mb-6 ml-2.5 pl-4 text-2xl">
-              {props.content.statusIs}{' '}
-              <strong>{props.content.status[response.status]}</strong>.
-            </p>
-          ) : (
-            <p className="border-l-6 border-accent-warning mb-6 ml-2.5 pl-4 text-2xl">
-              {props.content.unableToFindStatus}
-            </p>
-          )}
-        </div>
-      )}
+      <h1 className="mb-4">{props.content.header}</h1>
+      {!response ? <p>{props.content.description}</p> : undefined}
 
       {!errorSummary ? null : (
         <ErrorSummary
@@ -117,54 +117,77 @@ export default function Home(props) {
           errors={errorSummary}
         />
       )}
-      <form onSubmit={handleSubmit} id="form-get-status">
-        <InputFeild
-          id="esrf"
-          name="FileNumber"
-          label={props.content.esrf.label}
-          required
-          textRequired={props.commonContent.required}
-          value={esrf}
-          onChange={setEsrf}
-          errorMessage={esrfError}
-        />
-        <InputFeild
-          id="givenName"
-          name="givenName"
-          label={props.content.givenName.label}
-          required
-          textRequired={props.commonContent.required}
-          value={givenName}
-          onChange={setGivenName}
-          errorMessage={givenNameError}
-        />
-        <InputFeild
-          id="surname"
-          name="surname"
-          label={props.content.surname.label}
-          required
-          textRequired={props.commonContent.required}
-          value={surname}
-          onChange={setSurname}
-          errorMessage={surnameError}
-        />
-        <InputFeild
-          id="dob"
-          name="birthDate"
-          label={props.content.birthDate.label}
-          required
-          textRequired={props.commonContent.required}
-          value={birthDate}
-          onChange={setBirthDate}
-          errorMessage={birthDateError}
-          type="date"
-        />
-        <ActionButton
-          type="submit"
-          text={props.content.checkStatus}
-          style="primary"
-        />
-      </form>
+      {!response ? (
+        <form onSubmit={handleSubmit} id="form-get-status">
+          <InputFeild
+            id="esrf"
+            name="FileNumber"
+            label={props.content.esrf.label}
+            required
+            textRequired={props.commonContent.required}
+            value={esrf}
+            onChange={setEsrf}
+            errorMessage={esrfError}
+          />
+          <InputFeild
+            id="givenName"
+            name="givenName"
+            label={props.content.givenName.label}
+            required
+            textRequired={props.commonContent.required}
+            value={givenName}
+            onChange={setGivenName}
+            errorMessage={givenNameError}
+          />
+          <InputFeild
+            id="surname"
+            name="surname"
+            label={props.content.surname.label}
+            required
+            textRequired={props.commonContent.required}
+            value={surname}
+            onChange={setSurname}
+            errorMessage={surnameError}
+          />
+          <InputFeild
+            id="dob"
+            name="birthDate"
+            label={props.content.birthDate.label}
+            required
+            textRequired={props.commonContent.required}
+            value={birthDate}
+            onChange={setBirthDate}
+            errorMessage={birthDateError}
+            type="date"
+          />
+          <ActionButton
+            type="submit"
+            text={props.content.checkStatus}
+            style="primary"
+          />
+        </form>
+      ) : (
+        <div id="response">
+          {response.success ? (
+            <p className="mb-6 text-2xl">
+              {props.content.statusIs}{' '}
+              <strong>{props.content.status[response.status]}</strong>.
+            </p>
+          ) : (
+            <p className=" mb-6 text-2xl">{props.content.unableToFindStatus}</p>
+          )}
+        </div>
+      )}
+      {response ? (
+        <div>
+          <p className="mb-6 text-2xl">{props.content.checkAgain}</p>
+          <ActionButton
+            onClick={handleReset}
+            text={props.content.resetForm}
+            style="primary"
+          />
+        </div>
+      ) : undefined}
     </>
   )
 }

--- a/pages/home.js
+++ b/pages/home.js
@@ -108,64 +108,65 @@ export default function Home(props) {
   return (
     <>
       <h1 className="mb-4">{props.content.header}</h1>
-      {!response ? <p>{props.content.description}</p> : undefined}
-
-      {!errorSummary ? null : (
-        <ErrorSummary
-          id="error-summary-get-status"
-          summary={props.commonContent.foundErrors}
-          errors={errorSummary}
-        />
-      )}
       {!response ? (
-        <form onSubmit={handleSubmit} id="form-get-status">
-          <InputFeild
-            id="esrf"
-            name="FileNumber"
-            label={props.content.esrf.label}
-            required
-            textRequired={props.commonContent.required}
-            value={esrf}
-            onChange={setEsrf}
-            errorMessage={esrfError}
-          />
-          <InputFeild
-            id="givenName"
-            name="givenName"
-            label={props.content.givenName.label}
-            required
-            textRequired={props.commonContent.required}
-            value={givenName}
-            onChange={setGivenName}
-            errorMessage={givenNameError}
-          />
-          <InputFeild
-            id="surname"
-            name="surname"
-            label={props.content.surname.label}
-            required
-            textRequired={props.commonContent.required}
-            value={surname}
-            onChange={setSurname}
-            errorMessage={surnameError}
-          />
-          <InputFeild
-            id="dob"
-            name="birthDate"
-            label={props.content.birthDate.label}
-            required
-            textRequired={props.commonContent.required}
-            value={birthDate}
-            onChange={setBirthDate}
-            errorMessage={birthDateError}
-            type="date"
-          />
-          <ActionButton
-            type="submit"
-            text={props.content.checkStatus}
-            style="primary"
-          />
-        </form>
+        <div>
+          <p>{props.content.description}</p>
+          {!errorSummary ? null : (
+            <ErrorSummary
+              id="error-summary-get-status"
+              summary={props.commonContent.foundErrors}
+              errors={errorSummary}
+            />
+          )}
+          <form onSubmit={handleSubmit} id="form-get-status">
+            <InputFeild
+              id="esrf"
+              name="FileNumber"
+              label={props.content.esrf.label}
+              required
+              textRequired={props.commonContent.required}
+              value={esrf}
+              onChange={setEsrf}
+              errorMessage={esrfError}
+            />
+            <InputFeild
+              id="givenName"
+              name="givenName"
+              label={props.content.givenName.label}
+              required
+              textRequired={props.commonContent.required}
+              value={givenName}
+              onChange={setGivenName}
+              errorMessage={givenNameError}
+            />
+            <InputFeild
+              id="surname"
+              name="surname"
+              label={props.content.surname.label}
+              required
+              textRequired={props.commonContent.required}
+              value={surname}
+              onChange={setSurname}
+              errorMessage={surnameError}
+            />
+            <InputFeild
+              id="dob"
+              name="birthDate"
+              label={props.content.birthDate.label}
+              required
+              textRequired={props.commonContent.required}
+              value={birthDate}
+              onChange={setBirthDate}
+              errorMessage={birthDateError}
+              type="date"
+            />
+            <ActionButton
+              type="submit"
+              text={props.content.checkStatus}
+              style="primary"
+            />
+          </form>
+        </div>
       ) : (
         <div id="response">
           {response.success ? (
@@ -176,10 +177,6 @@ export default function Home(props) {
           ) : (
             <p className=" mb-6 text-2xl">{props.content.unableToFindStatus}</p>
           )}
-        </div>
-      )}
-      {response ? (
-        <div>
           <p className="mb-6 text-2xl">{props.content.checkAgain}</p>
           <ActionButton
             onClick={handleReset}
@@ -187,7 +184,7 @@ export default function Home(props) {
             style="primary"
           />
         </div>
-      ) : undefined}
+      )}
     </>
   )
 }


### PR DESCRIPTION
## [ADO-661](https://dev.azure.com/DTS-STN/passport-status/_workitems/edit/661)

### Description

This PR adds conditional rendering to the home page so that when a user enters valid information, the form disappears and a response message is shown indicating either the status of the application or that there was a problem retrieving the information (in this case when a name is entered that has no info). I've also changed the error handling for the ESRF field so it catches when the number is less than 8 digits. I've also removed the borders on the response messages as they aren't inline with the form anymore. Lastly, I added a button that is shown below the response that resets all form data via a handler and updated the focus styling on the `ActionButton` component.

### What to test for/How to test
1. Pull in branch
2. Type `npm run dev`
3. Enter valid and invalid data in the form to ensure it works as intended (ie. enter 1234 into the ESRF field for the 8 digit error to pop up, enter John for given name and then Jack to see success message vs problem retrieving)