### PR TITLE
use a key-value pair to lookup the status

### DIFF
--- a/locales/home/en.tsx
+++ b/locales/home/en.tsx
@@ -1,7 +1,7 @@
-const status: { [key: string]: string } = {
-  ['APPROVED']: 'Approved',
-  ['IN_EXAMINATION']: 'In examination',
-  ['REJECTED']: 'Rejected',
+const status: Record<string, string> = {
+  APPROVED: 'Approved',
+  IN_EXAMINATION: 'In examination',
+  REJECTED: 'Rejected',
 }
 
 const homeEN = {

--- a/locales/home/en.tsx
+++ b/locales/home/en.tsx
@@ -1,3 +1,9 @@
+const status: { [key: string]: string } = {
+  ['APPROVED']: 'Approved',
+  ['IN_EXAMINATION']: 'In examination',
+  ['REJECTED']: 'Rejected',
+}
+
 const homeEN = {
   header: 'Passport Status Check',
   description:
@@ -35,11 +41,7 @@ const homeEN = {
     'We are unable to determine the status of your application at this time using this service.',
   statusIs:
     'The latest status of your application according to our records is: ',
-  status: {
-    APPROVED: 'Approved',
-    IN_EXAMINATION: 'In examination',
-    REJECTED: 'Rejected',
-  },
+  status: status,
   checkAgain:
     'To check the status of another application, click the button below:',
   goBack: 'Go Back',

--- a/locales/home/fr.tsx
+++ b/locales/home/fr.tsx
@@ -1,3 +1,9 @@
+const status: { [key: string]: string } = {
+  ['APPROVED']: 'Approuvé',
+  ['IN_EXAMINATION']: 'En examen',
+  ['REJECTED']: 'Rejetée',
+}
+
 const homeFR = {
   header: 'Vérification du statut du passeport',
   description:
@@ -34,11 +40,7 @@ const homeFR = {
   unableToFindStatus:
     'Nous ne sommes pas en mesure de déterminer le statut de votre demande pour le moment en utilisant ce service.',
   statusIs: 'Le dernier statut de votre candidature selon nos dossiers est : ',
-  status: {
-    APPROVED: 'Approuvé',
-    IN_EXAMINATION: 'En examen',
-    REJECTED: 'Rejetée',
-  },
+  status: status,
   checkAgain:
     "Pour vérifier l'état d'une autre demande, cliquez sur le bouton ci-dessous:",
   goBack: 'Retourner',

--- a/locales/home/fr.tsx
+++ b/locales/home/fr.tsx
@@ -1,7 +1,7 @@
-const status: { [key: string]: string } = {
-  ['APPROVED']: 'Approuvé',
-  ['IN_EXAMINATION']: 'En examen',
-  ['REJECTED']: 'Rejetée',
+const status: Record<string, string> = {
+  APPROVED: 'Approuvé',
+  IN_EXAMINATION: 'En examen',
+  REJECTED: 'Rejetée',
 }
 
 const homeFR = {

--- a/pages/home.tsx
+++ b/pages/home.tsx
@@ -174,24 +174,17 @@ export const PassportStatusInfo: FC<PassportStatusInfoProps> = ({
 }) => {
   const homeLocale = useHomeLocale()
 
-  const getStatusText = (status?: string) => {
-    switch (status?.toUpperCase()) {
-      case 'IN_EXAMINATION':
-        return homeLocale.status.IN_EXAMINATION
-      case 'APPROVED':
-        return homeLocale.status.APPROVED
-      case 'REJECTED':
-        return homeLocale.status.REJECTED
-      default:
-        return status
-    }
-  }
-
   return (
     <div id="response">
       <p className="mb-6 text-2xl">
         {homeLocale.statusIs}{' '}
-        <strong>{getStatusText(checkStatusResponse.status)}</strong>.
+        <strong>
+          {checkStatusResponse.status
+            ? homeLocale.status[checkStatusResponse.status.toUpperCase()] ??
+              checkStatusResponse.status
+            : null}
+        </strong>
+        .
       </p>
       <p className="mb-6 text-2xl">{homeLocale.checkAgain}</p>
       <ActionButton


### PR DESCRIPTION
### Description

List of proposed changes:

- This changes out a switch/case for a key/value pair lookup which would be faster, but main benefit is not having to update the "hard code" (if ever translations were extracted from a CMS) to include new status'

### What to test for/How to test

Everything works the same as before

### Additional Notes
