### PR TITLE
Tweak CSS and content for error pages

### DIFF
--- a/__tests__/pages/404.test.js
+++ b/__tests__/pages/404.test.js
@@ -8,8 +8,6 @@ import Custom404 from '../../pages/404'
 describe('404', () => {
   it('renders 404 without crashing', () => {
     render(<Custom404 />)
-    expect(
-      screen.getByText('An error 404 occured on server')
-    ).toBeInTheDocument()
+    expect(screen.getByText('Error 404')).toBeInTheDocument()
   })
 })

--- a/__tests__/pages/_error.test.js
+++ b/__tests__/pages/_error.test.js
@@ -8,9 +8,7 @@ import CustomError from '../../pages/_error'
 describe('custom error', () => {
   it('renders custom statusCode without crashing', () => {
     render(<CustomError statusCode="500" />)
-    expect(
-      screen.getByText('An error 500 occurred on server')
-    ).toBeInTheDocument()
+    expect(screen.getByText('Error 500')).toBeInTheDocument()
   })
 
   it('renders no statusCode without crashing', () => {

--- a/components/ErrorLayout.tsx
+++ b/components/ErrorLayout.tsx
@@ -6,32 +6,36 @@ export interface ErrorLayoutProps {
 
 const ErrorLayout: FC<ErrorLayoutProps> = ({ children }) => {
   return (
-    <div className="container mx-auto">
-      <img
-        className="h-5 w-auto xs:h-6 sm:h-8 md:h-8 lg:h-7 xl:h-8 my-5 mx-4 lg:mx-6"
-        src={'/sig-blk-en.svg'}
-        alt="Government of Canada - Gouvernement du Canada"
-      />
-
+    <div className="flex flex-col min-h-screen">
+      <header className="container mx-auto px-6 my-6">
+        <img
+          className="h-5 w-auto xs:h-6 sm:h-8 md:h-8 lg:h-7 xl:h-8"
+          src={'/sig-blk-en.svg'}
+          alt="Government of Canada - Gouvernement du Canada"
+        />
+      </header>
+      <hr />
       <main
         role="main"
-        className="grid grid-cols-1 lg:grid-cols-2 mx-4 lg:mx-6 gap-4 lg:gap-8"
+        id="mainContent"
+        className="container mx-auto px-6 my-8 flex-1"
       >
         {children}
       </main>
-
-      <footer className="mt-12 mb-3 flex lg:flex-row-reverse pr-4 lg:pr-6 justify-between">
-        <a className="w-32 sm:w-36 pl-4 lg:hidden text-sm font-body" href="#">
-          Top of page / Haut de la page&nbsp;
-          <span className="font-extrabold">&#8963;</span>
-        </a>
-        <img
-          className="h-6 w-auto lg:h-auto lg:w-40"
-          src={'/wmms-blk.svg'}
-          alt={
-            'Symbol of the Government of Canada - Symbole du gouvernement du Canada'
-          }
-        />
+      <footer className="py-4 bg-gray-light">
+        <div className="container mx-auto px-6 flex lg:flex-row-reverse justify-between">
+          <a className="w-32 sm:w-36 lg:hidden text-sm font-body" href="#">
+            Top of page / Haut de la page&nbsp;
+            <span className="font-extrabold">&#8963;</span>
+          </a>
+          <img
+            className="h-6 w-auto lg:h-auto lg:w-40"
+            src={'/wmms-blk.svg'}
+            alt={
+              'Symbol of the Government of Canada - Symbole du gouvernement du Canada'
+            }
+          />
+        </div>
       </footer>
     </div>
   )

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -13,60 +13,62 @@ const Custom404 = () => {
           title: 'Not Found | Pas trouvé - Canada.ca',
         }}
       />
-      <div>
-        <h1 className="text-2xl">We couldn&#39;t find that Web page</h1>
-        <h2>An error 404 occured on server</h2>
-        <p>
-          We&#39;re sorry you ended up here. Sometimes a page gets moved or
-          deleted, but hopefully we can help you find what you&#39;re looking
-          for. What next?
-        </p>
 
-        <ul>
-          <li>
-            Return to the{' '}
-            <Link href="/" locale="default">
-              <a className="text-cyan-600 underline">home page</a>
-            </Link>
-            ;
-          </li>
-          <li>
-            <a
-              href="https://www.canada.ca/en/contact.html"
-              className="text-cyan-600 underline"
-            >
-              Contact us
-            </a>
-            &nbsp;and we&#39;ll help you out
-          </li>
-        </ul>
-      </div>
-      <div>
-        <h1 className="text-2xl">Nous ne pouvons trouver cette page Web</h1>
-        <h2>Erreur 404</h2>
-        <p>
-          Nous sommes désolés que vous ayez abouti ici. Il arrive parfois
-          qu&#39;une page ait été déplacée ou supprimée. Heureusement, nous
-          pouvons vous aider à trouver ce que vous cherchez. Que faire?
-        </p>
-        <ul>
-          <li>
-            Retournez à la{' '}
-            <Link href="/" locale="default">
-              <a className="text-cyan-600 underline">page d&#39;accueil</a>
-            </Link>
-            ;
-          </li>
-          <li>
-            <a
-              href="https://www.canada.ca/fr/contact.html"
-              className="text-cyan-600 underline"
-            >
-              Communiquez avec nous
-            </a>
-            &nbsp;pour obtenir de l&#39;aide.
-          </li>
-        </ul>
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 lg:gap-8">
+        <div lang="en">
+          <h1 className="text-2xl">We couldn&#39;t find that Web page</h1>
+          <h2>Error 404</h2>
+          <p>
+            We&#39;re sorry you ended up here. Sometimes a page gets moved or
+            deleted, but hopefully we can help you find what you&#39;re looking
+            for. What next?
+          </p>
+          <ul className="list-disc list-inside mb-3">
+            <li>
+              Return to the{' '}
+              <Link href="/" locale="default">
+                <a className="text-cyan-600 underline">home page</a>
+              </Link>
+              ;
+            </li>
+            <li>
+              <a
+                href="https://www.canada.ca/en/contact.html"
+                className="text-cyan-600 underline"
+              >
+                Contact us
+              </a>{' '}
+              and we&#39;ll help you out.
+            </li>
+          </ul>
+        </div>
+        <div lang="fr">
+          <h1 className="text-2xl">Nous ne pouvons trouver cette page Web</h1>
+          <h2>Erreur 404</h2>
+          <p>
+            Nous sommes désolés que vous ayez abouti ici. Il arrive parfois
+            qu&#39;une page ait été déplacée ou supprimée. Heureusement, nous
+            pouvons vous aider à trouver ce que vous cherchez. Que faire?
+          </p>
+          <ul className="list-disc list-inside mb-3">
+            <li>
+              Retournez à la{' '}
+              <Link href="/" locale="default">
+                <a className="text-cyan-600 underline">page d&#39;accueil</a>
+              </Link>
+              ;
+            </li>
+            <li>
+              <a
+                href="https://www.canada.ca/fr/contact.html"
+                className="text-cyan-600 underline"
+              >
+                Communiquez avec nous
+              </a>{' '}
+              pour obtenir de l&#39;aide.
+            </li>
+          </ul>
+        </div>
       </div>
     </ErrorLayout>
   )

--- a/pages/_error.tsx
+++ b/pages/_error.tsx
@@ -21,67 +21,76 @@ const Error: NextPage<ErrorProps> = ({ statusCode }) => {
               : 'Service Unavailable | Service indisponible - Canada.ca',
         }}
       />
-      <div>
-        <h1 className="text-2xl">We couldn&#39;t find that Web page</h1>
-        <h2>
-          {statusCode
-            ? `An error ${statusCode} occurred on server`
-            : 'An error occurred on client'}
-        </h2>
-        <p>
-          We&#39;re sorry you ended up here. Sometimes a page gets moved or
-          deleted, but hopefully we can help you find what you&#39;re looking
-          for. What next?
-        </p>
-        <ul>
-          <li>
-            Return to the{' '}
-            <Link href="/">
-              <a className="text-cyan-600 underline">home page</a>
-            </Link>
-            ;
-          </li>
-          <li>
-            <a
-              href="https://www.canada.ca/en/contact.html"
-              className="text-cyan-600 underline"
-            >
-              Contact us
-            </a>
-            &nbsp;and we&#39;ll help you out
-          </li>
-        </ul>
-      </div>
-      <div>
-        <h1 className="text-2xl">Nous ne pouvons trouver cette page Web</h1>
-        <h2>
-          {statusCode
-            ? `Erreur ${statusCode}`
-            : 'Erreur produite sur le client'}
-        </h2>
-        <p>
-          Nous sommes désolés que vous ayez abouti ici. Il arrive parfois
-          qu&#39;une page ait été déplacée ou supprimée. Heureusement, nous
-          pouvons vous aider à trouver ce que vous cherchez. Que faire?
-        </p>
-        <ul>
-          <li>
-            Retournez à la{' '}
-            <Link href="/">
-              <a className="text-cyan-600 underline">page d&#39;accueil</a>
-            </Link>
-            ;
-          </li>
-          <li>
-            <a
-              href="https://www.canada.ca/fr/contact.html"
-              className="text-cyan-600 underline"
-            >
-              Communiquez avec nous
-            </a>
-            &nbsp;pour obtenir de l&#39;aide.
-          </li>
-        </ul>
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 lg:gap-8">
+        <div lang="en">
+          <h1 className="text-2xl">
+            We&#39;re having a problem with that page
+          </h1>
+          <h2>
+            {statusCode ? `Error ${statusCode}` : 'An error occurred on client'}
+          </h2>
+          <p>
+            We expect the problem to be fixed shortly. It&#39;s not your
+            computer or Internet connection but a problem with our website&#39;s
+            server. What next?
+          </p>
+          <ul className="list-disc list-inside mb-3">
+            <li>Try refreshing the page or try again later;</li>
+            <li>
+              Return to the{' '}
+              <Link href="/">
+                <a className="text-cyan-600 underline">home page</a>
+              </Link>
+              ;
+            </li>
+            <li>
+              <a
+                href="https://www.canada.ca/en/contact.html"
+                className="text-cyan-600 underline"
+              >
+                Contact us
+              </a>
+              &nbsp;and we&#39;ll help you out
+            </li>
+          </ul>
+          <p>Thank you for your patience.</p>
+        </div>
+        <div lang="fr">
+          <h1 className="text-2xl">
+            Nous éprouvons des difficultés avec cette page
+          </h1>
+          <h2>
+            {statusCode
+              ? `Erreur ${statusCode}`
+              : 'Erreur produite sur le client'}
+          </h2>
+          <p>
+            Nous espérons résoudre le problème sous peu. Il ne s&#39;agit pas
+            d&#39;un problème avec votre ordinateur ou Internet, mais plutôt
+            avec le serveur de notre site Web. Que faire?
+          </p>
+          <ul className="list-disc list-inside mb-3">
+            <li>Actualisez la page ou réessayez plus tard;</li>
+            <li>
+              Retournez à la{' '}
+              <Link href="/">
+                <a className="text-cyan-600 underline">page d&#39;accueil</a>
+              </Link>
+              ;
+            </li>
+            <li>
+              <a
+                href="https://www.canada.ca/fr/contact.html"
+                className="text-cyan-600 underline"
+              >
+                Communiquez avec nous
+              </a>{' '}
+              pour obtenir de l&#39;aide.
+            </li>
+          </ul>
+          <p>Merci de votre patience.</p>
+        </div>
       </div>
     </ErrorLayout>
   )


### PR DESCRIPTION
## [ADO-XXX](https://dev.azure.com/DTS-STN/passport-status/_workitems/edit/xxx)

### Description

List of proposed changes:

- Tweak CSS to match existing `Laout` component's header and footer
- Change `_error` content for other errors other than 404 because it's handled by `404.tsx` custom page.
- Add `lang="en"` and `lang="fr"` to `div`s because the page is bilingual and it's needed for a11y.

### What to test for/How to test

For `404` load the application and type a non existing page url.

For `_error` add `PASSPORT_STATUS_API_BASE_URI=ht://example.com` env. variable in `.env.local` file. Build and start the application and try to check the status. The API should return `500` http status code. After N attempts the error will be thrown and the `_error` page will render.

### Additional Notes

404 page
![image](https://user-images.githubusercontent.com/114004123/200611526-8de6cfe0-608d-46fe-872a-f92a81f03fb5.png)

_error page
![image](https://user-images.githubusercontent.com/114004123/200612219-96f13a3a-90ac-431f-9797-7e588c0973ea.png)

