### PR TITLE
cleaning up some things with status page

### DIFF
--- a/.github/workflows/dast.yml
+++ b/.github/workflows/dast.yml
@@ -2,7 +2,7 @@ name: Dynamic Application Security Tests
 
 on:  
   schedule:
-    - cron: '1 1 * * 7'
+    - cron: '0 0 * * 0'
 
 jobs:
   zap-proxy-scan:

--- a/locales/en/status.json
+++ b/locales/en/status.json
@@ -24,6 +24,7 @@
     "label": "Given Name"
   },
   "go-back": "Go Back",
+  "reset": "Restart",
   "header": "Passport Status Check",
   "status": {
     "APPROVED": "Approved",

--- a/locales/fr/status.json
+++ b/locales/fr/status.json
@@ -24,6 +24,7 @@
     "label": "Prénom"
   },
   "go-back": "Retourner",
+  "reset": "Redémarrer",
   "header": "Vérification du statut du passeport",
   "status": {
     "APPROVED": "Approuvée",

--- a/pages/status.tsx
+++ b/pages/status.tsx
@@ -15,10 +15,6 @@ import StatusInfo from '../components/StatusInfo'
 import { GetStaticProps } from 'next'
 import Router from 'next/router'
 
-export const getStaticProps: GetStaticProps = async () => ({
-  props: {},
-})
-
 const Status: FC = () => {
   const { t } = useTranslation('status')
 
@@ -183,4 +179,9 @@ const Status: FC = () => {
     </Layout>
   )
 }
+
+export const getStaticProps: GetStaticProps = async () => ({
+  props: {},
+})
+
 export default Status

--- a/pages/status.tsx
+++ b/pages/status.tsx
@@ -6,12 +6,18 @@ import ErrorSummary, {
   getErrorSummaryItem,
 } from '../components/ErrorSummary'
 import Layout from '../components/Layout'
-import { CheckStatusReponse, CheckStatusRequestBody } from './api/check-status'
+import { CheckStatusRequestBody } from './api/check-status'
 import { useCheckStatus } from '../hooks/api/useCheckStatus'
 import { useFormik } from 'formik'
 import * as Yup from 'yup'
 import useTranslation from 'next-translate/useTranslation'
 import StatusInfo from '../components/StatusInfo'
+import { GetStaticProps } from 'next'
+import Router from 'next/router'
+
+export const getStaticProps: GetStaticProps = async () => ({
+  props: {},
+})
 
 const Status: FC = () => {
   const { t } = useTranslation('status')
@@ -67,13 +73,13 @@ const Status: FC = () => {
       )
   }, [formik, t])
 
-  const handleReset: MouseEventHandler<HTMLButtonElement> = useCallback(
-    (e) => {
-      e.preventDefault()
-      formik.resetForm()
-    },
-    [formik]
-  )
+  // const handleReset: MouseEventHandler<HTMLButtonElement> = useCallback(
+  //   (e) => {
+  //     e.preventDefault()
+  //     formik.resetForm()
+  //   },
+  //   [formik]
+  // )
 
   const handleGoBack: MouseEventHandler<HTMLButtonElement> = useCallback(
     (e) => {
@@ -93,14 +99,16 @@ const Status: FC = () => {
       {}
       {checkStatusReponse !== undefined ? (
         <StatusInfo
-          handleGoBackClick={handleGoBack}
-          goBackText={t('go-back')}
+          handleGoBackClick={
+            checkStatusReponse ? () => Router.push('/landing') : handleGoBack
+          }
+          goBackText={checkStatusReponse ? t('reset') : t('go-back')}
           goBackStyle="primary"
           checkAgainText={t('check-again')}
         >
           {checkStatusReponse ? (
             <p className="mb-6 text-2xl">
-              {t('status-is')}{' '}
+              {`${t('status-is')} `}
               <strong>
                 {t(`status.${checkStatusReponse.status}`, null, {
                   default: checkStatusReponse.status,
@@ -113,73 +121,65 @@ const Status: FC = () => {
           )}
         </StatusInfo>
       ) : (
-        <>
-          <div>
-            <p>{t('description')}</p>
-            {errorSummary.length > 0 && (
-              <ErrorSummary
-                id="error-summary-get-status"
-                summary={t('common:found-errors', {
-                  count: errorSummary.length,
-                })}
-                errors={errorSummary}
-              />
-            )}
-            <form onSubmit={formik.handleSubmit} id="form-get-status">
-              <InputField
-                id="esrf"
-                name="esrf"
-                label={t('esrf.label')}
-                onChange={formik.handleChange}
-                value={formik.values.esrf}
-                errorMessage={formik.errors.esrf && t(formik.errors.esrf)}
-                textRequired={t('common:required')}
-                required
-              />
-              <InputField
-                id="givenName"
-                name="givenName"
-                label={t('given-name.label')}
-                onChange={formik.handleChange}
-                value={formik.values.givenName}
-                errorMessage={
-                  formik.errors.givenName && t(formik.errors.givenName)
-                }
-                textRequired={t('common:required')}
-                required
-              />
-              <InputField
-                id="surname"
-                name="surname"
-                label={t('surname.label')}
-                onChange={formik.handleChange}
-                value={formik.values.surname}
-                errorMessage={formik.errors.surname && t(formik.errors.surname)}
-                textRequired={t('common:required')}
-                required
-              />
-              <InputField
-                id="birthDate"
-                name="birthDate"
-                type="date"
-                label={t('birth-date.label')}
-                onChange={formik.handleChange}
-                value={formik.values.birthDate}
-                errorMessage={
-                  formik.errors.birthDate && t(formik.errors.birthDate)
-                }
-                textRequired={t('common:required')}
-                required
-              />
-              <ActionButton
-                disabled={isCheckStatusLoading}
-                type="submit"
-                text={t('check-status')}
-                style="primary"
-              />
-            </form>
-          </div>
-        </>
+        <form onSubmit={formik.handleSubmit} id="form-get-status">
+          <p>{t('description')}</p>
+          {errorSummary.length > 0 && (
+            <ErrorSummary
+              id="error-summary-get-status"
+              summary={t('common:found-errors', {
+                count: errorSummary.length,
+              })}
+              errors={errorSummary}
+            />
+          )}
+          <InputField
+            id="esrf"
+            name="esrf"
+            label={t('esrf.label')}
+            onChange={formik.handleChange}
+            value={formik.values.esrf}
+            errorMessage={formik.errors.esrf && t(formik.errors.esrf)}
+            textRequired={t('common:required')}
+            required
+          />
+          <InputField
+            id="givenName"
+            name="givenName"
+            label={t('given-name.label')}
+            onChange={formik.handleChange}
+            value={formik.values.givenName}
+            errorMessage={formik.errors.givenName && t(formik.errors.givenName)}
+            textRequired={t('common:required')}
+            required
+          />
+          <InputField
+            id="surname"
+            name="surname"
+            label={t('surname.label')}
+            onChange={formik.handleChange}
+            value={formik.values.surname}
+            errorMessage={formik.errors.surname && t(formik.errors.surname)}
+            textRequired={t('common:required')}
+            required
+          />
+          <InputField
+            id="birthDate"
+            name="birthDate"
+            type="date"
+            label={t('birth-date.label')}
+            onChange={formik.handleChange}
+            value={formik.values.birthDate}
+            errorMessage={formik.errors.birthDate && t(formik.errors.birthDate)}
+            textRequired={t('common:required')}
+            required
+          />
+          <ActionButton
+            disabled={isCheckStatusLoading}
+            type="submit"
+            text={t('check-status')}
+            style="primary"
+          />
+        </form>
       )}
     </Layout>
   )

--- a/pages/status.tsx
+++ b/pages/status.tsx
@@ -96,7 +96,6 @@ const Status: FC = () => {
   return (
     <Layout>
       <h1 className="mb-4">{t('header')}</h1>
-      {}
       {checkStatusReponse !== undefined ? (
         <StatusInfo
           handleGoBackClick={

--- a/pages/status.tsx
+++ b/pages/status.tsx
@@ -92,28 +92,31 @@ const Status: FC = () => {
   return (
     <Layout>
       <h1 className="mb-4">{t('header')}</h1>
-      {checkStatusReponse !== undefined ? (
+      {checkStatusReponse ? (
         <StatusInfo
-          handleGoBackClick={
-            checkStatusReponse ? () => Router.push('/landing') : handleGoBack
-          }
-          goBackText={checkStatusReponse ? t('reset') : t('go-back')}
+          handleGoBackClick={() => Router.push('/landing')}
+          goBackText={t('reset')}
           goBackStyle="primary"
           checkAgainText={t('check-again')}
         >
-          {checkStatusReponse ? (
-            <p className="mb-6 text-2xl">
-              {`${t('status-is')} `}
-              <strong>
-                {t(`status.${checkStatusReponse.status}`, null, {
-                  default: checkStatusReponse.status,
-                })}
-              </strong>
-              .
-            </p>
-          ) : (
-            <p className=" mb-6 text-2xl">{t('unable-to-find-status')}</p>
-          )}
+          <p className="mb-6 text-2xl">
+            {`${t('status-is')} `}
+            <strong>
+              {t(`status.${checkStatusReponse.status}`, null, {
+                default: checkStatusReponse.status,
+              })}
+            </strong>
+            .
+          </p>
+        </StatusInfo>
+      ) : checkStatusReponse === null ? (
+        <StatusInfo
+          handleGoBackClick={handleGoBack}
+          goBackText={t('go-back')}
+          goBackStyle="primary"
+          checkAgainText={t('check-again')}
+        >
+          <p className=" mb-6 text-2xl">{t('unable-to-find-status')}</p>
         </StatusInfo>
       ) : (
         <form onSubmit={formik.handleSubmit} id="form-get-status">


### PR DESCRIPTION
### Description

List of proposed changes:

- Enable a Reset to bring you back to landing on success getting a status
- Convert page to be static
- Remove some un-used code
- fix the cron

### What to test for/How to test

If you get a status response, the "go back" should be "restart" and bring you back to the landing page to start the flow again.

### Additional Notes
