### PR TITLE
Update button classname and skip to content button styling

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -18,7 +18,7 @@ const Header: FC = () => {
       >
         <a
           id="skipToMainContent"
-          className="bg-blue-800 text-white px-2 focus:outline-black-solid hover:bg-gray-dark"
+          className="bg-blue-dark border border-blue-dark text-white px-2 focus:text-white focus:ring-2 focus:ring-offset-2 focus:ring-orange-dark hover:bg-basic-darkgray font-body font-bold focus:ring-inset "
           href="#mainContent"
           draggable="false"
         >

--- a/components/LinkButton.tsx
+++ b/components/LinkButton.tsx
@@ -14,25 +14,7 @@ const LinkButton: FC<LinkButtonProps> = ({ href, text, id, lang }) => {
       <a
         id={id}
         lang={lang}
-        className={`
-        font-display
-        border-blue-dark
-        bg-blue-dark 
-        text-basic-white 
-        hover:bg-blue-normal 
-        inline-block 
-        text-center 
-        align-middle 
-        rounded 
-        border
-        py-2 
-        px-10 
-        focus:ring-1 
-        focus:ring-offset-2
-        focus:ring-black 
-        focus:text-basic-white
-        focus:bg-blue-normal
-        active:bg-blue-active`}
+        className="font-display border-blue-dark bg-blue-dark text-basic-white hover:bg-blue-normal inline-block text-center align-middle rounded border py-2 px-10 focus:ring-1 focus:ring-offset-2 focus:ring-black focus:text-basic-white focus:bg-blue-normal active:bg-blue-active"
       >
         {text}
       </a>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -17,6 +17,7 @@ module.exports = {
         basic: {
           gray: '#333',
           white: '#fff',
+          darkgray: '#444',
         },
         accent: {
           main: '#26374A',
@@ -48,6 +49,9 @@ module.exports = {
           default: '#dcdee1',
           dark: '#cfd1d5',
           deep: '#bbbfc5',
+        },
+        orange: {
+          dark: '#e59700',
         },
       },
       backgroundImage: () => ({


### PR DESCRIPTION
## [ADO-XXX](https://dev.azure.com/DTS-STN/passport-status/_workitems/edit/xxx)

### Description
Was pointed out to me that the `LinkButton` component was using template literals for `className`. We aren't evaluating any expressions or adding in custom styling via props so this PR switches it to be more in line with the other button component which just uses a string. During testing, I also noticed that the Skip to main content button was not accessible at all when focused, so I've gone ahead and mimicked the [Canada.ca](https://www.canada.ca) styling. I've experimented adding the dark orange inner ring on focus like Canada.ca has it, so it can also be added to the rest of our buttons if we want to follow that design pattern.

### What to test for/How to test
1. Pull in branch
2. Type `npm run dev`
3. Make sure button styling on the splash page shows as expected.
4. Navigate to `/en/landing`
5. Tab into the Skip to main content button and ensure that it is accessible

### Additional Notes
We aren't really utilizing the skip button currently and though there isn't really any content beyond the buttons and the form we should probably still add the `#mainContent` link on each of our pages at some point