### PR TITLE
Add plurals to found-errors locale

### DIFF
--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -12,7 +12,10 @@
     "terms-and-condition": "Terms and conditions",
     "terms-and-condition-url": "https://www.canada.ca/en/transparency/terms.html"
   },
-  "found-errors": "The following errors were found in the form:",
+  "found-errors": {
+    "one": "The following error was found in the form:",
+    "other": "The following {{count}} errors were found in the form:"
+  },
   "francais": "Français",
   "goc": "Government of Canada",
   "goc-link": "https://www.canada.ca/en.html",

--- a/locales/fr/common.json
+++ b/locales/fr/common.json
@@ -12,7 +12,10 @@
     "terms-and-condition": "Avis",
     "terms-and-condition-url": "https://www.canada.ca/en/transparency/terms.html"
   },
-  "found-errors": "Les erreurs suivantes ont été trouvées dans le formulaire\u00A0: ",
+  "found-errors": {
+    "one": "L'erreur suivante a été trouvée dans le formulaire\u00A0: ",
+    "other": "Les {{count}} erreurs suivantes ont été trouvées dans le formulaire\u00A0: "
+  },
   "francais": "Français",
   "goc": "Governement du Canada",
   "goc-link": "https://www.canada.ca/fr.html",

--- a/pages/status.tsx
+++ b/pages/status.tsx
@@ -119,7 +119,9 @@ const Status: FC = () => {
             {errorSummary.length > 0 && (
               <ErrorSummary
                 id="error-summary-get-status"
-                summary={t('common:found-errors')}
+                summary={t('common:found-errors', {
+                  count: errorSummary.length,
+                })}
                 errors={errorSummary}
               />
             )}


### PR DESCRIPTION
## [ADO-XXX](https://dev.azure.com/DTS-STN/passport-status/_workitems/edit/xxx)

### Description

List of proposed changes:

- Add plurals to `common:found-errors` locale using `next-translate` feature

### What to test for/How to test

English messages should be: 
- The following error was found in the form:
- The following `count` errors were found in the form:

French messages should be: 
- L'erreur suivante a été trouvée dans le formulaire :
- Les `count` erreurs suivantes ont été trouvées dans le formulaire :

### Additional Notes

Next-translate plurals: https://github.com/aralroca/next-translate#5-plurals
