### PR TITLE
Added landing page, updated ActionButton component

### DIFF
--- a/__tests__/components/ActionButton.test.tsx
+++ b/__tests__/components/ActionButton.test.tsx
@@ -21,6 +21,18 @@ describe('ActionButton', () => {
     )
   })
 
+  it('renders properly as an anchor tag using Next/Link', () => {
+    render(
+      <ActionButton
+        text="text"
+        style="primary"
+        href="https://www.someurl.com"
+      />
+    )
+    const sut = screen.getByText('text')
+    expect(sut).toBeInTheDocument()
+  })
+
   it('is meets a11y', async () => {
     const results = await axe(container)
     expect(results).toHaveNoViolations()

--- a/__tests__/pages/home.test.js
+++ b/__tests__/pages/home.test.js
@@ -1,31 +1,22 @@
+/**
+ * @jest-environment jsdom
+ */
 import { render, screen } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import Home from '../../pages/home'
 import { useRouter } from 'next/router'
-import { useCheckStatus } from '../../hooks/api/useCheckStatus'
 
 // mocks useRouter to be able to use component' router.asPath
 jest.mock('next/router', () => ({
   useRouter: jest.fn(),
 }))
-jest.mock('../../components/InputField', () => () => {
-  return <mock-modal data-testid="test-modal" />
-})
-jest.mock('../../components/ActionButton', () => () => {
-  return <mock-modal data-testid="button-modal" />
-})
-jest.mock('../../components/ErrorSummary', () => () => {
-  return <mock-modal data-testid="errors-modal" />
-})
-jest.mock('../../hooks/api/useCheckStatus')
 
-describe('Home page', () => {
+describe('landing page', () => {
   beforeEach(() => {
     useRouter.mockImplementation(() => ({
       pathname: '/',
       asPath: '/',
     }))
-    useCheckStatus.mockImplementation(() => ({}))
   })
 
   it('should render the page', () => {

--- a/__tests__/pages/status.test.js
+++ b/__tests__/pages/status.test.js
@@ -1,0 +1,36 @@
+import { render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import Status from '../../pages/status'
+import { useRouter } from 'next/router'
+import { useCheckStatus } from '../../hooks/api/useCheckStatus'
+
+// mocks useRouter to be able to use component' router.asPath
+jest.mock('next/router', () => ({
+  useRouter: jest.fn(),
+}))
+jest.mock('../../components/InputField', () => () => {
+  return <mock-modal data-testid="test-modal" />
+})
+jest.mock('../../components/ActionButton', () => () => {
+  return <mock-modal data-testid="button-modal" />
+})
+jest.mock('../../components/ErrorSummary', () => () => {
+  return <mock-modal data-testid="errors-modal" />
+})
+jest.mock('../../hooks/api/useCheckStatus')
+
+describe('Check status page page', () => {
+  beforeEach(() => {
+    useRouter.mockImplementation(() => ({
+      pathname: '/',
+      asPath: '/',
+    }))
+    useCheckStatus.mockImplementation(() => ({}))
+  })
+
+  it('should render the page', () => {
+    render(<Status />)
+    const heading = screen.getByRole('heading', { level: 1 })
+    expect(heading).toBeInTheDocument()
+  })
+})

--- a/components/ActionButton.tsx
+++ b/components/ActionButton.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link'
 import { FC, MouseEventHandler } from 'react'
 
 export interface ActionButtonProps {
@@ -6,6 +7,7 @@ export interface ActionButtonProps {
   style?: 'default' | 'primary' | 'super' | 'danger'
   text: string
   type?: 'button' | 'submit' | 'reset'
+  href?: string
 }
 
 const ActionButton: FC<ActionButtonProps> = ({
@@ -14,6 +16,7 @@ const ActionButton: FC<ActionButtonProps> = ({
   style,
   text,
   type,
+  href,
 }) => {
   let classStyle =
     'inline-block text-center align-middle rounded border py-2.5 px-3.5 focus:ring-2 focus:ring-offset-2 '
@@ -28,7 +31,11 @@ const ActionButton: FC<ActionButtonProps> = ({
       break
   }
 
-  return (
+  return href ? (
+    <Link href={href}>
+      <a className={classStyle}>{text}</a>
+    </Link>
+  ) : (
     <button
       className={classStyle}
       onClick={onClick}

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -13,7 +13,7 @@ const Header: FC = () => {
     <>
       <nav
         role="navigation"
-        aria-label={t('skip-to-main-content')}
+        aria-label={t('skip-to.main-content')}
         className="absolute w-px h-px -left-96 focus-within:w-screen focus-within:h-auto focus-within:top-4 focus-within:z-50 focus-within:flex focus-within:justify-center"
       >
         <a
@@ -22,7 +22,7 @@ const Header: FC = () => {
           href="#mainContent"
           draggable="false"
         >
-          {t('skip-to-main-content')}
+          {t('skip-to.main-content')}
         </a>
       </nav>
 

--- a/i18n.json
+++ b/i18n.json
@@ -3,6 +3,7 @@
   "defaultLocale": "en",
   "pages": {
     "*": ["common"],
-    "/home": ["home"]
+    "/home": ["home"],
+    "/status": ["status"]
   }
 }

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -29,7 +29,7 @@
   "service-and-benefits": "Service and Benefits",
   "skip-to": {
     "about-government": "Skip to 'About government'",
-    "mainContent": "Skip to main content"
+    "main-content": "Skip to main content"
   },
   "title": "home",
   "tools": "Tools",

--- a/locales/en/home.json
+++ b/locales/en/home.json
@@ -1,41 +1,7 @@
 {
-  "birth-date": {
-    "error": {
-      "current": "The Date of birth must be a date in the past",
-      "invalid": "The Date of birth must be a valid date in the format of (dd/mm/yyyy)",
-      "required": "The Date of birth is required"
-    },
-    "label": "Date of birth"
-  },
-  "check-again": "To check the status of another application, click the button below:",
-  "check-status": "Check Status",
-  "description": "Use this service with your ESRF to check the status of your passport application.",
-  "esrf": {
-    "error": {
-      "length": "The File number must be 8 characters long",
-      "required": "The File number is required"
-    },
-    "label": "File number"
-  },
-  "given-name": {
-    "error": {
-      "required": "The Given name is required"
-    },
-    "label": "Given Name"
-  },
-  "go-back": "Go Back",
   "header": "Passport Status Check",
-  "status": {
-    "APPROVED": "Approved",
-    "IN_EXAMINATION": "In examination",
-    "REJECTED": "Rejected"
-  },
-  "status-is": "The latest status of your application according to our records is: ",
-  "surname": {
-    "error": {
-      "required": "The Surname is required"
-    },
-    "label": "Surname"
-  },
-  "unable-to-find-status": "We are unable to determine the status of your application at this time using this service."
+  "description": "In order to better serve you, please select the option below that best suits you",
+  "intakeForm": "https://www.canada.ca/en/immigration-refugees-citizenship/services/canadian-passports/check-passport-travel-document-application.html",
+  "withESRF": "I have my file number (ESRF)",
+  "withoutESRF": "I don't have my file number (ESRF)"
 }

--- a/locales/en/status.json
+++ b/locales/en/status.json
@@ -1,0 +1,41 @@
+{
+  "birth-date": {
+    "error": {
+      "current": "The Date of birth must be a date in the past",
+      "invalid": "The Date of birth must be a valid date in the format of (dd/mm/yyyy)",
+      "required": "The Date of birth is required"
+    },
+    "label": "Date of birth"
+  },
+  "check-again": "To check the status of another application, click the button below:",
+  "check-status": "Check Status",
+  "description": "Use this service with your ESRF to check the status of your passport application.",
+  "esrf": {
+    "error": {
+      "length": "The File number must be 8 characters long",
+      "required": "The File number is required"
+    },
+    "label": "File number"
+  },
+  "given-name": {
+    "error": {
+      "required": "The Given name is required"
+    },
+    "label": "Given Name"
+  },
+  "go-back": "Go Back",
+  "header": "Passport Status Check",
+  "status": {
+    "APPROVED": "Approved",
+    "IN_EXAMINATION": "In examination",
+    "REJECTED": "Rejected"
+  },
+  "status-is": "The latest status of your application according to our records is: ",
+  "surname": {
+    "error": {
+      "required": "The Surname is required"
+    },
+    "label": "Surname"
+  },
+  "unable-to-find-status": "We are unable to determine the status of your application at this time using this service."
+}

--- a/locales/fr/home.json
+++ b/locales/fr/home.json
@@ -1,41 +1,7 @@
 {
-  "birth-date": {
-    "error": {
-      "current": "La date de naissance doit être une date dans le passé",
-      "invalid": "La date de naissance doit être une date valide au format (yyyy-MM-dd)",
-      "required": "La date de naissance est obligatoire"
-    },
-    "label": "Date de naissance"
-  },
-  "check-again": "Pour vérifier l'état d'une autre demande, cliquez sur le bouton ci-dessous:",
-  "check-status": "Vérifier l'état",
-  "description": "Utilisez ce service avec votre ESRF pour vérifier le statut de votre demande de passeport.",
-  "esrf": {
-    "error": {
-      "length": "Le numéro de dossier doit comporter 8 caractères",
-      "required": "Le numéro de dossier est obligatoire"
-    },
-    "label": "Numéro de dossier"
-  },
-  "given-name": {
-    "error": {
-      "required": "Le prénom est obligatoire"
-    },
-    "label": "Prénom"
-  },
-  "go-back": "Retourner",
   "header": "Vérification du statut du passeport",
-  "status": {
-    "APPROVED": "Approuvée",
-    "IN_EXAMINATION": "En examen",
-    "REJECTED": "Rejetée"
-  },
-  "status-is": "Le dernier statut de votre candidature selon nos dossiers est : ",
-  "surname": {
-    "error": {
-      "required": "Le nom de famille est obligatoire"
-    },
-    "label": "Nom de famille"
-  },
-  "unable-to-find-status": "Nous ne sommes pas en mesure de déterminer le statut de votre demande pour le moment en utilisant ce service."
+  "description": "Afin de mieux vous servir, veuillez sélectionner l'option ci-dessous qui vous convient le mieux.",
+  "intakeForm": "https://www.canada.ca/fr/immigration-refugies-citoyennete/services/passeports-canadiens/verifier-demande-passeports-documents-voyage.html",
+  "withESRF": "J'ai mon numéro de dossier (ESRF)",
+  "withoutESRF": "Je n'ai pas mon numéro de dossier (ESRF)"
 }

--- a/locales/fr/status.json
+++ b/locales/fr/status.json
@@ -1,0 +1,41 @@
+{
+  "birth-date": {
+    "error": {
+      "current": "La date de naissance doit être une date dans le passé",
+      "invalid": "La date de naissance doit être une date valide au format (yyyy-MM-dd)",
+      "required": "La date de naissance est obligatoire"
+    },
+    "label": "Date de naissance"
+  },
+  "check-again": "Pour vérifier l'état d'une autre demande, cliquez sur le bouton ci-dessous:",
+  "check-status": "Vérifier l'état",
+  "description": "Utilisez ce service avec votre ESRF pour vérifier le statut de votre demande de passeport.",
+  "esrf": {
+    "error": {
+      "length": "Le numéro de dossier doit comporter 8 caractères",
+      "required": "Le numéro de dossier est obligatoire"
+    },
+    "label": "Numéro de dossier"
+  },
+  "given-name": {
+    "error": {
+      "required": "Le prénom est obligatoire"
+    },
+    "label": "Prénom"
+  },
+  "go-back": "Retourner",
+  "header": "Vérification du statut du passeport",
+  "status": {
+    "APPROVED": "Approuvée",
+    "IN_EXAMINATION": "En examen",
+    "REJECTED": "Rejetée"
+  },
+  "status-is": "Le dernier statut de votre candidature selon nos dossiers est : ",
+  "surname": {
+    "error": {
+      "required": "Le nom de famille est obligatoire"
+    },
+    "label": "Nom de famille"
+  },
+  "unable-to-find-status": "Nous ne sommes pas en mesure de déterminer le statut de votre demande pour le moment en utilisant ce service."
+}

--- a/pages/home.tsx
+++ b/pages/home.tsx
@@ -1,221 +1,33 @@
-import InputField from '../components/InputField'
 import ActionButton from '../components/ActionButton'
-import { FC, MouseEventHandler, useCallback, useMemo, useState } from 'react'
-import ErrorSummary, {
-  ErrorSummaryItem,
-  getErrorSummaryItem,
-} from '../components/ErrorSummary'
+import { FC } from 'react'
 import Layout from '../components/Layout'
-import { CheckStatusReponse, CheckStatusRequestBody } from './api/check-status'
-import { useCheckStatus } from '../hooks/api/useCheckStatus'
-import { useFormik } from 'formik'
-import * as Yup from 'yup'
 import useTranslation from 'next-translate/useTranslation'
-import Error from 'next/error'
+import Router from 'next/router'
 
 const Home: FC = () => {
   const { t } = useTranslation('home')
 
-  const [formSubmitted, setFormSubmitted] = useState(false)
-
-  const formik = useFormik<CheckStatusRequestBody>({
-    initialValues: {
-      birthDate: '',
-      esrf: '',
-      givenName: '',
-      surname: '',
-    },
-    validationSchema: Yup.object({
-      esrf: Yup.string()
-        .required('esrf.error.required')
-        .length(8, 'esrf.error.length'),
-      givenName: Yup.string().required('given-name.error.required'),
-      surname: Yup.string().required('surname.error.required'),
-      birthDate: Yup.date()
-        .required('birth-date.error.required')
-        .max(new Date(), 'birth-date.error.current'),
-    }),
-    validateOnBlur: false,
-    validateOnChange: false,
-    validateOnMount: false,
-    onReset: () => {
-      setFormSubmitted(false)
-      removeCheckStatusResponse()
-    },
-    onSubmit: (values) => {
-      setFormSubmitted(true)
-    },
-  })
-
-  const {
-    isLoading: isCheckStatusLoading,
-    error: checkStatusError,
-    data: checkStatusReponse,
-    remove: removeCheckStatusResponse,
-  } = useCheckStatus(formik.values, {
-    enabled: formik.isValid && formSubmitted,
-  })
-
-  const errorSummary = useMemo<ErrorSummaryItem[]>(() => {
-    return Object.keys(formik.errors)
-      .filter((key) => !!formik.errors[key as keyof typeof formik.errors])
-      .map((key) =>
-        getErrorSummaryItem(
-          key,
-          t(formik.errors[key as keyof typeof formik.errors] as string)
-        )
-      )
-  }, [formik, t])
-
-  const handleReset: MouseEventHandler<HTMLButtonElement> = useCallback(
-    (e) => {
-      e.preventDefault()
-      formik.resetForm()
-    },
-    [formik]
-  )
-
-  const handleGoBack: MouseEventHandler<HTMLButtonElement> = useCallback(
-    (e) => {
-      e.preventDefault()
-      setFormSubmitted(false)
-      removeCheckStatusResponse()
-    },
-    [removeCheckStatusResponse]
-  )
-
   return (
     <Layout>
       <h1 className="mb-4">{t('header')}</h1>
-      {checkStatusError ? (
-        <Error statusCode={checkStatusError.statusCode} />
-      ) : checkStatusReponse ? (
-        <PassportStatusInfo
-          checkStatusResponse={checkStatusReponse}
-          handleGoBackClick={handleReset}
-        />
-      ) : checkStatusReponse === null ? (
-        <PassportStatusUnavailable handleGoBackClick={handleGoBack} />
-      ) : (
-        <>
-          <div>
-            <p>{t('description')}</p>
-            {errorSummary.length > 0 && (
-              <ErrorSummary
-                id="error-summary-get-status"
-                summary={t('common:found-errors')}
-                errors={errorSummary}
-              />
-            )}
-            <form onSubmit={formik.handleSubmit} id="form-get-status">
-              <InputField
-                id="esrf"
-                name="esrf"
-                label={t('esrf.label')}
-                onChange={formik.handleChange}
-                value={formik.values.esrf}
-                errorMessage={formik.errors.esrf && t(formik.errors.esrf)}
-                textRequired={t('common:required')}
-                required
-              />
-              <InputField
-                id="givenName"
-                name="givenName"
-                label={t('given-name.label')}
-                onChange={formik.handleChange}
-                value={formik.values.givenName}
-                errorMessage={
-                  formik.errors.givenName && t(formik.errors.givenName)
-                }
-                textRequired={t('common:required')}
-                required
-              />
-              <InputField
-                id="surname"
-                name="surname"
-                label={t('surname.label')}
-                onChange={formik.handleChange}
-                value={formik.values.surname}
-                errorMessage={formik.errors.surname && t(formik.errors.surname)}
-                textRequired={t('common:required')}
-                required
-              />
-              <InputField
-                id="birthDate"
-                name="birthDate"
-                type="date"
-                label={t('birth-date.label')}
-                onChange={formik.handleChange}
-                value={formik.values.birthDate}
-                errorMessage={
-                  formik.errors.birthDate && t(formik.errors.birthDate)
-                }
-                textRequired={t('common:required')}
-                required
-              />
-              <ActionButton
-                disabled={isCheckStatusLoading}
-                type="submit"
-                text={t('check-status')}
-                style="primary"
-              />
-            </form>
-          </div>
-        </>
-      )}
+      <h2 className="my-14">{t('description')}</h2>
+      <div className="grid grid-flow-row auto-rows-auto place-items-center text-xl gap-4">
+        <div className="text-center lg:w-1/3">
+          <ActionButton
+            href={t('intakeForm')}
+            style="primary"
+            text={t('withoutESRF')}
+          />
+        </div>
+        <div className="text-center lg:w-1/3">
+          <ActionButton
+            style="primary"
+            onClick={() => Router.push('/status')}
+            text={t('withESRF')}
+          />
+        </div>
+      </div>
     </Layout>
-  )
-}
-
-export interface PassportStatusInfoProps {
-  handleGoBackClick: MouseEventHandler<HTMLButtonElement>
-  checkStatusResponse: CheckStatusReponse
-}
-
-export const PassportStatusInfo: FC<PassportStatusInfoProps> = ({
-  checkStatusResponse,
-  handleGoBackClick,
-}) => {
-  const { t } = useTranslation('home')
-  return (
-    <div id="response">
-      <p className="mb-6 text-2xl">
-        {t('status-is')}{' '}
-        <strong>
-          {t(`status.${checkStatusResponse.status}`, null, {
-            default: checkStatusResponse.status,
-          })}
-        </strong>
-        .
-      </p>
-      <p className="mb-6 text-2xl">{t('check-again')}</p>
-      <ActionButton
-        onClick={handleGoBackClick}
-        text={t('go-back')}
-        style="primary"
-      />
-    </div>
-  )
-}
-
-export interface PassportStatusUnavailableProps {
-  handleGoBackClick: MouseEventHandler<HTMLButtonElement>
-}
-
-export const PassportStatusUnavailable: FC<PassportStatusUnavailableProps> = ({
-  handleGoBackClick,
-}) => {
-  const { t } = useTranslation('home')
-  return (
-    <div id="response">
-      <p className=" mb-6 text-2xl">{t('unable-to-find-status')}</p>
-      <p className="mb-6 text-2xl">{t('check-again')}</p>
-      <ActionButton
-        onClick={handleGoBackClick}
-        text={t('go-back')}
-        style="primary"
-      />
-    </div>
   )
 }
 


### PR DESCRIPTION
## [ADO-836](https://dev.azure.com/DTS-STN/passport-status/_workitems/edit/836)

### Description

This PR adds a simple landing page that either sends the user to our form if they have an ESRF or to the existing intake form if they don't have an ESRF (this may change in the future/we may add another form w/o ESRF but until the data feed solution is finalized this way is considered MVP).

I updated the `ActionButton` component to render a link using `Next/Link` if supplied an `href`.

There were a couple typos in the locale files that were resulting in some console warnings that I fixed as well.

### What to test for/How to test
1. Pull in branch
2. Type `npm run dev`
3. Upon selecting your language at the splash screen, you should be redirected to the new landing page.
4. If you select the left button (no ESRF) you will be redirected to the existing intake form
5. If you select the right button (you have your ESRF) you will be redirected to our form

### Additional Notes

The landing page in its current state is very simple, so I'm open to ideas/suggestions on sprucing it up