### PR TITLE
Added 4 digit max input for date field. Only works on chromium

### DIFF
--- a/components/InputField.tsx
+++ b/components/InputField.tsx
@@ -12,6 +12,7 @@ export interface InputFieldProps {
   errorMessage?: string
   type?: React.HTMLInputTypeAttribute
   value?: string | number | readonly string[]
+  max?: string
   onChange?: React.ChangeEventHandler<HTMLInputElement>
 }
 
@@ -25,6 +26,7 @@ const InputField: FC<InputFieldProps> = ({
   textRequired,
   type,
   value,
+  max,
   helpMessage,
 }) => {
   return (
@@ -44,6 +46,7 @@ const InputField: FC<InputFieldProps> = ({
         name={name}
         type={type}
         value={value ?? ''}
+        max={max}
         onChange={onChange}
         aria-required={required}
         aria-describedby={helpMessage && `input-${id}-help`}

--- a/pages/email.tsx
+++ b/pages/email.tsx
@@ -135,6 +135,7 @@ export default function Email() {
             errorMessage={
               formik.errors.dateOfBirth && t(formik.errors.dateOfBirth)
             }
+            max={'9999-12-31'}
             textRequired={t('common:required')}
             required
             helpMessage={t('help-message.date-of-birth')}

--- a/pages/status.tsx
+++ b/pages/status.tsx
@@ -254,6 +254,7 @@ const Status: FC = () => {
                 formik.errors.dateOfBirth && t(formik.errors.dateOfBirth)
               }
               textRequired={t('common:required')}
+              max={'9999-12-31'}
               required
               helpMessage={t('help-message.date-of-birth')}
             />


### PR DESCRIPTION
## [ADO-XXX](https://dev.azure.com/DTS-STN/passport-status/_workitems/edit/xxx)

### Description

added 4 digit limit on date field. Only works on chromium browsers.
List of proposed changes:

added the 4 digit limit on date field

### What to test for/How to test

go to /email and /status

try entering more than 4 digits in year
### Additional Notes
