### PR TITLE
Add reusable error messaging

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -39,5 +39,11 @@
   "title": "home",
   "tools": "Tools",
   "top-of-page": "Top of Page",
-  "welcome": "Welcome to"
+  "welcome": "Welcome to",
+  "error-messages": {
+    "required": "is required",
+    "in-past": "must be in the past",
+    "valid-format": "must be in a valid format of {{format}}",
+    "meet-length": "must be {{length}} characters long"
+  }
 }

--- a/public/locales/en/status.json
+++ b/public/locales/en/status.json
@@ -1,9 +1,9 @@
 {
   "birth-date": {
     "error": {
-      "current": "The Date of birth must be a date in the past",
-      "invalid": "The Date of birth must be a valid date in the format of (dd/mm/yyyy)",
-      "required": "The Date of birth is required"
+      "current": "The $t(birth-date.label) $t(common:error-messages.in-past)",
+      "invalid": "The $t(birth-date.label) $t(common:error-messages.valid-format, { \"format\": \"dd/mm/yyyy\" })",
+      "required": "The $t(birth-date.label) $t(common:error-messages.required)"
     },
     "label": "Date of birth"
   },
@@ -12,14 +12,14 @@
   "description": "Use this service with your ESRF to check the status of your passport application.",
   "esrf": {
     "error": {
-      "length": "The File number must be 8 characters long",
-      "required": "The File number is required"
+      "length": "The $t(esrf.label) $t(common:error-messages.meet-length, {\"length\": 8})",
+      "required": "The $t(esrf.label) $t(common:error-messages.required)"
     },
     "label": "File number"
   },
   "given-name": {
     "error": {
-      "required": "The Given name is required"
+      "required": "The $t(given-name.label) $t(common:error-messages.required)"
     },
     "label": "Given Name"
   },
@@ -34,7 +34,7 @@
   "status-is": "The latest status of your application according to our records is: ",
   "surname": {
     "error": {
-      "required": "The Surname is required"
+      "required": "The $t(surname.label) $t(common:error-messages.required)"
     },
     "label": "Surname"
   },

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -39,5 +39,11 @@
   "title": "accueil",
   "tools": "Outils",
   "top-of-page": "Haut de la page",
-  "welcome": "Bienvenue a"
+  "welcome": "Bienvenue a",
+  "error-messages": {
+    "required": "est obligatoire",
+    "in-past": "doit être dans le passé",
+    "valid-format": "doit être valide au format de {{format}}",
+    "meet-length": "doit comporter {{length}} caractères"
+  }
 }

--- a/public/locales/fr/status.json
+++ b/public/locales/fr/status.json
@@ -1,9 +1,9 @@
 {
   "birth-date": {
     "error": {
-      "current": "La date de naissance doit être une date dans le passé",
-      "invalid": "La date de naissance doit être une date valide au format (yyyy-MM-dd)",
-      "required": "La date de naissance est obligatoire"
+      "current": "La $t(birth-date.label) $t(common:error-messages.in-past)",
+      "invalid": "La $t(birth-date.label) $t(common:error-messages.valid-format, { \"format\": \"dd-mm-yyyy\" })",
+      "required": "La $t(birth-date.label) $t(common:error-messages.required)"
     },
     "label": "Date de naissance"
   },
@@ -12,14 +12,14 @@
   "description": "Utilisez ce service avec votre ESRF pour vérifier le statut de votre demande de passeport.",
   "esrf": {
     "error": {
-      "length": "Le numéro de dossier doit comporter 8 caractères",
-      "required": "Le numéro de dossier est obligatoire"
+      "length": "Le $t(esrf.label) $t(common:error-messages.meet-length, {\"length\": 8})",
+      "required": "Le $t(esrf.label) $t(common:error-messages.required)"
     },
     "label": "Numéro de dossier"
   },
   "given-name": {
     "error": {
-      "required": "Le prénom est obligatoire"
+      "required": "Le $t(given-name.label) $t(common:error-messages.required)"
     },
     "label": "Prénom"
   },
@@ -34,7 +34,7 @@
   "status-is": "Le dernier statut de votre candidature selon nos dossiers est : ",
   "surname": {
     "error": {
-      "required": "Le nom de famille est obligatoire"
+      "required": "Le $t(surname.label) $t(common:error-messages.required)"
     },
     "label": "Nom de famille"
   },


### PR DESCRIPTION
### Description

List of proposed changes:

- Use some i18next nesting so that repeated text is only in our translation file in one spot.

### What to test for/How to test

All error message still show properly and translate.

### Additional Notes
