### PR TITLE
Update missing translations

### DIFF
--- a/components/DateModified.tsx
+++ b/components/DateModified.tsx
@@ -13,16 +13,18 @@ export interface DateModifiedProps {
  */
 const DateModified: FC<DateModifiedProps> = ({ id, text }) => {
   return (
-    <dl id={id} className="container mx-auto pl-6">
-      <dt className="inline">{text}</dt>
-      <dd className="inline">{process.env.NEXT_PUBLIC_BUILD_DATE}</dd>
-    </dl>
+    <time>
+      <dl id={id} className="container mx-auto pl-6">
+        <dt className="inline">{text}</dt>
+        <dd className="inline">{process.env.NEXT_PUBLIC_BUILD_DATE}</dd>
+      </dl>
+    </time>
   )
 }
 
 DateModified.defaultProps = {
   id: 'date-modified',
-  text: 'Date Modified:',
+  text: 'Date Modified: ',
 }
 
 export default DateModified

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -2,7 +2,7 @@
   "contact-us": "Nous contacter",
   "english": "English",
   "footer": {
-    "date-modified": "Date de modification\u00A0: ",
+    "dateModifiedText": "Date de modification\u00A0: ",
     "about-this-site": "À propos de ce site",
     "canada-ca-alt-text": "Symbole du gouvernement du Canada",
     "links": {

--- a/public/locales/fr/consent.json
+++ b/public/locales/fr/consent.json
@@ -1,6 +1,6 @@
 {
   "header": "Consentement par e-mail",
   "description": "Nous respectons votre vie privée. Sur la page suivante, après avoir rempli le formulaire, votre numéro de dossier (ESRF) sera envoyé à l'adresse électronique figurant dans votre dossier. Afin de continuer, veuillez indiquer ci-dessous si vous consentez à ce que nous vous envoyions un e-mail.",
-  "yesButton": "Oui, je souhaite recevoir un email",
-  "noButton": "Non, je ne souhaite pas recevoir d'email"
+  "yes-button": "Oui, je souhaite recevoir un email",
+  "no-button": "Non, je ne souhaite pas recevoir d'email"
 }


### PR DESCRIPTION
## [ADO-1167](https://dev.azure.com/DTS-STN/passport-status/_workitems/edit/1167)

### Description
Was pointed out that our Date modified component wasn't translating. Turns out the reason was because the key was different for French. I've changed it to be in line with English and it now properly translates. I also noticed that the keys were different for the buttons on the consent page so I've added that fix in this PR as well. I also wrapped the `<dl>` in the DateModified component with `<time>` as per Greg's suggestion.

### What to test for/How to test
1. Pull in branch
2. Type `npm run dev`
3. Navigate to `/consent`
4. Switch languages and ensure both the date modified text and the text for the 2 buttons are translated.