### PR TITLE
Add the new email esrf api endpoint

### DIFF
--- a/__mocks__/statusMock.js
+++ b/__mocks__/statusMock.js
@@ -1,7 +1,0 @@
-const status = {
-  jane: 'MAILED',
-  john: 'INPROGRESS',
-  joe: 'MAILED',
-}
-
-export default status

--- a/lib/emailEsrfHook.ts
+++ b/lib/emailEsrfHook.ts
@@ -1,0 +1,13 @@
+import { useQuery } from '@tanstack/react-query'
+import { EmailEsrfRequestBody } from '../pages/api/email-esrf'
+
+export function EmailEsrf(requestBody: EmailEsrfRequestBody) {
+  const query = useQuery(
+    ['ps:api:email-esrf', requestBody],
+    async () =>
+      await fetch('/api/email-esrf', {
+        method: 'POST',
+        body: JSON.stringify(requestBody),
+      })
+  )
+}

--- a/pages/api/email-esrf.tsx
+++ b/pages/api/email-esrf.tsx
@@ -1,0 +1,39 @@
+import { NextApiRequest, NextApiResponse } from 'next'
+import logger from '../../lib/logger'
+
+export interface EmailEsrfRequestBody {
+  dateOfBirth: string
+  email: string
+  firstName: string
+  lastName: string
+}
+export interface EmailEsrfResponse {}
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (req.method !== 'POST')
+    return res.status(405).send(`Invalid request method ${req.method}`)
+
+  try {
+    const response = await (process.env.PASSPORT_STATUS_API_BASE_URI
+      ? EmailEsrfApi(req.body)
+      : EmailEsrfMock(res))
+    return res.status(response.status).send(response.statusText)
+  } catch (error) {
+    logger.error(error)
+    return res.status(500).send('Something went wrong.')
+  }
+}
+
+function EmailEsrfApi(rqBody: any): Promise<Response> {
+  return fetch(
+    `${process.env.PASSPORT_STATUS_API_BASE_URI}/api/v1/electronic-service-requests/`,
+    { method: 'POST', body: rqBody }
+  )
+}
+
+function EmailEsrfMock(res: NextApiResponse): Promise<Response> {
+  return new Promise<Response>(() => res.status(202).send('Email sent'))
+}

--- a/pages/api/email-esrf.tsx
+++ b/pages/api/email-esrf.tsx
@@ -7,7 +7,6 @@ export interface EmailEsrfRequestBody {
   firstName: string
   lastName: string
 }
-export interface EmailEsrfResponse {}
 
 export default async function handler(
   req: NextApiRequest,


### PR DESCRIPTION
## [ADO-1053](https://dev.azure.com/DTS-STN/passport-status/_workitems/edit/1053)

### Description

List of proposed changes:

- Creating the API and Hook (Light weight and just the basics for now, expect more to be added when call from client is added)
- Remove unused mock file

### What to test for/How to test

API should get responses with env variable set.

### Additional Notes
