### PR TITLE
Error page padding

### DIFF
--- a/components/DateModified.tsx
+++ b/components/DateModified.tsx
@@ -13,12 +13,12 @@ export interface DateModifiedProps {
  */
 const DateModified: FC<DateModifiedProps> = ({ id, text }) => {
   return (
-    <time>
-      <dl id={id} className="container mx-auto pl-6">
-        <dt className="inline">{text}</dt>
-        <dd className="inline">{process.env.NEXT_PUBLIC_BUILD_DATE}</dd>
-      </dl>
-    </time>
+    <dl id={id} className="container mx-auto pl-6">
+      <dt className="inline">{text}</dt>
+      <dd className="inline">
+        <time>{process.env.NEXT_PUBLIC_BUILD_DATE}</time>
+      </dd>
+    </dl>
   )
 }
 

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -28,7 +28,7 @@ const Custom404 = () => {
               >
                 Contact us
               </a>
-              &nbsp; and we&#39;ll help you out
+              &nbsp;and we&#39;ll help you out
             </li>
           </ul>
         </div>

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -2,54 +2,56 @@ import Link from 'next/link'
 
 const Custom404 = () => {
   return (
-    <div className="grid md:grid-cols-2 sm:grid-cols-1 items-center justify-center overflow-visible md:h-96 sm:h-screen mx-2 my-2 px-20">
-      <div className="error-404">
-        <h1 className="text-2xl">{"We couldn't find that Web page"}</h1>
-        <h2>An error 404 occured on server</h2>
-        <p>
-          {
-            "We're sorry you ended up here. Sometimes a page gets moved or deleted, but hopefully we can help you find what you're looking for. What next?"
-          }
-        </p>
-        <ul>
-          <li>
-            Return to the{' '}
-            <Link href="/" locale="default">
-              <a className="text-cyan-600 underline">home page</a>
-            </Link>
-            ;
-          </li>
-          <li>
-            <Link href="https://www.canada.ca/en/contact.html">
-              <a className="text-cyan-600 underline">Contact us</a>
-            </Link>
-            {" and we'll help you out."}
-          </li>
-        </ul>
-      </div>
-      <div className="error-404">
-        <h1 className="text-2xl">Nous ne pouvons trouver cette page Web</h1>
-        <h2>Erreur 404</h2>
-        <p>
-          {
-            "Nous sommes désolés que vous ayez abouti ici. Il arrive parfois qu'une page ait été déplacée ou supprimée. Heureusement, nous pouvons vous aider à trouver ce que vous cherchez. Que faire?"
-          }
-        </p>
-        <ul>
-          <li>
-            Retournez à la{' '}
-            <Link href="/" locale="default">
-              <a className="text-cyan-600 underline">page {"d'accueil;"}</a>
-            </Link>
-          </li>
-          <li>
-            <Link href="https://www.canada.ca/en/contact.html">
-              <a className="text-cyan-600 underline">Communiquez avec nous</a>
-            </Link>
-            {" pour obtenir de l'aide."}
-          </li>
-        </ul>
-      </div>
+    <div className="min-h-screen">
+      <section className="grid lg:grid-cols-3 sm:grid-cols-1 mx-6 xxs:mx-4 xs:px-0 md:px-0 lg:container lg:mx-auto xl:px-12 lg:px-6 pb-44">
+        <div className="h-auto xxl:w-400px lg:w-96 xl:h-400px lg:h-500px mb-8 lg:mb-0 col-span-2">
+          <h1 className="text-2xl">{"We couldn't find that Web page"}</h1>
+          <h2>An error 404 occured on server</h2>
+          <p>
+            {
+              "We're sorry you ended up here. Sometimes a page gets moved or deleted, but hopefully we can help you find what you're looking for. What next?"
+            }
+          </p>
+          <ul>
+            <li>
+              Return to the{' '}
+              <Link href="/" locale="default">
+                <a className="text-cyan-600 underline">home page</a>
+              </Link>
+              ;
+            </li>
+            <li>
+              <Link href="https://www.canada.ca/en/contact.html">
+                <a className="text-cyan-600 underline">Contact us</a>
+              </Link>
+              {" and we'll help you out."}
+            </li>
+          </ul>
+        </div>
+        <div className="h-auto xxl:w-400px lg:w-96 xl:h-400px lg:h-500px mb-8 lg:mb-0">
+          <h1 className="text-2xl">Nous ne pouvons trouver cette page Web</h1>
+          <h2>Erreur 404</h2>
+          <p>
+            {
+              "Nous sommes désolés que vous ayez abouti ici. Il arrive parfois qu'une page ait été déplacée ou supprimée. Heureusement, nous pouvons vous aider à trouver ce que vous cherchez. Que faire?"
+            }
+          </p>
+          <ul>
+            <li>
+              Retournez à la{' '}
+              <Link href="/" locale="default">
+                <a className="text-cyan-600 underline">page {"d'accueil;"}</a>
+              </Link>
+            </li>
+            <li>
+              <Link href="https://www.canada.ca/en/contact.html">
+                <a className="text-cyan-600 underline">Communiquez avec nous</a>
+              </Link>
+              {" pour obtenir de l'aide."}
+            </li>
+          </ul>
+        </div>
+      </section>
     </div>
   )
 }

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -2,16 +2,17 @@ import Link from 'next/link'
 
 const Custom404 = () => {
   return (
-    <div className="min-h-screen">
-      <section className="grid lg:grid-cols-3 sm:grid-cols-1 mx-6 xxs:mx-4 xs:px-0 md:px-0 lg:container lg:mx-auto xl:px-12 lg:px-6 pb-44">
-        <div className="h-auto xxl:w-400px lg:w-96 xl:h-400px lg:h-500px mb-8 lg:mb-0 col-span-2">
-          <h1 className="text-2xl">{"We couldn't find that Web page"}</h1>
+    <div className="container mx-auto">
+      <section className="grid grid-cols-1 lg:grid-cols-2 mx-4 lg:mx-6 gap-4 lg:gap-8">
+        <div>
+          <h1 className="text-2xl">We couldn&#39;t find that Web page</h1>
           <h2>An error 404 occured on server</h2>
           <p>
-            {
-              "We're sorry you ended up here. Sometimes a page gets moved or deleted, but hopefully we can help you find what you're looking for. What next?"
-            }
+            We&#39;re sorry you ended up here. Sometimes a page gets moved or
+            deleted, but hopefully we can help you find what you&#39;re looking
+            for. What next?
           </p>
+
           <ul>
             <li>
               Return to the{' '}
@@ -21,33 +22,40 @@ const Custom404 = () => {
               ;
             </li>
             <li>
-              <Link href="https://www.canada.ca/en/contact.html">
-                <a className="text-cyan-600 underline">Contact us</a>
-              </Link>
-              {" and we'll help you out."}
+              <a
+                href="https://www.canada.ca/en/contact.html"
+                className="text-cyan-600 underline"
+              >
+                Contact us
+              </a>
+              &nbsp; and we&#39;ll help you out
             </li>
           </ul>
         </div>
-        <div className="h-auto xxl:w-400px lg:w-96 xl:h-400px lg:h-500px mb-8 lg:mb-0">
+        <div>
           <h1 className="text-2xl">Nous ne pouvons trouver cette page Web</h1>
           <h2>Erreur 404</h2>
           <p>
-            {
-              "Nous sommes désolés que vous ayez abouti ici. Il arrive parfois qu'une page ait été déplacée ou supprimée. Heureusement, nous pouvons vous aider à trouver ce que vous cherchez. Que faire?"
-            }
+            Nous sommes désolés que vous ayez abouti ici. Il arrive parfois
+            qu&#39;une page ait été déplacée ou supprimée. Heureusement, nous
+            pouvons vous aider à trouver ce que vous cherchez. Que faire?
           </p>
           <ul>
             <li>
               Retournez à la{' '}
               <Link href="/" locale="default">
-                <a className="text-cyan-600 underline">page {"d'accueil;"}</a>
+                <a className="text-cyan-600 underline">page d&#39;accueil</a>
               </Link>
+              ;
             </li>
             <li>
-              <Link href="https://www.canada.ca/en/contact.html">
-                <a className="text-cyan-600 underline">Communiquez avec nous</a>
-              </Link>
-              {" pour obtenir de l'aide."}
+              <a
+                href="https://www.canada.ca/fr/contact.html"
+                className="text-cyan-600 underline"
+              >
+                Communiquez avec nous
+              </a>
+              &nbsp;pour obtenir de l&#39;aide.
             </li>
           </ul>
         </div>

--- a/pages/_error.tsx
+++ b/pages/_error.tsx
@@ -7,19 +7,19 @@ export interface ErrorProps {
 
 const Error: NextPage<ErrorProps> = ({ statusCode }) => {
   return (
-    <div className="min-h-screen">
-      <section className="grid lg:grid-cols-3 sm:grid-cols-1 mx-6 xxs:mx-4 xs:px-0 md:px-0 lg:container lg:mx-auto xl:px-12 lg:px-6 pb-44">
-        <div className="h-auto xxl:w-400px lg:w-96 xl:h-400px lg:h-500px mb-8 lg:mb-0 col-span-2">
-          <h1 className="text-2xl">{"We couldn't find that Web page"}</h1>
+    <div className="container mx-auto">
+      <section className="grid grid-cols-1 lg:grid-cols-2 mx-4 lg:mx-6 gap-4 lg:gap-8">
+        <div>
+          <h1 className="text-2xl">We couldn&#39;t find that Web page</h1>
           <h2>
             {statusCode
               ? `An error ${statusCode} occurred on server`
               : 'An error occurred on client'}
           </h2>
           <p>
-            {
-              "We're sorry you ended up here. Sometimes a page gets moved or deleted, but hopefully we can help you find what you're looking for. What next?"
-            }
+            We&#39;re sorry you ended up here. Sometimes a page gets moved or
+            deleted, but hopefully we can help you find what you&#39;re looking
+            for. What next?
           </p>
           <ul>
             <li>
@@ -30,14 +30,17 @@ const Error: NextPage<ErrorProps> = ({ statusCode }) => {
               ;
             </li>
             <li>
-              <Link href="https://www.canada.ca/en/contact.html">
-                <a className="text-cyan-600 underline">Contact us</a>
-              </Link>
-              {" and we'll help you out."}
+              <a
+                href="https://www.canada.ca/en/contact.html"
+                className="text-cyan-600 underline"
+              >
+                Contact us
+              </a>
+              &nbsp;and we&#39;ll help you out
             </li>
           </ul>
         </div>
-        <div className="h-auto xxl:w-400px lg:w-96 xl:h-400px lg:h-500px mb-8 lg:mb-0">
+        <div>
           <h1 className="text-2xl">Nous ne pouvons trouver cette page Web</h1>
           <h2>
             {statusCode
@@ -45,22 +48,26 @@ const Error: NextPage<ErrorProps> = ({ statusCode }) => {
               : 'Erreur produite sur le client'}
           </h2>
           <p>
-            {
-              "Nous sommes désolés que vous ayez abouti ici. Il arrive parfois qu'une page ait été déplacée ou supprimée. Heureusement, nous pouvons vous aider à trouver ce que vous cherchez. Que faire?"
-            }
+            Nous sommes désolés que vous ayez abouti ici. Il arrive parfois
+            qu&#39;une page ait été déplacée ou supprimée. Heureusement, nous
+            pouvons vous aider à trouver ce que vous cherchez. Que faire?
           </p>
           <ul>
             <li>
               Retournez à la{' '}
               <Link href="/">
-                <a className="text-cyan-600 underline">page {"d'accueil;"}</a>
+                <a className="text-cyan-600 underline">page d&#39;accueil</a>
               </Link>
+              ;
             </li>
             <li>
-              <Link href="https://www.canada.ca/en/contact.html">
-                <a className="text-cyan-600 underline">Communiquez avec nous</a>
-              </Link>
-              {" pour obtenir de l'aide."}
+              <a
+                href="https://www.canada.ca/fr/contact.html"
+                className="text-cyan-600 underline"
+              >
+                Communiquez avec nous
+              </a>
+              &nbsp;pour obtenir de l&#39;aide.
             </li>
           </ul>
         </div>

--- a/pages/_error.tsx
+++ b/pages/_error.tsx
@@ -7,62 +7,64 @@ export interface ErrorProps {
 
 const Error: NextPage<ErrorProps> = ({ statusCode }) => {
   return (
-    <div className="grid md:grid-cols-2 sm:grid-cols-1 items-center justify-center overflow-visible md:h-96 sm:h-screen mx-2 my-2 px-20">
-      <div className="error-404">
-        <h1 className="text-2xl">{"We couldn't find that Web page"}</h1>
-        <h2>
-          {statusCode
-            ? `An error ${statusCode} occurred on server`
-            : 'An error occurred on client'}
-        </h2>
-        <p>
-          {
-            "We're sorry you ended up here. Sometimes a page gets moved or deleted, but hopefully we can help you find what you're looking for. What next?"
-          }
-        </p>
-        <ul>
-          <li>
-            Return to the{' '}
-            <Link href="/">
-              <a className="text-cyan-600 underline">home page</a>
-            </Link>
-            ;
-          </li>
-          <li>
-            <Link href="https://www.canada.ca/en/contact.html">
-              <a className="text-cyan-600 underline">Contact us</a>
-            </Link>
-            {" and we'll help you out."}
-          </li>
-        </ul>
-      </div>
-      <div className="error-404">
-        <h1 className="text-2xl">Nous ne pouvons trouver cette page Web</h1>
-        <h2>
-          {statusCode
-            ? `Erreur ${statusCode}`
-            : 'Erreur produite sur le client'}
-        </h2>
-        <p>
-          {
-            "Nous sommes désolés que vous ayez abouti ici. Il arrive parfois qu'une page ait été déplacée ou supprimée. Heureusement, nous pouvons vous aider à trouver ce que vous cherchez. Que faire?"
-          }
-        </p>
-        <ul>
-          <li>
-            Retournez à la{' '}
-            <Link href="/">
-              <a className="text-cyan-600 underline">page {"d'accueil;"}</a>
-            </Link>
-          </li>
-          <li>
-            <Link href="https://www.canada.ca/en/contact.html">
-              <a className="text-cyan-600 underline">Communiquez avec nous</a>
-            </Link>
-            {" pour obtenir de l'aide."}
-          </li>
-        </ul>
-      </div>
+    <div className="min-h-screen">
+      <section className="grid lg:grid-cols-3 sm:grid-cols-1 mx-6 xxs:mx-4 xs:px-0 md:px-0 lg:container lg:mx-auto xl:px-12 lg:px-6 pb-44">
+        <div className="h-auto xxl:w-400px lg:w-96 xl:h-400px lg:h-500px mb-8 lg:mb-0 col-span-2">
+          <h1 className="text-2xl">{"We couldn't find that Web page"}</h1>
+          <h2>
+            {statusCode
+              ? `An error ${statusCode} occurred on server`
+              : 'An error occurred on client'}
+          </h2>
+          <p>
+            {
+              "We're sorry you ended up here. Sometimes a page gets moved or deleted, but hopefully we can help you find what you're looking for. What next?"
+            }
+          </p>
+          <ul>
+            <li>
+              Return to the{' '}
+              <Link href="/">
+                <a className="text-cyan-600 underline">home page</a>
+              </Link>
+              ;
+            </li>
+            <li>
+              <Link href="https://www.canada.ca/en/contact.html">
+                <a className="text-cyan-600 underline">Contact us</a>
+              </Link>
+              {" and we'll help you out."}
+            </li>
+          </ul>
+        </div>
+        <div className="h-auto xxl:w-400px lg:w-96 xl:h-400px lg:h-500px mb-8 lg:mb-0">
+          <h1 className="text-2xl">Nous ne pouvons trouver cette page Web</h1>
+          <h2>
+            {statusCode
+              ? `Erreur ${statusCode}`
+              : 'Erreur produite sur le client'}
+          </h2>
+          <p>
+            {
+              "Nous sommes désolés que vous ayez abouti ici. Il arrive parfois qu'une page ait été déplacée ou supprimée. Heureusement, nous pouvons vous aider à trouver ce que vous cherchez. Que faire?"
+            }
+          </p>
+          <ul>
+            <li>
+              Retournez à la{' '}
+              <Link href="/">
+                <a className="text-cyan-600 underline">page {"d'accueil;"}</a>
+              </Link>
+            </li>
+            <li>
+              <Link href="https://www.canada.ca/en/contact.html">
+                <a className="text-cyan-600 underline">Communiquez avec nous</a>
+              </Link>
+              {" pour obtenir de l'aide."}
+            </li>
+          </ul>
+        </div>
+      </section>
     </div>
   )
 }


### PR DESCRIPTION
## [ADO-1168](https://dev.azure.com/DTS-STN/passport-status/_workitems/edit/1168)

### Description
The English and French sections of our error pages had next to no space between them and the headers weren't aligned (the latter seemingly because of `items-center` for whatever reason). I took this opportunity to adjust the styling a little bit. Canada.ca's error page displays the 2 sections in block when the width is 768px, so I followed that example and adjusted the grid. This PR also fixes the styling for mobile resolutions as it looks really really bad currently.

I've also updated the `<time>` tag in the DateModified component to actually wrap the time.

### What to test for/How to test
1. Pull in branch
2. Type `npm run dev`
3. Navigate to `/foo`
4. Confirm that the error page displays properly & content does not overlap at any resolution
