### PR TITLE
Added consent page and updated navigation

### DIFF
--- a/__tests__/pages/consent.test.js
+++ b/__tests__/pages/consent.test.js
@@ -1,0 +1,26 @@
+/**
+ * @jest-environment jsdom
+ */
+import { render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom'
+import Consent from '../../pages/consent'
+import { axe, toHaveNoViolations } from 'jest-axe'
+
+expect.extend(toHaveNoViolations)
+
+jest.mock('../../components/Layout', () => 'Layout')
+jest.mock('../../components/LinkButton')
+
+describe('Consent page', () => {
+  it('should render the page', () => {
+    render(<Consent />)
+    const heading = screen.getByRole('heading', { level: 1 })
+    expect(heading).toBeInTheDocument()
+  })
+
+  it('should be accessable', async () => {
+    const { container } = render(<Consent />)
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
+  })
+})

--- a/components/LinkButton.tsx
+++ b/components/LinkButton.tsx
@@ -19,8 +19,8 @@ const LinkButton: FC<LinkButtonProps> = ({
   return (
     <Link href={href} passHref>
       <a
-        target={external ? '_blank' : ''}
-        rel={external ? 'noopener noreferrer' : ''}
+        target={external ? '_blank' : undefined}
+        rel={external ? 'noopener noreferrer' : undefined}
         id={id}
         lang={lang}
         className="font-display border-blue-dark bg-blue-dark text-basic-white hover:bg-blue-normal inline-block text-center align-middle rounded border py-2 px-10 focus:ring-1 focus:ring-offset-2 focus:ring-black focus:text-basic-white focus:bg-blue-normal active:bg-blue-active"

--- a/components/LinkSummary.tsx
+++ b/components/LinkSummary.tsx
@@ -24,8 +24,8 @@ const LinkSummary: FC<LinkSummaryProps> = ({ title, links }) => {
           >
             <Link href={href} passHref>
               <a
-                target={external ? '_blank' : ''}
-                rel={external ? 'noopener noreferrer' : ''}
+                target={external ? '_blank' : undefined}
+                rel={external ? 'noopener noreferrer' : undefined}
               >
                 {text}
               </a>

--- a/cypress/e2e/consent.cy.js
+++ b/cypress/e2e/consent.cy.js
@@ -1,0 +1,38 @@
+describe('consent page loads', () => {
+    beforeEach(() => {
+      cy.visit('/consent')
+      cy.injectAxe();
+    })
+  
+    it('displays the consent page', () => {
+      cy.url().should("contains", "/consent");
+    })
+
+    it('should display the button for agreeing to give consent',()=>{
+        cy.get(`#yesButton`).should('be.visible')
+    })
+
+    it('should display the button for not giving consent',()=>{
+        cy.get(`#noButton`).should('be.visible')
+    })
+  
+    it('App has no detectable a11y violations on load', () => {
+      cy.checkA11y()
+    })
+})
+
+describe('user gives consent',()=>{
+    it('should redirect to the email page',()=>{
+        cy.visit('/consent')
+        cy.get('#yesButton').click()
+        cy.url().should('contain','/email')
+    })
+})
+
+describe('user does not give consent',()=>{
+  it('should redirect to the contact page',()=>{
+      cy.visit('/consent')
+      cy.get('#noButton').click()
+      cy.url().should('contain','/contact')
+  })
+})

--- a/cypress/e2e/landing.cy.js
+++ b/cypress/e2e/landing.cy.js
@@ -22,10 +22,10 @@ describe('landing page loads', () => {
 })
 
 describe('user has ESRF number',()=>{
-    it('should redirect to the form',()=>{
+    it('should redirect to the consent page',()=>{
         cy.visit('/landing')
         cy.get('#withoutESRF').click()
-        cy.url().should('contain','/email')
+        cy.url().should('contain','/consent')
     })
 })
 

--- a/pages/consent.tsx
+++ b/pages/consent.tsx
@@ -5,8 +5,8 @@ import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import Layout from '../components/Layout'
 import LinkButton from '../components/LinkButton'
 
-const Landing: FC = () => {
-  const { t } = useTranslation('landing')
+const Consent: FC = () => {
+  const { t } = useTranslation('consent')
 
   return (
     <Layout
@@ -17,11 +17,11 @@ const Landing: FC = () => {
       <h1 className="mb-4">{t('header')}</h1>
       <h2 className="my-14">{t('description')}</h2>
       <div className="flex justify-center flex-wrap text-xl gap-4">
-        <div id="withoutESRF">
-          <LinkButton href="/consent" text={t('withoutESRF')}></LinkButton>
+        <div id="yesButton">
+          <LinkButton text={t('yesButton')} href="/email" />
         </div>
-        <div id="withESRF">
-          <LinkButton href="/status" text={t('withESRF')}></LinkButton>
+        <div id="noButton">
+          <LinkButton text={t('noButton')} href="/contact" />
         </div>
       </div>
     </Layout>
@@ -32,9 +32,9 @@ export const getStaticProps: GetStaticProps = async ({ locale }) => ({
   props: {
     ...(await serverSideTranslations(locale ?? 'default', [
       'common',
-      'landing',
+      'consent',
     ])),
   },
 })
 
-export default Landing
+export default Consent

--- a/pages/contact.tsx
+++ b/pages/contact.tsx
@@ -1,12 +1,15 @@
-import { FC } from 'react'
+import { FC, useState } from 'react'
 import { GetStaticProps } from 'next'
+import Router from 'next/router'
 import { useTranslation } from 'next-i18next'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import Layout from '../components/Layout'
 import LinkSummary, { LinkSummaryItem } from '../components/LinkSummary'
+import Modal from '../components/Modal'
 
 const Contact: FC = () => {
   const { t } = useTranslation('contact')
+  const [modalOpen, setModalOpen] = useState(false)
 
   return (
     <Layout
@@ -21,6 +24,28 @@ const Contact: FC = () => {
           links={t<string, LinkSummaryItem[]>('common:program-links', {
             returnObjects: true,
           })}
+        />
+      </div>
+      <div className="py-2">
+        <Modal
+          buttonText={t('backToHome')}
+          description={t('common:cancel-modal.description')}
+          isOpen={modalOpen}
+          onClick={() => setModalOpen(!modalOpen)}
+          buttons={[
+            {
+              text: t('common:cancel-modal.yes-button'),
+              onClick: () => Router.push('/landing'),
+              style: 'primary',
+              type: 'button',
+            },
+            {
+              text: t('common:cancel-modal.no-button'),
+              onClick: () => setModalOpen(!modalOpen),
+              style: 'default',
+              type: 'button',
+            },
+          ]}
         />
       </div>
     </Layout>

--- a/pages/email.tsx
+++ b/pages/email.tsx
@@ -1,20 +1,23 @@
 import { useFormik } from 'formik'
 import * as Yup from 'yup'
 import { GetStaticProps } from 'next'
+import Router from 'next/router'
 import { useTranslation } from 'next-i18next'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import Layout from '../components/Layout'
 import { EmailEsrfRequestBody, EmailEsrf } from '../lib/EmailEsrfHook'
-import { useMemo } from 'react'
+import { useMemo, useState } from 'react'
 import ErrorSummary, {
   ErrorSummaryItem,
   GetErrorSummary,
 } from '../components/ErrorSummary'
 import InputField from '../components/InputField'
 import ActionButton from '../components/ActionButton'
+import Modal from '../components/Modal'
 
 export default function Email() {
   const { t } = useTranslation('email')
+  const [modalOpen, setModalOpen] = useState(false)
 
   const initialValues: EmailEsrfRequestBody = {
     dateOfBirth: '',
@@ -115,12 +118,38 @@ export default function Email() {
           textRequired={t('common:required')}
           required
         />
-        <ActionButton
-          disabled={isLoading}
-          type="submit"
-          text={t('email-esrf')}
-          style="primary"
-        />
+        <div className="flex flex-wrap">
+          <div className="py-1 pr-2">
+            <ActionButton
+              disabled={isLoading}
+              type="submit"
+              text={t('email-esrf')}
+              style="primary"
+            />
+          </div>
+          <div className="py-1">
+            <Modal
+              buttonText={t('common:cancel-modal.cancel-button')}
+              description={t('common:cancel-modal.description')}
+              isOpen={modalOpen}
+              onClick={() => setModalOpen(!modalOpen)}
+              buttons={[
+                {
+                  text: t('common:cancel-modal.yes-button'),
+                  onClick: () => Router.push('/landing'),
+                  style: 'primary',
+                  type: 'button',
+                },
+                {
+                  text: t('common:cancel-modal.no-button'),
+                  onClick: () => setModalOpen(!modalOpen),
+                  style: 'default',
+                  type: 'button',
+                },
+              ]}
+            />
+          </div>
+        </div>
       </form>
     </Layout>
   )

--- a/pages/status.tsx
+++ b/pages/status.tsx
@@ -224,19 +224,19 @@ const Status: FC = () => {
               </div>
               <div className="py-1">
                 <Modal
-                  buttonText={t('cancel-modal.cancel-button')}
-                  description={t('cancel-modal.description')}
+                  buttonText={t('common:cancel-modal.cancel-button')}
+                  description={t('common:cancel-modal.description')}
                   isOpen={modalOpen}
                   onClick={() => setModalOpen(!modalOpen)}
                   buttons={[
                     {
-                      text: t('cancel-modal.yes-button'),
+                      text: t('common:cancel-modal.yes-button'),
                       onClick: () => Router.push('/landing'),
                       style: 'primary',
                       type: 'button',
                     },
                     {
-                      text: t('cancel-modal.no-button'),
+                      text: t('common:cancel-modal.no-button'),
                       onClick: () => setModalOpen(!modalOpen),
                       style: 'default',
                       type: 'button',

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -63,5 +63,11 @@
       "href": "https://eservices.canada.ca/en/reservation/",
       "external": true
     }
-  ]
+  ],
+  "cancel-modal": {
+    "cancel-button": "Cancel",
+    "yes-button": "Yes",
+    "no-button": "No",
+    "description": "Are you sure you want to go back?"
+  }
 }

--- a/public/locales/en/consent.json
+++ b/public/locales/en/consent.json
@@ -1,0 +1,6 @@
+{
+  "header": "Email Consent",
+  "description": "We respect your privacy. On the following page, upon filling out the form, your file number (ESRF) will be sent to the email on file. In order to continue, please indicate below if you consent to us sending you an email",
+  "yesButton": "Yes, I wish to receive an email",
+  "noButton": "No, I do not wish to receive an email"
+}

--- a/public/locales/en/contact.json
+++ b/public/locales/en/contact.json
@@ -1,4 +1,5 @@
 {
   "header": "Contact Us",
-  "description": "Didn't find what you were looking for? Get in touch with us using the link below or see our other services"
+  "description": "Didn't find what you were looking for? Get in touch with us using the link below or see our other services",
+  "backToHome": "Return to home page"
 }

--- a/public/locales/en/status.json
+++ b/public/locales/en/status.json
@@ -39,12 +39,6 @@
     "label": "Surname"
   },
   "unable-to-find-status": "We are unable to determine the status of your application at this time using this service.",
-  "cancel-modal": {
-    "cancel-button": "Cancel",
-    "yes-button": "Yes",
-    "no-button": "No",
-    "description": "Are you sure you want to go back?"
-  },
   "other-ways-to-status": "Contact us",
   "no-match-title": "Other ways to get your status:"
 }

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -63,5 +63,11 @@
       "href": "https://eservices.canada.ca/fr/reservation/",
       "external": true
     }
-  ]
+  ],
+  "cancel-modal": {
+    "cancel-button": "Annuler",
+    "yes-button": "Oui",
+    "no-button": "Non",
+    "description": "Tu es sûr que tu veux y retourner ?"
+  }
 }

--- a/public/locales/fr/consent.json
+++ b/public/locales/fr/consent.json
@@ -1,0 +1,6 @@
+{
+  "header": "Consentement par e-mail",
+  "description": "Nous respectons votre vie privée. Sur la page suivante, après avoir rempli le formulaire, votre numéro de dossier (ESRF) sera envoyé à l'adresse électronique figurant dans votre dossier. Afin de continuer, veuillez indiquer ci-dessous si vous consentez à ce que nous vous envoyions un e-mail.",
+  "yesButton": "Oui, je souhaite recevoir un email",
+  "noButton": "Non, je ne souhaite pas recevoir d'email"
+}

--- a/public/locales/fr/contact.json
+++ b/public/locales/fr/contact.json
@@ -1,4 +1,5 @@
 {
   "header": "Contactez-nous",
-  "description": "Vous n'avez pas trouvé ce que vous cherchiez ? Contactez-nous en utilisant le lien ci-dessous ou consultez nos autres services"
+  "description": "Vous n'avez pas trouvé ce que vous cherchiez ? Contactez-nous en utilisant le lien ci-dessous ou consultez nos autres services",
+  "backToHome": "Return to home page"
 }

--- a/public/locales/fr/status.json
+++ b/public/locales/fr/status.json
@@ -39,12 +39,6 @@
     "label": "Nom de famille"
   },
   "unable-to-find-status": "Nous ne sommes pas en mesure de déterminer le statut de votre demande pour le moment en utilisant ce service.",
-  "cancel-modal": {
-    "cancel-button": "Annuler",
-    "yes-button": "Oui",
-    "no-button": "Non",
-    "description": "Tu es sûr que tu veux y retourner ?"
-  },
   "other-ways-to-status": "Contactez-nous",
   "no-match-title": "D'autres façons d'obtenir votre statut:"
 }


### PR DESCRIPTION
## [ADO-1065](https://dev.azure.com/DTS-STN/passport-status/_workitems/edit/1065)

### Description

This PR adds the consent page and updates the navigation flow. A lot of files are touched in this PR but most changes are just to tests & routing to align with the new navigation. I've also moved the translations for the modal into `common` since we are now using this on more than one page. The meat of the changes is in the `consent.tsx` page.

### What to test for/How to test
1. Pull in branch
2. Type `npm run dev`
3. Navigate to `/landing`
4. Select `I don't have my file number (ESRF)`
5. Confirm you were redirected to `consent`
6. Confirm that answering yes redirects you to `email`
7. Confirm that answering no redirects you to `contact` and that the `Return to home` button redirects you to `landing`
