### PR TITLE
Updated LinkButton & ActionButton styling

### DIFF
--- a/__tests__/components/ActionButton.test.tsx
+++ b/__tests__/components/ActionButton.test.tsx
@@ -17,7 +17,7 @@ describe('ActionButton', () => {
     render(<ActionButton text="text" style="primary" />)
     const sut = screen.getByText('text')
     expect(sut).toHaveClass(
-      'border-blue-deep bg-blue-dark text-basic-white hover:bg-blue-normal'
+      'inline-block text-center align-middle rounded border py-2 px-10 focus:ring-1 focus:ring-offset-2 focus:ring-black focus:text-basic-white border-blue-dark bg-blue-dark text-basic-white focus:bg-blue-normal hover:bg-blue-normal active:bg-[#16446c]'
     )
   })
 

--- a/__tests__/components/ActionButton.test.tsx
+++ b/__tests__/components/ActionButton.test.tsx
@@ -17,7 +17,7 @@ describe('ActionButton', () => {
     render(<ActionButton text="text" style="primary" />)
     const sut = screen.getByText('text')
     expect(sut).toHaveClass(
-      'inline-block text-center align-middle rounded border py-2 px-10 focus:ring-1 focus:ring-offset-2 focus:ring-black focus:text-basic-white border-blue-dark bg-blue-dark text-basic-white focus:bg-blue-normal hover:bg-blue-normal active:bg-[#16446c]'
+      'inline-block text-center align-middle rounded border py-2 px-10 focus:ring-1 focus:ring-offset-2 focus:ring-black focus:text-basic-white border-blue-dark bg-blue-dark text-basic-white focus:bg-blue-normal hover:bg-blue-normal active:bg-blue-active'
     )
   })
 

--- a/components/ActionButton.tsx
+++ b/components/ActionButton.tsx
@@ -20,7 +20,7 @@ const ActionButton: FC<ActionButtonProps> = ({
   switch (style) {
     case 'primary':
       classStyle +=
-        'border-blue-dark bg-blue-dark text-basic-white focus:bg-blue-normal hover:bg-blue-normal active:bg-[#16446c]'
+        'border-blue-dark bg-blue-dark text-basic-white focus:bg-blue-normal hover:bg-blue-normal active:bg-blue-active'
       break
     default:
       classStyle +=

--- a/components/ActionButton.tsx
+++ b/components/ActionButton.tsx
@@ -16,11 +16,11 @@ const ActionButton: FC<ActionButtonProps> = ({
   type,
 }) => {
   let classStyle =
-    'inline-block text-center align-middle rounded border py-2.5 px-3.5 focus:ring-2 focus:ring-offset-2 '
+    'inline-block text-center align-middle rounded border py-2 px-10 focus:ring-1 focus:ring-offset-2 focus:ring-black focus:text-basic-white '
   switch (style) {
     case 'primary':
       classStyle +=
-        'border-blue-deep bg-blue-dark text-basic-white hover:bg-blue-normal'
+        'border-blue-dark bg-blue-dark text-basic-white focus:bg-blue-normal hover:bg-blue-normal active:bg-[#16446c]'
       break
     default:
       classStyle +=

--- a/components/LinkButton.tsx
+++ b/components/LinkButton.tsx
@@ -32,7 +32,7 @@ const LinkButton: FC<LinkButton> = ({ href, text, id, lang }) => {
         focus:ring-black 
         focus:text-basic-white
         focus:bg-blue-normal
-        active:bg-[#16446c]`}
+        active:bg-blue-active`}
       >
         {text}
       </a>

--- a/components/LinkButton.tsx
+++ b/components/LinkButton.tsx
@@ -4,14 +4,19 @@ import Link from 'next/link'
 export interface LinkButton {
   href: string
   text: string
+  id?: string
+  lang?: string
 }
 
-const LinkButton: FC<LinkButton> = ({ href, text }) => {
+const LinkButton: FC<LinkButton> = ({ href, text, id, lang }) => {
   return (
     <Link href={href} passHref>
       <a
+        id={id}
+        lang={lang}
         className={`
-        border-blue-deep
+        font-display
+        border-blue-dark
         bg-blue-dark 
         text-basic-white 
         hover:bg-blue-normal 
@@ -20,10 +25,14 @@ const LinkButton: FC<LinkButton> = ({ href, text }) => {
         align-middle 
         rounded 
         border
-        py-2.5 
-        px-3.5 
-        focus:ring-2 
-        focus:ring-offset-2 `}
+        py-2 
+        px-10 
+        focus:ring-1 
+        focus:ring-offset-2
+        focus:ring-black 
+        focus:text-basic-white
+        focus:bg-blue-normal
+        active:bg-[#16446c]`}
       >
         {text}
       </a>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,5 +1,6 @@
 import Image from 'next/image'
 import Link from 'next/link'
+import LinkButton from '../components/LinkButton'
 import MetaData from '../components/MetaData'
 import defaultTranslations from '../utils/defaultTranslations.json'
 
@@ -30,30 +31,18 @@ const Index = () => {
           </div>
           <div className="flex w-max container py-11 mx-auto font-display">
             <div className="grid grid-cols-2 gap-2 xl:gap-6">
-              <Link href="/en/landing">
-                <a
-                  className="font-display rounded focus:ring-1 focus:ring-black focus:ring-offset-2 py-2 px-10 whitespace-pre bg-[#173451] text-white text-center border border-[#173451] active:bg-[#21303F] hover:bg-#245C81 grid place-items-center"
-                  // onClick={props.onClick}
-                  role="button"
-                  draggable="false"
-                  lang="en"
-                  id="english-button"
-                >
-                  English
-                </a>
-              </Link>
-              <Link href="/fr/landing">
-                <a
-                  className="font-display rounded focus:ring-1 focus:ring-black focus:ring-offset-2 py-2 px-10 whitespace-pre bg-[#173451] text-white text-center border border-[#173451] active:bg-[#21303F] hover:bg-#245C81 grid place-items-center"
-                  // onClick={props.onClick}
-                  role="button"
-                  draggable="false"
-                  lang="fr"
-                  id="french-button"
-                >
-                  Français
-                </a>
-              </Link>
+              <LinkButton
+                href="/en/landing"
+                text="English"
+                id="english-button"
+                lang="en"
+              />
+              <LinkButton
+                href="/fr/landing"
+                text="Français"
+                id="french-button"
+                lang="fr"
+              />
             </div>
           </div>
         </div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -40,6 +40,7 @@ module.exports = {
           default: '#091c2d',
           dark: '#26374a',
           deep: '#26374a',
+          active: '#16446c',
         },
         gray: {
           light: '#f8f8f8',


### PR DESCRIPTION
## [ADO-947](https://dev.azure.com/DTS-STN/passport-status/_workitems/edit/947)

### Description

This PR addresses the focus, active & hover styling for both the `LinkButton` and `ActiveButton` components. I've adjusted the colors on the buttons to match what is on [Canada.ca](https://www.canada.ca) and also swapped out the `Link` components on the index page with our `LinkButton` component.

As seen below, the active styling passes WCAG AA standards:
<img width="900" alt="Screenshot 2022-10-06 101124" src="https://user-images.githubusercontent.com/71025360/194347599-1f5a5d05-3e5f-442a-96fd-edbe445b4dbb.png">


### What to test for/How to test
1. Pull in branch
2. Type `npm run dev`
3. Use your contrast checker extension of choice (I use [WCAG Contrast Color Checker](https://chrome.google.com/webstore/detail/wcag-color-contrast-check/plnahcmalebffmaghcpcmpaciebdhgdf?hl=en)) and test the contrast of the focus/hover/active states by opening the developer console, selecting the element and forcing element state under the styles tab.