### PR TITLE
Dynamic branch links

### DIFF
--- a/.github/workflows/pr-helper.yml
+++ b/.github/workflows/pr-helper.yml
@@ -25,7 +25,7 @@ jobs:
           edit-mode: replace
           issue-number: ${{ github.event.pull_request.number }}
           body: |
-            [Integration Deployment :rocket: ](https://passport-status-d-${{ github.head_ref }}.dev-rhp.dts-stn.com) - [![Build Status](https://teamcity.dev.admin.dts-stn.com/app/rest/builds/buildType:id:passport_status_Dynamic,branch:name:${{ github.head_ref }}/statusIcon.svg)](https://teamcity.dev.admin.dts-stn.com/buildConfiguration/passport_status_dynamic?branch=${{ github.head_ref }}&buildTypeTab=overview&mode=builds)
+            [Integration Deployment :rocket: ](https://passport-status-d-${{ github.head_ref }}.dev-rhp.dts-stn.com) - [Build Status](https://teamcity.dev.admin.dts-stn.com/buildConfiguration/passport_status_dynamic?branch=${{ github.head_ref }}&buildTypeTab=overview&mode=builds)
             ![Default Tests Workflow Status](https://github.com/DTS-STN/${{ github.event.pull_request.base.repo.name }}/actions/workflows/default-tests.yml/badge.svg?branch=${{ github.head_ref }})
             [Jest Coverage Report](https://dts-stn.github.io/${{ github.event.pull_request.base.repo.name }}/${{ github.ref }}/unit-test-results/lcov-report/) 
             [Cypress Coverage Report](https://dts-stn.github.io/${{ github.event.pull_request.base.repo.name }}/${{ github.ref }}/e2e-test-report/) 

--- a/.github/workflows/pr-helper.yml
+++ b/.github/workflows/pr-helper.yml
@@ -25,7 +25,7 @@ jobs:
           edit-mode: replace
           issue-number: ${{ github.event.pull_request.number }}
           body: |
-            [Integration Deployment :rocket: ](https://passport-status-d-${{ github.head_ref }}.bdm-dev-rhp.dts-stn.com) - [Build Status)](https://teamcity.dev.admin.dts-stn.com/buildConfiguration/DtsDevelopment_PassportStatus_BuildDynamic?branch=${{ github.head_ref }}&buildTypeTab=overview&mode=builds)
+            [Integration Deployment :rocket: ](https://passport-status-d-${{ github.head_ref }}.dev-rhp.dts-stn.com) - [Build Status)](https://teamcity.dev.admin.dts-stn.com/buildConfiguration/passport_status_dynamic?branch=${{ github.head_ref }}&buildTypeTab=overview&mode=builds) [Build Status](https://teamcity.dev.admin.dts-stn.com/app/rest/builds/buildType:id:passport_status_Dynamic,branch:name:${{ github.head_ref }}/statusIcon.svg)
             ![Default Tests Workflow Status](https://github.com/DTS-STN/${{ github.event.pull_request.base.repo.name }}/actions/workflows/default-tests.yml/badge.svg?branch=${{ github.head_ref }})
             [Jest Coverage Report](https://dts-stn.github.io/${{ github.event.pull_request.base.repo.name }}/${{ github.ref }}/unit-test-results/lcov-report/) 
             [Cypress Coverage Report](https://dts-stn.github.io/${{ github.event.pull_request.base.repo.name }}/${{ github.ref }}/e2e-test-report/) 

--- a/.github/workflows/pr-helper.yml
+++ b/.github/workflows/pr-helper.yml
@@ -25,7 +25,7 @@ jobs:
           edit-mode: replace
           issue-number: ${{ github.event.pull_request.number }}
           body: |
-            [Integration Deployment :rocket: ](https://passport-status-d-${{ github.head_ref }}.dev-rhp.dts-stn.com) - [Build Status)](https://teamcity.dev.admin.dts-stn.com/buildConfiguration/passport_status_dynamic?branch=${{ github.head_ref }}&buildTypeTab=overview&mode=builds) [Build Status](https://teamcity.dev.admin.dts-stn.com/app/rest/builds/buildType:id:passport_status_Dynamic,branch:name:${{ github.head_ref }}/statusIcon.svg)
+            [Integration Deployment :rocket: ](https://passport-status-d-${{ github.head_ref }}.dev-rhp.dts-stn.com) - [![Build Status](https://teamcity.dev.admin.dts-stn.com/app/rest/builds/buildType:id:passport_status_Dynamic,branch:name:${{ github.head_ref }}/statusIcon.svg)](https://teamcity.dev.admin.dts-stn.com/buildConfiguration/passport_status_dynamic?branch=${{ github.head_ref }}&buildTypeTab=overview&mode=builds)
             ![Default Tests Workflow Status](https://github.com/DTS-STN/${{ github.event.pull_request.base.repo.name }}/actions/workflows/default-tests.yml/badge.svg?branch=${{ github.head_ref }})
             [Jest Coverage Report](https://dts-stn.github.io/${{ github.event.pull_request.base.repo.name }}/${{ github.ref }}/unit-test-results/lcov-report/) 
             [Cypress Coverage Report](https://dts-stn.github.io/${{ github.event.pull_request.base.repo.name }}/${{ github.ref }}/e2e-test-report/) 


### PR DESCRIPTION
## [ADO-682](https://dev.azure.com/DTS-STN/passport-status/_workitems/edit/682)

### Description

List of proposed changes:

- Fixes the link in the PR comment to point to the dynamic build. (The build configuration is done manually in TC)  
  Note: this may not work for long branch names

### What to test for/How to test

Check that the links in the comment work (Integration Deployment & Build Status)

### Additional Notes
