### PR TITLE
Remove react query cache and stale time options

### DIFF
--- a/hooks/api/useCheckStatus.ts
+++ b/hooks/api/useCheckStatus.ts
@@ -35,7 +35,7 @@ export const useCheckStatus = (
   >(
     [checkStatusQueryKey, requestBody],
     ({ signal }) => fetchCheckStatus(requestBody, { signal }),
-    { cacheTime: Infinity, staleTime: Infinity, ...(queryOptions ?? {}) }
+    { ...(queryOptions ?? {}) }
   )
 
   // fix isLoading with disabled: false


### PR DESCRIPTION
## [ADO-XXX](https://dev.azure.com/DTS-STN/passport-status/_workitems/edit/xxx)

### Description

List of proposed changes:

- Remove react query cache and stale time options

### What to test for/How to test

You should be able to query the api again after 5 mins of your first API call, . CacheTime default is 5 mins.

### Additional Notes

Caching Examples
https://tanstack.com/query/v4/docs/guides/caching