### PR TITLE
Fix translation & add hover/focus styling to Link Summary

### DIFF
--- a/components/LinkSummary.tsx
+++ b/components/LinkSummary.tsx
@@ -17,7 +17,10 @@ const LinkSummary: FC<LinkSummaryProps> = ({ title, links }) => {
       <p>{title}</p>
       <ul className="list-disc pb-6 ml-4">
         {links.map(({ href, text }, index) => (
-          <li key={index} className="text-link-default">
+          <li
+            key={index}
+            className="text-link-default hover:text-link-selected focus:text-link-selected"
+          >
             <Link href={href}>{text}</Link>
           </li>
         ))}

--- a/pages/status.tsx
+++ b/pages/status.tsx
@@ -142,7 +142,7 @@ const Status: FC = () => {
               <StatusInfo
                 id="reponse-no-result"
                 handleGoBackClick={handleGoBack}
-                goBackText={t('go-back')}
+                goBackText={t('previous')}
                 goBackStyle="primary"
                 checkAgainText={t('check-again')}
               >

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -52,7 +52,7 @@
     @apply underline;
   }
   main > a:hover, a:focus {
-    @apply text-link-slected;
+    @apply text-link-selected;
   }
   main > a:visited {
     @apply text-link-visited;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -24,7 +24,7 @@ module.exports = {
           error: '#d3080c',
           warning: '#ee7100',
           info: '#269abc',
-          slected: '#333',
+          selected: '#333',
         },
         red: {
           light: '#f3e9e8',
@@ -32,7 +32,7 @@ module.exports = {
         },
         link: {
           default: '#2b4380',
-          slected: '#0535d2',
+          selected: '#0535d2',
           visited: '#7834bc',
         },
         blue: {


### PR DESCRIPTION
### Description

Small PR that updates the reference for the previous button on the status page. I've also added focus and hover styling to the `LinkSummary` component.

### What to test for/How to test
1. Pull in branch
2. Type `npm run dev`
3. Enter data into form and click `Check Status`
4. Confirm that the button now says `Previous` and that the links below are now highlighted when focusing or hovering
