### PR TITLE
Update esrf validation and disallow spaces

### DIFF
--- a/pages/status.tsx
+++ b/pages/status.tsx
@@ -42,7 +42,7 @@ const Status: FC = () => {
         .max(new Date(), 'date-of-birth.error.current'),
       esrf: Yup.string()
         .required('esrf.error.required')
-        .length(8, 'esrf.error.length')
+        .max(8, 'esrf.error.length')
         .trim()
         .matches(/^[A-Za-z]/, 'esrf.error.starts-with-letter'),
       givenName: Yup.string().required('given-name.error.required'),
@@ -199,7 +199,12 @@ const Status: FC = () => {
               id="esrf"
               name="esrf"
               label={t('esrf.label')}
-              onChange={formik.handleChange}
+              onChange={(event) =>
+                formik.setFieldValue(
+                  event.target.name,
+                  event.target.value.replace(/[^a-z0-9]/gi, '')
+                )
+              }
               value={formik.values.esrf}
               errorMessage={formik.errors.esrf && t(formik.errors.esrf)}
               textRequired={t('common:required')}

--- a/public/locales/en/status.json
+++ b/public/locales/en/status.json
@@ -12,7 +12,7 @@
   "description": "Use this service with your file number (ESRF) to check the status of your passport application.",
   "esrf": {
     "error": {
-      "length": "The file number must be 8 characters long.",
+      "length": "The file number can be a maximum of 8 characters long.",
       "required": "The file number is required.",
       "starts-with-letter": "The file number must begin with a letter (e.g. A1234567)."
     },

--- a/public/locales/fr/status.json
+++ b/public/locales/fr/status.json
@@ -12,7 +12,7 @@
   "description": "Utilisez ce service avec votre numéro de dossier (FEDS) pour vérifier le statut de votre demande de passeport.",
   "esrf": {
     "error": {
-      "length": "Le numéro de dossier doit comporter 8 caractères.",
+      "length": "Le numéro de dossier peut comporter un maximum de 8 caractères.",
       "required": "Le numéro de dossier est obligatoire.",
       "starts-with-letter": "Le numéro de dossier doit commencer par une lettre (p. ex. A1234567)."
     },


### PR DESCRIPTION
## [ADO-1282](https://dev.azure.com/DTS-STN/passport-status/_workitems/edit/1282)

### Description
This PR updates the validation schema for the ESRF field to be a max of 8 characters, instead of a required length of 8 characters. I've also updated the `onChange` for the ESRF input to not allow spaces.

### What to test for/How to test
1. Pull in branch
2. Type `npm run dev`
3. Navigate to `/status`
4. Confirm that you are not able to add spaces to the field and that any entry starting with a letter and having a length that does not exceed 8 characters is considered valid.

