### PR TITLE
Added privacy/emailterm pages into the workflow. Missing actual data.

### DIFF
--- a/cypress/e2e/landing.cy.js
+++ b/cypress/e2e/landing.cy.js
@@ -21,15 +21,15 @@ describe('landing page loads', () => {
     })
 })
 
-describe('user has ESRF number',()=>{
-    it('should redirect to the consent page',()=>{
+describe('user does not ESRF number',()=>{
+    it('should redirect to the privacy page',()=>{
         cy.visit('/landing')
         cy.get('#without-esrf').click()
-        cy.url().should('contain','/consent')
+        cy.url().should('contain','/privacy')
     })
 })
 
-describe('user does not have ESRF number',()=>{
+describe('user does have ESRF number',()=>{
   it('should redirect to the form',()=>{
       cy.visit('/landing')
       cy.get('#with-esrf').click()

--- a/cypress/e2e/privacy.cy.js
+++ b/cypress/e2e/privacy.cy.js
@@ -22,7 +22,7 @@ describe('User agrees to the term',()=>{
     it('hide the terms and display the privacy',()=>{
         cy.visit('/privacy')
         cy.get('#termsBtnGrp button').first().click()
-        cy.get('#terms').should('be.visible')
+        cy.get('#privacy').should('be.visible')
     })
 })
 
@@ -30,7 +30,7 @@ describe('User agree to terms and privay',()=>{
   it('should redirect to the consent page',()=>{
         cy.visit('/privacy')
         cy.get('#termsBtnGrp button').first().click()
-        cy.get('#privacyBtnGrp button').first().click()
+        cy.get('#privacyBtnGrp a').first().click()
         cy.url().should('contain','/consent')
   })
 })

--- a/cypress/e2e/privacy.cy.js
+++ b/cypress/e2e/privacy.cy.js
@@ -1,0 +1,36 @@
+describe('privacy page loads', () => {
+    beforeEach(() => {
+      cy.visit('/privacy')
+      cy.injectAxe();
+    })
+  
+    it('displays the privacy page', () => {
+      cy.url().should("contains", "/privacy");
+    })
+
+    it('displays the terms content',()=>{
+        cy.get(`#terms`).should('be.visible')
+    })
+
+  
+    it('App has no detectable a11y violations on load', () => {
+      cy.checkA11y()
+    })
+})
+
+describe('User agrees to the term',()=>{
+    it('hide the terms and display the privacy',()=>{
+        cy.visit('/privacy')
+        cy.get('#termsBtnGrp button').first().click()
+        cy.get('#terms').should('be.visible')
+    })
+})
+
+describe('User agree to terms and privay',()=>{
+  it('should redirect to the consent page',()=>{
+        cy.visit('/privacy')
+        cy.get('#termsBtnGrp button').first().click()
+        cy.get('#privacyBtnGrp button').first().click()
+        cy.url().should('contain','/consent')
+  })
+})

--- a/pages/landing.tsx
+++ b/pages/landing.tsx
@@ -18,7 +18,7 @@ const Landing: FC = () => {
       <h2 className="my-14">{t('description')}</h2>
       <div className="flex justify-center flex-wrap text-xl gap-4">
         <div id="without-esrf">
-          <LinkButton href="/consent" text={t('without-esrf')}></LinkButton>
+          <LinkButton href="/privacy" text={t('without-esrf')}></LinkButton>
         </div>
         <div id="with-esrf">
           <LinkButton href="/status" text={t('with-esrf')}></LinkButton>

--- a/pages/privacy.tsx
+++ b/pages/privacy.tsx
@@ -20,7 +20,7 @@ const Privacy: FC = () => {
       <h1 className="mb-4">{t('header')}</h1>
       <div className="ml-auto mr-auto p-3">
         {!agree && (
-          <span id="terms">
+          <div id="terms">
             <h2 className="my-14">{t('terms-text')}</h2>
             <div
               id="termsBtnGrp"
@@ -37,11 +37,11 @@ const Privacy: FC = () => {
                 onClick={() => Router.push('/contact')}
               />
             </div>
-          </span>
+          </div>
         )}
 
         {agree && (
-          <span id="privacy">
+          <div id="privacy">
             <h2 className="my-14">{t('privacy-text')}</h2>
             <div
               id="privacyBtnGrp"
@@ -58,7 +58,7 @@ const Privacy: FC = () => {
                 style="primary"
               />
             </div>
-          </span>
+          </div>
         )}
       </div>
     </Layout>

--- a/pages/privacy.tsx
+++ b/pages/privacy.tsx
@@ -18,38 +18,48 @@ const Privacy: FC = () => {
       footer={t('common:footer', { returnObjects: true })}
     >
       <h1 className="mb-4">{t('header')}</h1>
-      <div className="max-w-4xl overflow-hidden ml-auto mr-auto p-3">
-        <span id="terms" style={{ display: !agree ? 'block' : 'none' }}>
-          <p>{t('terms-text')}</p>
-          <div
-            id="termsBtnGrp"
-            className="flex flex-wrap justify-end space-x-2"
-          >
-            <ActionButton
-              text={t('agree')}
-              style="primary"
-              onClick={() => setAgree(true)}
-            />
-            <ActionButton
-              text={t('disagree')}
-              onClick={() => Router.push('/contact')}
-            />
-          </div>
-        </span>
-        <span id="privacy" style={{ display: agree ? 'block' : 'none' }}>
-          <p>{t('privacy-text')}</p>
-          <div
-            id="privacyBtnGrp"
-            className="flex flex-wrap justify-end space-x-2"
-          >
-            <LinkButton
-              id="goToConsent"
-              href="/consent"
-              text={t('continue')}
-            ></LinkButton>
-            <ActionButton text={t('back')} onClick={() => setAgree(false)} />
-          </div>
-        </span>
+      <div className="ml-auto mr-auto p-3">
+        {!agree && (
+          <span id="terms">
+            <h2 className="my-14">{t('terms-text')}</h2>
+            <div
+              id="termsBtnGrp"
+              className="flex flex-wrap justify-center space-x-2"
+            >
+              <ActionButton
+                text={t('agree')}
+                style="primary"
+                onClick={() => setAgree(true)}
+              />
+              <ActionButton
+                text={t('disagree')}
+                style="primary"
+                onClick={() => Router.push('/contact')}
+              />
+            </div>
+          </span>
+        )}
+
+        {agree && (
+          <span id="privacy">
+            <h2 className="my-14">{t('privacy-text')}</h2>
+            <div
+              id="privacyBtnGrp"
+              className="flex flex-wrap justify-center space-x-2"
+            >
+              <LinkButton
+                id="goToConsent"
+                href="/consent"
+                text={t('continue')}
+              />
+              <ActionButton
+                text={t('back')}
+                onClick={() => setAgree(false)}
+                style="primary"
+              />
+            </div>
+          </span>
+        )}
       </div>
     </Layout>
   )

--- a/pages/privacy.tsx
+++ b/pages/privacy.tsx
@@ -1,0 +1,67 @@
+import { FC, useState } from 'react'
+import { GetStaticProps } from 'next'
+import Router from 'next/router'
+import { useTranslation } from 'next-i18next'
+import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
+import Layout from '../components/Layout'
+import ActionButton from '../components/ActionButton'
+import LinkButton from '../components/LinkButton'
+
+const Privacy: FC = () => {
+  const { t } = useTranslation('privacy')
+  const [agree, setAgree] = useState(false)
+
+  return (
+    <Layout
+      meta={t('common:meta', { returnObjects: true })}
+      header={t('common:header', { returnObjects: true })}
+      footer={t('common:footer', { returnObjects: true })}
+    >
+      <h1 className="mb-4">{t('header')}</h1>
+      <div className="max-w-4xl overflow-hidden ml-auto mr-auto p-3">
+        <span id="terms" style={{ display: !agree ? 'block' : 'none' }}>
+          <p>{t('terms-text')}</p>
+          <div
+            id="termsBtnGrp"
+            className="flex flex-wrap justify-end space-x-2"
+          >
+            <ActionButton
+              text={t('agree')}
+              style="primary"
+              onClick={() => setAgree(true)}
+            />
+            <ActionButton
+              text={t('disagree')}
+              onClick={() => Router.push('/contact')}
+            />
+          </div>
+        </span>
+        <span id="privacy" style={{ display: agree ? 'block' : 'none' }}>
+          <p>{t('privacy-text')}</p>
+          <div
+            id="privacyBtnGrp"
+            className="flex flex-wrap justify-end space-x-2"
+          >
+            <LinkButton
+              id="goToConsent"
+              href="/consent"
+              text={t('continue')}
+            ></LinkButton>
+            <ActionButton text={t('back')} onClick={() => setAgree(false)} />
+          </div>
+        </span>
+      </div>
+    </Layout>
+  )
+}
+
+export const getStaticProps: GetStaticProps = async ({ locale }) => ({
+  props: {
+    ...(await serverSideTranslations(locale ?? 'default', [
+      'common',
+      'privacy',
+    ])),
+  },
+})
+
+export default Privacy

--- a/public/locales/en/privacy.json
+++ b/public/locales/en/privacy.json
@@ -1,0 +1,9 @@
+{
+  "header": "Privacy and Email Terms",
+  "privacy-text": "[privacy information here]",
+  "terms-text": "Do you agree to the email terms and conditions?",
+  "agree": "I agree",
+  "disagree": "I do not agree",
+  "continue": "continue",
+  "back": "back"
+}

--- a/public/locales/fr/privacy.json
+++ b/public/locales/fr/privacy.json
@@ -1,0 +1,9 @@
+{
+  "header": "Conditions de confidentialité et d'e-mail",
+  "privacy-text": "[privacy text here] (fr)",
+  "terms-text": "Acceptez-vous les termes et conditions de l'e-mail?",
+  "agree": "Je suis d'accord",
+  "disagree": "je ne suis pas d'accord",
+  "continue": "suivant",
+  "back": "retour"
+}


### PR DESCRIPTION


### Description

##Opinion needed, not to be merged YET.

I added the privacy and email terms page before the consent page. I took a little creative liberty with the flow and would like your opinion.

I went with a sort of multi-step form in the sense of "next -> next -> I agree -> [ redirect to Form Page]"; Should I add the consent portion into this flow or have this flow match the consent page.

I know it may sound complicated but you will understand once you play with it.

List of proposed changes:

- Added privacy and email terms page
- modify flow

### What to test for/How to test

in the landing page select "I don't have my ESRF number"

Follow the flow

### Additional Notes
