### PR TITLE
988 no match status

### DIFF
--- a/__tests__/components/LinkSummary.test.tsx
+++ b/__tests__/components/LinkSummary.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom/extend-expect'
+import { axe, toHaveNoViolations } from 'jest-axe'
+import LinkSummary, { LinkSummaryItem } from '../../components/LinkSummary'
+expect.extend(toHaveNoViolations)
+
+const noMatchHref: LinkSummaryItem[] = [
+  {
+    href: 'www.google.com',
+    text: 'Test Link',
+  },
+]
+
+describe('LinkSummary', () => {
+  const sut = <LinkSummary id={'testId'} links={noMatchHref} />
+
+  it('renders', () => {
+    render(sut)
+    const screenText = screen.getByText('Test Link')
+    expect(screenText).toBeInTheDocument()
+  })
+
+  it('is meets a11y', async () => {
+    const { container } = render(sut)
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
+  })
+})

--- a/__tests__/components/LinkSummary.test.tsx
+++ b/__tests__/components/LinkSummary.test.tsx
@@ -12,7 +12,7 @@ const noMatchHref: LinkSummaryItem[] = [
 ]
 
 describe('LinkSummary', () => {
-  const sut = <LinkSummary id={'testId'} links={noMatchHref} />
+  const sut = <LinkSummary links={noMatchHref} />
 
   it('renders', () => {
     render(sut)

--- a/components/LinkSummary.tsx
+++ b/components/LinkSummary.tsx
@@ -7,14 +7,15 @@ export interface LinkSummaryItem {
 }
 
 export interface LinkSummaryProps {
-  id: string
+  title?: string
   links: LinkSummaryItem[]
 }
 
-const LinkSummary: FC<LinkSummaryProps> = ({ id, links }) => {
+const LinkSummary: FC<LinkSummaryProps> = ({ title, links }) => {
   return (
-    <section id={id}>
-      <ul className="list-none pb-6 ml-4">
+    <section className="mt-5">
+      <p>{title}</p>
+      <ul className="list-disc pb-6 ml-4">
         {links.map(({ href, text }, index) => (
           <li key={index} className="text-link-default">
             <Link href={href}>{text}</Link>

--- a/components/LinkSummary.tsx
+++ b/components/LinkSummary.tsx
@@ -1,0 +1,28 @@
+import { FC } from 'react'
+import Link from 'next/link'
+
+export interface LinkSummaryItem {
+  href: string
+  text: string
+}
+
+export interface LinkSummaryProps {
+  id: string
+  links: LinkSummaryItem[]
+}
+
+const LinkSummary: FC<LinkSummaryProps> = ({ id, links }) => {
+  return (
+    <section id={id}>
+      <ul className="list-none pb-6 ml-4">
+        {links.map(({ href, text }, index) => (
+          <li key={index} className="text-link-default">
+            <Link href={href}>{text}</Link>
+          </li>
+        ))}
+      </ul>
+    </section>
+  )
+}
+
+export default LinkSummary

--- a/pages/status.tsx
+++ b/pages/status.tsx
@@ -27,14 +27,9 @@ const initialValues: CheckStatusRequestBody = {
 const Status: FC = () => {
   const { t } = useTranslation('status')
 
-  const getLinkSummaryItems: any = () => {
-    const LSI: any = t('no-match-status-links', { returnObjects: true })
-    const noMatchHref: LinkSummaryItem[] = []
-    for (const keys in LSI) {
-      noMatchHref.push(LSI[keys] as LinkSummaryItem)
-    }
-    return noMatchHref
-  }
+  const lsItems = t<string, LinkSummaryItem[]>('no-match-status-links', {
+    returnObjects: true,
+  })
 
   const formik = useFormik<CheckStatusRequestBody>({
     initialValues,
@@ -139,7 +134,7 @@ const Status: FC = () => {
           </StatusInfo>
           <LinkSummary
             title={t('no-match-title')}
-            links={getLinkSummaryItems()}
+            links={lsItems}
           ></LinkSummary>
         </>
       ) : (

--- a/pages/status.tsx
+++ b/pages/status.tsx
@@ -27,20 +27,14 @@ const initialValues: CheckStatusRequestBody = {
 const Status: FC = () => {
   const { t } = useTranslation('status')
 
-  const noMatchHref: LinkSummaryItem[] = [
-    {
-      href: 'https://ircc.canada.ca/english/passport/map/map.asp',
-      text: t('no-match-status-links.near-you'),
-    },
-    {
-      href: 'https://www.canada.ca/en/immigration-refugees-citizenship/services/canadian-passports/contact-passport-program.html',
-      text: t('no-match-status-links.contact-program'),
-    },
-    {
-      href: 'https://eservices.canada.ca/en/reservation/',
-      text: t('no-match-status-links.appointment'),
-    },
-  ]
+  const getLinkSummaryItems: any = () => {
+    const LSI: any = t('no-match-status-links', { returnObjects: true })
+    const noMatchHref: LinkSummaryItem[] = []
+    for (const keys in LSI) {
+      noMatchHref.push(LSI[keys] as LinkSummaryItem)
+    }
+    return noMatchHref
+  }
 
   const formik = useFormik<CheckStatusRequestBody>({
     initialValues,
@@ -135,10 +129,6 @@ const Status: FC = () => {
         </StatusInfo>
       ) : checkStatusReponse === null ? (
         <>
-          <LinkSummary
-            id={'noMatchLinkSummary'}
-            links={noMatchHref}
-          ></LinkSummary>
           <StatusInfo
             handleGoBackClick={handleGoBack}
             goBackText={t('go-back')}
@@ -147,6 +137,10 @@ const Status: FC = () => {
           >
             <p className=" mb-6 text-2xl">{t('unable-to-find-status')}</p>
           </StatusInfo>
+          <LinkSummary
+            title={t('no-match-title')}
+            links={getLinkSummaryItems()}
+          ></LinkSummary>
         </>
       ) : (
         <form onSubmit={formik.handleSubmit} id="form-get-status">

--- a/pages/status.tsx
+++ b/pages/status.tsx
@@ -14,12 +14,28 @@ import ErrorSummary, {
   ErrorSummaryItem,
   getErrorSummaryItem,
 } from '../components/ErrorSummary'
+import LinkSummary, { LinkSummaryItem } from '../components/LinkSummary'
 import StatusInfo from '../components/StatusInfo'
 
 const Status: FC = () => {
   const { t } = useTranslation('status')
 
   const [formSubmitted, setFormSubmitted] = useState(false)
+
+  const noMatchHref: LinkSummaryItem[] = [
+    {
+      href: 'https://ircc.canada.ca/english/passport/map/map.asp',
+      text: t('no-match-status-links.near-you'),
+    },
+    {
+      href: 'https://www.canada.ca/en/immigration-refugees-citizenship/services/canadian-passports/contact-passport-program.html',
+      text: t('no-match-status-links.contact-program'),
+    },
+    {
+      href: 'https://eservices.canada.ca/en/reservation/',
+      text: t('no-match-status-links.appointment'),
+    },
+  ]
 
   const formik = useFormik<CheckStatusRequestBody>({
     initialValues: {
@@ -115,14 +131,20 @@ const Status: FC = () => {
           </p>
         </StatusInfo>
       ) : checkStatusReponse === null ? (
-        <StatusInfo
-          handleGoBackClick={handleGoBack}
-          goBackText={t('go-back')}
-          goBackStyle="primary"
-          checkAgainText={t('check-again')}
-        >
-          <p className=" mb-6 text-2xl">{t('unable-to-find-status')}</p>
-        </StatusInfo>
+        <>
+          <LinkSummary
+            id={'noMatchLinkSummary'}
+            links={noMatchHref}
+          ></LinkSummary>
+          <StatusInfo
+            handleGoBackClick={handleGoBack}
+            goBackText={t('go-back')}
+            goBackStyle="primary"
+            checkAgainText={t('check-again')}
+          >
+            <p className=" mb-6 text-2xl">{t('unable-to-find-status')}</p>
+          </StatusInfo>
+        </>
       ) : (
         <form onSubmit={formik.handleSubmit} id="form-get-status">
           <p>{t('description')}</p>

--- a/public/locales/en/status.json
+++ b/public/locales/en/status.json
@@ -38,5 +38,10 @@
     },
     "label": "Surname"
   },
-  "unable-to-find-status": "We are unable to determine the status of your application at this time using this service."
+  "unable-to-find-status": "We are unable to determine the status of your application at this time using this service.",
+  "no-match-status-links": {
+    "contact-program": "Contact the Passport Program",
+    "near-you": "Find a passport service location near you",
+    "appointment": "Appointment booking"
+  }
 }

--- a/public/locales/en/status.json
+++ b/public/locales/en/status.json
@@ -40,18 +40,18 @@
   },
   "unable-to-find-status": "We are unable to determine the status of your application at this time using this service.",
   "no-match-title": "Other ways to get your status.",
-  "no-match-status-links": {
-    "contact": {
+  "no-match-status-links": [
+    {
       "text": "Contact the Passport Program",
       "href": "https://ircc.canada.ca/english/passport/map/map.asp"
     },
-    "find": {
+    {
       "text": "Find a passport service location near you",
       "href": "https://www.canada.ca/en/immigration-refugees-citizenship/services/canadian-passports/contact-passport-program.html"
     },
-    "appt": {
+    {
       "text": "Appointment booking",
       "href": "https://eservices.canada.ca/en/reservation/"
     }
-  }
+  ]
 }

--- a/public/locales/en/status.json
+++ b/public/locales/en/status.json
@@ -39,9 +39,19 @@
     "label": "Surname"
   },
   "unable-to-find-status": "We are unable to determine the status of your application at this time using this service.",
+  "no-match-title": "Other ways to get your status.",
   "no-match-status-links": {
-    "contact-program": "Contact the Passport Program",
-    "near-you": "Find a passport service location near you",
-    "appointment": "Appointment booking"
+    "contact": {
+      "text": "Contact the Passport Program",
+      "href": "https://ircc.canada.ca/english/passport/map/map.asp"
+    },
+    "find": {
+      "text": "Find a passport service location near you",
+      "href": "https://www.canada.ca/en/immigration-refugees-citizenship/services/canadian-passports/contact-passport-program.html"
+    },
+    "appt": {
+      "text": "Appointment booking",
+      "href": "https://eservices.canada.ca/en/reservation/"
+    }
   }
 }

--- a/public/locales/fr/status.json
+++ b/public/locales/fr/status.json
@@ -40,18 +40,18 @@
   },
   "unable-to-find-status": "Nous ne sommes pas en mesure de déterminer le statut de votre demande pour le moment en utilisant ce service.",
   "no-match-title": "D'autres façons d'obtenir votre statut.",
-  "no-match-status-links": {
-    "contact": {
+  "no-match-status-links": [
+    {
       "text": "Communiquez avec le Programme de passeport",
       "href": "https://ircc.canada.ca/francais/passeport/map/carte.asp"
     },
-    "find": {
+    {
       "text": "Trouvez un emplacement de service de passeport près de chez vous",
       "href": "https://www.canada.ca/fr/immigration-refugies-citoyennete/services/passeports-canadiens/communiquer-programme-passeport.html"
     },
-    "appt": {
+    {
       "text": "Prise de rendez-vous",
       "href": "https://eservices.canada.ca/fr/reservation/"
     }
-  }
+  ]
 }

--- a/public/locales/fr/status.json
+++ b/public/locales/fr/status.json
@@ -38,5 +38,10 @@
     },
     "label": "Nom de famille"
   },
-  "unable-to-find-status": "Nous ne sommes pas en mesure de déterminer le statut de votre demande pour le moment en utilisant ce service."
+  "unable-to-find-status": "Nous ne sommes pas en mesure de déterminer le statut de votre demande pour le moment en utilisant ce service.",
+  "no-match-status-links": {
+    "contact-program": "Contactez le program de passport",
+    "near-you": "Trouvez un emplacement de service de passeport près de chez vous",
+    "appointment": "Prise de rendez-vous"
+  }
 }

--- a/public/locales/fr/status.json
+++ b/public/locales/fr/status.json
@@ -39,9 +39,19 @@
     "label": "Nom de famille"
   },
   "unable-to-find-status": "Nous ne sommes pas en mesure de déterminer le statut de votre demande pour le moment en utilisant ce service.",
+  "no-match-title": "D'autres façons d'obtenir votre statut.",
   "no-match-status-links": {
-    "contact-program": "Contactez le program de passport",
-    "near-you": "Trouvez un emplacement de service de passeport près de chez vous",
-    "appointment": "Prise de rendez-vous"
+    "contact": {
+      "text": "Communiquez avec le Programme de passeport",
+      "href": "https://ircc.canada.ca/francais/passeport/map/carte.asp"
+    },
+    "find": {
+      "text": "Trouvez un emplacement de service de passeport près de chez vous",
+      "href": "https://www.canada.ca/fr/immigration-refugies-citoyennete/services/passeports-canadiens/communiquer-programme-passeport.html"
+    },
+    "appt": {
+      "text": "Prise de rendez-vous",
+      "href": "https://eservices.canada.ca/fr/reservation/"
+    }
   }
 }


### PR DESCRIPTION


### Description

List of proposed changes:

Added a LinkSummary component that displays a list of links. 

Display LinkSummary for no match results, showing three links provided in the user story.

### What to test for/How to test

1. enter false but valid data.
2. Test the links bring you to the appropriate places.


### Additional Notes

@s-laugh , @krischarbonneau  Please let me know if there is a specific way this should be styled and I will alter it. I left it pretty bare bones as to make it easy to change.

Also if you guys know of a better way to store the LinkSummaryItems outside of status.tsx, pls let me know.