### PR TITLE
Add idle timeout to form pages

### DIFF
--- a/components/Modal.tsx
+++ b/components/Modal.tsx
@@ -28,8 +28,8 @@ const Modal: FC<ModalProps> = ({
             style={{ background: 'rgba(71, 71, 71, 0.8)' }}
           >
             <div className="p-4 bg-white border-2 border-black">
-              <p className="font-body">{description}</p>
-              <div className="flex space-x-2 mx-4">
+              <p className="font-body p-2">{description}</p>
+              <div className="flex space-x-2 mx-4 justify-center">
                 {buttons.map((buttonProps) => (
                   <ActionButton key={buttonProps.text} {...buttonProps} />
                 ))}

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "react": "18.2.0",
         "react-dom": "18.2.0",
         "react-focus-on": "^3.7.0",
+        "react-idle-timer": "^5.4.2",
         "yup": "^0.32.11"
       },
       "devDependencies": {
@@ -14134,6 +14135,15 @@
         }
       }
     },
+    "node_modules/react-idle-timer": {
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/react-idle-timer/-/react-idle-timer-5.4.2.tgz",
+      "integrity": "sha512-ofCS/qpFjm6ZguEyePvtf9YMDnLj7zZfeLXRWGRpsC6Ga47H4dm7EvoUW8MsozGEGy8zCvPK0Sk6YuAnwLEzRQ==",
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
+      }
+    },
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -26487,6 +26497,12 @@
         "@babel/runtime": "^7.14.5",
         "html-parse-stringify": "^3.0.1"
       }
+    },
+    "react-idle-timer": {
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/react-idle-timer/-/react-idle-timer-5.4.2.tgz",
+      "integrity": "sha512-ofCS/qpFjm6ZguEyePvtf9YMDnLj7zZfeLXRWGRpsC6Ga47H4dm7EvoUW8MsozGEGy8zCvPK0Sk6YuAnwLEzRQ==",
+      "requires": {}
     },
     "react-is": {
       "version": "17.0.2",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-focus-on": "^3.7.0",
+    "react-idle-timer": "^5.4.2",
     "yup": "^0.32.11"
   },
   "devDependencies": {

--- a/pages/email.tsx
+++ b/pages/email.tsx
@@ -16,6 +16,8 @@ import Modal from '../components/Modal'
 import LinkSummary, { LinkSummaryItem } from '../components/LinkSummary'
 import useEmailEsrf from '../lib/useEmailEsrf'
 import { EmailEsrfApiRequestBody } from '../lib/types'
+import { useIdleTimer } from 'react-idle-timer'
+import { setCookie } from 'cookies-next'
 
 const initialValues: EmailEsrfApiRequestBody = {
   dateOfBirth: '',
@@ -27,6 +29,35 @@ const initialValues: EmailEsrfApiRequestBody = {
 export default function Email() {
   const { t } = useTranslation('email')
   const [modalOpen, setModalOpen] = useState(false)
+  const [isIdle, setIsIdle] = useState(false)
+  const onIdle = () => {
+    setIsIdle(true)
+    setModalOpen(true)
+  }
+
+  const modalRedirectHandler = () => {
+    //If user is idle and selects option to go back, clear the cookie so they get redirected to /expectations instead
+    if (isIdle) {
+      setCookie('agreed-to-email-esrf-terms', 'false', {
+        sameSite: true,
+      })
+    }
+    Router.push('/landing')
+  }
+
+  const modalResetHandler = () => {
+    setModalOpen(!modalOpen)
+    if (isIdle) {
+      setIsIdle(false)
+      reset()
+    }
+  }
+
+  const { reset } = useIdleTimer({
+    onIdle,
+    //15 minute timeout
+    timeout: 150 * 6 * 1000,
+  })
 
   const {
     isLoading: isEmailEsrfLoading,
@@ -151,20 +182,24 @@ export default function Email() {
             </div>
             <div className="py-1">
               <Modal
-                buttonText={t('common:cancel-modal.cancel-button')}
-                description={t('common:cancel-modal.description')}
+                buttonText={t('common:modal.cancel-button')}
+                description={
+                  isIdle
+                    ? t('common:modal.idle')
+                    : t('common:modal.description')
+                }
                 isOpen={modalOpen}
                 onClick={() => setModalOpen(!modalOpen)}
                 buttons={[
                   {
-                    text: t('common:cancel-modal.yes-button'),
-                    onClick: () => Router.push('/landing'),
+                    text: t('common:modal.yes-button'),
+                    onClick: modalRedirectHandler,
                     style: 'primary',
                     type: 'button',
                   },
                   {
-                    text: t('common:cancel-modal.no-button'),
-                    onClick: () => setModalOpen(!modalOpen),
+                    text: t('common:modal.no-button'),
+                    onClick: modalResetHandler,
                     style: 'default',
                     type: 'button',
                   },

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -57,10 +57,11 @@
       "external": true
     }
   ],
-  "cancel-modal": {
+  "modal": {
     "cancel-button": "Cancel",
     "yes-button": "Yes",
     "no-button": "No",
-    "description": "Are you sure you want to go back?"
+    "description": "Are you sure you want to go back?",
+    "idle": "You have been inactive for 15 minutes. Would you like to start over?"
   }
 }

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -57,10 +57,11 @@
       "external": true
     }
   ],
-  "cancel-modal": {
+  "modal": {
     "cancel-button": "Annuler",
     "yes-button": "Oui",
     "no-button": "Non",
-    "description": "Êtes-vous sûr de vouloir revenir en arrière?"
+    "description": "Êtes-vous sûr de vouloir revenir en arrière?",
+    "idle": "Vous avez été inactif pendant 15 minutes. Souhaitez-vous recommencer?"
   }
 }


### PR DESCRIPTION
## [ADO-1417](https://dev.azure.com/DTS-STN/passport-status/_workitems/edit/1417) [ADO-1418](https://dev.azure.com/DTS-STN/passport-status/_workitems/edit/1418)

### Description
This PR leverages the [React Idle Timer](https://idletimer.dev/) library to prompt a user after 15 minutes of idle time (based on mouse & keyboard events) if they would like to be redirected or not. I modified the handlers for the modal on both `/email` and `/status` so that the modal can either open when the user selects the cancel button or when the timeout limit of 15 minutes is reached. If the modal opens as a result of a timeout and the user selects `yes`, the `agreed-to-email-esrf-terms` cookie is reset so that they are shown the `/expectations` page again (in the case of the site being accessed on a public computer), else the user is redirected to `/landing` like normal.

### What to test for/How to test
1. Pull in branch
2. Type `npm run dev`
3. Agree to terms and then navigate to `/status`
4. Set the value of `timeout` to `3000` on line 67
5. If you don't move your mouse for 3 seconds, the modal should pop up indicating that you've been inactive for 15 minutes.
6. Selecting `No` will close the modal (and since the timeout is set to 3000ms in this case, it will pop up again after 3 seconds of inactivity). Selecting yes will remove the `agreed-to-email-esrf-terms` cookie and redirect you to `/expectations`.
7. Confirm the modal stills works as expected when clicking the `Cancel` button normally.
8. Repeat steps for `/email` page