### PR TITLE
Changes to cypress tests

### DIFF
--- a/cypress/e2e/app.cy.js
+++ b/cypress/e2e/app.cy.js
@@ -3,14 +3,25 @@
 describe('app page loads', () => {
   beforeEach(() => {
     cy.visit('/')
-    cy.injectAxe();
   })
 
   it('displays the index page', () => {
-    cy.url().should("contains", "/");
+    cy.location('pathname').should('equal', "/")
   })
 
-  it('App has no detectable a11y violations on load', () => {
+  it('redirects to / when accessing /en', () => {
+    cy.visit('/en')
+    cy.location('pathname').should('equal', "/")
+  })
+
+  it('redirects to / when accessing /fr', () => {
+    cy.visit('/fr')
+    cy.location('pathname').should('equal', "/")
+  })
+
+  it('has no detectable a11y violations on load', () => {
+    cy.injectAxe();
+    cy.wait(500);
     cy.checkA11y()
   })
 })

--- a/cypress/e2e/contact.cy.js
+++ b/cypress/e2e/contact.cy.js
@@ -3,32 +3,30 @@ describe('contact page loads', () => {
       cy.visit('/expectations')
       cy.get('#confirmBtn button').first().click()
       cy.visit('/contact')
-      cy.injectAxe();
-    })
-  
-    it('displays the contact page', () => {
-      cy.url().should("contains", "/contact");
     })
 
-  
-    it('displays the language link to change to French', () => {
-      cy.url().should("contains", "/contact");
-      cy.get('[data-cy=toggle-language-link]').should('contain.text', 'Français');
-  
+    it('displays the contact page', () => {
+      cy.location('pathname').should("equal", "/en/contact");
     })
-  
+
+    it('displays the language link to change to French', () => {
+      cy.location('pathname').should("equal", "/en/contact");
+      cy.get('[data-cy=toggle-language-link]').should('contain.text', 'Français');
+    })
+
     it('displays the language link to change to English', () => {
       cy.get('[data-cy=toggle-language-link]').click()
-      cy.url().should("contains", "/fr/contact");
+      cy.location('pathname').should("equal", "/fr/contact");
       cy.get('[data-cy=toggle-language-link]').should('contain.text', 'English');
-  
     })
 
     it('has a list containing anchor tags',()=>{
         cy.get(`#contact-links > section > ul li:first > a`)
     })
-  
-    it('App has no detectable a11y violations on load', () => {
+
+    it('has no detectable a11y violations on load', () => {
+      cy.injectAxe();
+      cy.wait(500);
       cy.checkA11y()
     })
 })

--- a/cypress/e2e/email.cy.js
+++ b/cypress/e2e/email.cy.js
@@ -6,26 +6,25 @@ describe('email page loads', () => {
       cy.get('#confirmBtn button').first().click()
       cy.visit('/email')
     })
-  
+
     it('displays the status page', () => {
-      cy.url().should("contains", "/email");
+      cy.location('pathname').should("equal", "/en/email");
     })
-  
+
     it('displays the language link to change to French', () => {
-      cy.url().should("contains", "/email");
+      cy.location('pathname').should("equal", "/en/email");
       cy.get('[data-cy=toggle-language-link]').should('contain.text', 'Français');
-  
     })
-  
+
     it('displays the language link to change to English', () => {
       cy.get('[data-cy=toggle-language-link]').click()
-      cy.url().should("contains", "/fr/email");
+      cy.location('pathname').should("equal", "/fr/email");
       cy.get('[data-cy=toggle-language-link]').should('contain.text', 'English');
-  
     })
-  
-    it('Status page has no detectable a11y violations on load', () => {
+
+    it('has no detectable a11y violations on load', () => {
       cy.injectAxe();
+      cy.wait(500);
       cy.checkA11y()
     })
 })

--- a/cypress/e2e/landing.cy.js
+++ b/cypress/e2e/landing.cy.js
@@ -3,11 +3,10 @@ describe('landing page loads', () => {
       cy.visit('/expectations')
       cy.get('#confirmBtn button').first().click()
       cy.visit('/landing')
-      cy.injectAxe();
     })
-  
+
     it('displays the landing page', () => {
-      cy.url().should("contains", "/landing");
+      cy.location('pathname').should("equal", "/en/landing");
     })
 
     it('should display the button for no ESRF',()=>{
@@ -17,8 +16,10 @@ describe('landing page loads', () => {
     it('should display the button for has ESRF',()=>{
         cy.get(`#with-esrf`).should('be.visible')
     })
-  
-    it('App has no detectable a11y violations on load', () => {
+
+    it('has no detectable a11y violations on load', () => {
+      cy.injectAxe();
+      cy.wait(500);
       cy.checkA11y()
     })
 })
@@ -27,9 +28,9 @@ describe('user does not ESRF number',()=>{
     it('should redirect to the email page',()=>{
       cy.visit('/expectations')
       cy.get('#confirmBtn button').first().click()
-        cy.visit('/landing')
-        cy.get('#without-esrf').click()
-        cy.url().should('contain','/email')
+      cy.visit('/landing')
+      cy.get('#without-esrf').click()
+      cy.location('pathname').should("equal", "/en/email");
     })
 })
 
@@ -37,8 +38,8 @@ describe('user does have ESRF number',()=>{
   it('should redirect to the form',()=>{
     cy.visit('/expectations')
     cy.get('#confirmBtn button').first().click()
-      cy.visit('/landing')
-      cy.get('#with-esrf').click()
-      cy.url().should('contain','/status')
+    cy.visit('/landing')
+    cy.get('#with-esrf').click()
+    cy.location('pathname').should("equal", "/en/status");
   })
 })

--- a/cypress/e2e/status.cy.js
+++ b/cypress/e2e/status.cy.js
@@ -8,24 +8,23 @@ describe('status page loads', () => {
   })
 
   it('displays the status page', () => {
-    cy.url().should("contains", "/status");
+    cy.location('pathname').should("equal", "/en/status");
   })
 
   it('displays the language link to change to French', () => {
-    cy.url().should("contains", "/status");
+    cy.location('pathname').should("equal", "/en/status");
     cy.get('[data-cy=toggle-language-link]').should('contain.text', 'Français');
-
   })
 
   it('displays the language link to change to English', () => {
     cy.get('[data-cy=toggle-language-link]').click()
-    cy.url().should("contains", "/fr/status");
+    cy.location('pathname').should("equal", "/fr/status");
     cy.get('[data-cy=toggle-language-link]').should('contain.text', 'English');
-
   })
 
-  it('Status page has no detectable a11y violations on load', () => {
+  it('has no detectable a11y violations on load', () => {
     cy.injectAxe();
+    cy.wait(500);
     cy.checkA11y()
   })
 })
@@ -93,7 +92,6 @@ describe('surname field validation', ()=>{
   })
 })
 
-
 describe('Date of Birth field validation', ()=>{
   beforeEach(() => {
     cy.visit('/expectations')
@@ -136,6 +134,7 @@ describe('responses', ()=>{
 
   it('loads result is acessable', ()=>{
     cy.injectAxe();
+    cy.wait(500);
     cy.checkA11y()
   })
 
@@ -153,6 +152,7 @@ describe('responses', ()=>{
 
   it('no result is acessable', ()=>{
     cy.injectAxe();
+    cy.wait(500);
     cy.checkA11y()
   })
 })


### PR DESCRIPTION
## [ADO-XXX](https://dev.azure.com/DTS-STN/passport-status/_workitems/edit/xxx)

### Description

List of proposed changes:

- Add `cy.wait(500)` to fix `cy.checkA11y()` tests to randomly failling
- Switch `cy.url()` to `cy.location('pathname')` to strict pathname assertions

### What to test for/How to test

Load this branch and run cypress test with the following command: `npm run test:e2e`

### Additional Notes

Issue `#64` in `cypress-axe` github.
https://github.com/component-driven/cypress-axe/issues/
