### PR TITLE
add the env for api url to docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,5 +27,7 @@ COPY --from=build /build/tracing.js ./
 RUN VERSION_NEXT=`node -p -e "require('./package.json').dependencies.next"`&& npm install --no-package-lock --no-save next@"$VERSION_NEXT"
 
 # Runtime envs -- will default to build args if no env values are specified at docker run
+ARG PASSPORT_STATUS_API_BASE_URI
+ENV PASSPORT_STATUS_API_BASE_URI=$PASSPORT_STATUS_API_BASE_URI
 
 CMD npm run start


### PR DESCRIPTION
## [ADO-1070](https://dev.azure.com/DTS-STN/passport-status/_workitems/edit/1070)

### Description

List of proposed changes:

- Add env variable to docker at runtime

### What to test for/How to test

Validate that it's using data from the API and not our mock file

### Additional Notes
