### PR TITLE
Add next-i18next config appendNamespaceToMissingKey

### DIFF
--- a/next-i18next.config.js
+++ b/next-i18next.config.js
@@ -1,6 +1,12 @@
+// @ts-check
+
+/**
+ * @type {import('next-i18next').UserConfig}
+ **/
 module.exports = {
   i18n: {
     locales: ['default', 'en', 'fr'],
     defaultLocale: 'default',
   },
+  appendNamespaceToMissingKey: true,
 }


### PR DESCRIPTION
## [ADO-XXX](https://dev.azure.com/DTS-STN/passport-status/_workitems/edit/xxx)

### Description

List of proposed changes:

- Configure next-i18next appendNamespaceToMissingKey to true

### What to test for/How to test

If you call `useTranslation("status")` with a default namespace `status` then there is no need to append the namespace with the key when using `t` function like `t("go-back")`. If the key is not found then only the key is displayed. Configuring appendNamespaceToMissingKey to true will append the namespace to the missing key.

Before:
![image](https://user-images.githubusercontent.com/114004123/196452259-671f4d7f-5334-4e67-a6aa-fe478b9b1ff3.png)

After:
![image](https://user-images.githubusercontent.com/114004123/196452092-13540a32-bbda-4e87-9e86-7ace1e17bbdd.png)


### Additional Notes
https://www.i18next.com/overview/configuration-options#missing-keys