### PR TITLE
Remove trigger button from Modal

### DIFF
--- a/__tests__/components/Modal.test.tsx
+++ b/__tests__/components/Modal.test.tsx
@@ -7,17 +7,18 @@ expect.extend(toHaveNoViolations)
 
 describe('Modal', () => {
   const { container } = render(
-    <Modal
-      buttonText="Some text"
-      description="Some description"
-      isOpen={false}
-      onClick={() => jest.fn()}
-      buttons={[{ text: 'some text' }]}
-    />
+    <Modal open actionButtons={[{ text: 'button text' }]}>
+      <p>content</p>
+    </Modal>
   )
+
   it('renders', () => {
-    const sut = screen.getByText('Some text')
+    const sut = screen.getByRole('dialog')
+    const content = screen.getByText('content')
+    const actionButton = screen.getByText('button text')
     expect(sut).toBeInTheDocument()
+    expect(content).toBeInTheDocument()
+    expect(actionButton).toBeInTheDocument()
   })
 
   it('is meets a11y', async () => {

--- a/components/ActionButton.tsx
+++ b/components/ActionButton.tsx
@@ -2,6 +2,7 @@ import { FC, MouseEventHandler } from 'react'
 
 export interface ActionButtonProps {
   disabled?: boolean
+  id?: string
   onClick?: MouseEventHandler<HTMLButtonElement>
   style?: 'default' | 'primary' | 'super' | 'danger'
   text: string
@@ -10,26 +11,28 @@ export interface ActionButtonProps {
 
 const ActionButton: FC<ActionButtonProps> = ({
   disabled,
+  id,
   onClick,
   style,
   text,
   type,
 }) => {
   let classStyle =
-    'inline-block text-center align-middle rounded border py-2 px-10 focus:ring-1 focus:ring-offset-2 focus:ring-black focus:text-basic-white '
+    'inline-block text-center align-middle rounded border py-2 px-10 focus:ring-1 focus:ring-offset-2 focus:ring-black focus:text-basic-white shadow-sm disabled:opacity-70 disabled:cursor-not-allowed disabled:shadow-none disabled:pointer-events-none '
   switch (style) {
     case 'primary':
       classStyle +=
-        'border-blue-dark bg-blue-dark text-basic-white focus:bg-blue-normal hover:bg-blue-normal active:bg-blue-active shadow-sm'
+        'border-blue-dark bg-blue-dark text-basic-white focus:bg-blue-normal hover:bg-blue-normal active:bg-blue-active'
       break
     default:
       classStyle +=
-        'border-gray-dark bg-gray-normal text-blue-light hover:bg-gray-dark hover:border-l-gray-deep hover:border-t-gray-deep focus:text-blue-light focus:bg-gray-dark shadow-sm border-r-gray-500 border-b-gray-500'
+        'border-gray-dark bg-gray-normal text-blue-light hover:bg-gray-dark hover:border-l-gray-deep hover:border-t-gray-deep focus:text-blue-light focus:bg-gray-dark border-r-gray-500 border-b-gray-500'
       break
   }
 
   return (
     <button
+      id={id}
       className={classStyle}
       onClick={onClick}
       type={type}

--- a/components/Modal.tsx
+++ b/components/Modal.tsx
@@ -1,44 +1,41 @@
-import { FC, MouseEventHandler } from 'react'
-import ActionButton from './ActionButton'
-import { ActionButtonProps } from './ActionButton'
+import { FC, ReactNode, useId } from 'react'
+import ActionButton, { ActionButtonProps } from './ActionButton'
 import { FocusOn } from 'react-focus-on'
 
 export interface ModalProps {
-  buttonText: string
-  description: string
-  isOpen: boolean
-  onClick: MouseEventHandler<HTMLButtonElement>
-  buttons: ActionButtonProps[]
+  actionButtons: ActionButtonProps[]
+  children: ReactNode
+  open: boolean
 }
 
-const Modal: FC<ModalProps> = ({
-  buttonText,
-  description,
-  buttons,
-  onClick,
-  isOpen,
-}) => {
+const Modal: FC<ModalProps> = ({ actionButtons, children, open }) => {
+  const id = useId()
+  if (!open) return <></>
   return (
-    <>
-      <ActionButton text={buttonText} onClick={onClick} />
-      {isOpen && (
-        <FocusOn autoFocus={false}>
-          <div
-            className="fixed top-0 left-0 w-screen h-full flex justify-center items-center"
-            style={{ background: 'rgba(71, 71, 71, 0.8)' }}
-          >
-            <div className="p-4 bg-white border-2 border-black">
-              <p className="font-body p-2">{description}</p>
-              <div className="flex space-x-2 mx-4 justify-center">
-                {buttons.map((buttonProps) => (
-                  <ActionButton key={buttonProps.text} {...buttonProps} />
-                ))}
-              </div>
-            </div>
+    <FocusOn autoFocus={false}>
+      <div
+        className="fixed top-0 left-0 w-screen h-full flex justify-center items-center"
+        style={{ background: 'rgba(71, 71, 71, 0.8)' }}
+      >
+        <div
+          role="dialog"
+          aria-describedby={`${id}-modal-desc`}
+          className="mx-6 p-4 bg-white border-2 border-black"
+        >
+          <div id={`${id}-modal-desc`} className="mb-4">
+            {children}
           </div>
-        </FocusOn>
-      )}
-    </>
+          <div className="flex gap-2 justify-center">
+            {actionButtons.map((actionButtonProps) => (
+              <ActionButton
+                key={actionButtonProps.text}
+                {...actionButtonProps}
+              />
+            ))}
+          </div>
+        </div>
+      </div>
+    </FocusOn>
   )
 }
 

--- a/cypress/e2e/email.cy.js
+++ b/cypress/e2e/email.cy.js
@@ -28,3 +28,20 @@ describe('email page loads', () => {
       cy.checkA11y()
     })
 })
+
+describe('cancel email esrf', ()=>{
+  it('loads dialog', ()=>{
+    cy.visit('/expectations')
+    cy.get('#confirmBtn button').first().click()
+    cy.visit('/email')
+    cy.get('#btn-cancel').click()
+    cy.get('[role="dialog"]').should('exist')
+  })
+
+  it.skip('cancel email esrf has no detectable a11y violations', ()=>{
+    cy.injectAxe();
+    cy.wait(500);
+    cy.checkA11y()
+  })
+})
+

--- a/cypress/e2e/status.cy.js
+++ b/cypress/e2e/status.cy.js
@@ -38,18 +38,18 @@ describe('ESRF field validation', ()=>{
 
   it('validates valid ESRF',()=>{
     cy.get('#esrf').type('A5934S87')
-    cy.get('#button-get-status > button').click()
+    cy.get('#btn-submit').click()
     cy.get('#input-esrf > span').should('not.exist')
   })
 
   it('validates empty ESRF error',()=>{
-    cy.get('#button-get-status > button').click()
+    cy.get('#btn-submit').click()
     cy.get('#input-esrf > span').should('exist')
   })
 
   it('validates invalid length for ESRF', ()=>{
     cy.get('#esrf').type('1234')
-    cy.get('#button-get-status > button').click()
+    cy.get('#btn-submit').click()
     cy.get('#input-esrf > span').should('exist')
   })
 })
@@ -63,12 +63,12 @@ describe('givenName field validation', ()=>{
 
   it('validates valid givenName',()=>{
     cy.get('#givenName').type('Clara')
-    cy.get('#button-get-status > button').click()
+    cy.get('#btn-submit').click()
     cy.get('#input-givenName > span').should('not.exist')
   })
 
   it('validates empty givenName error',()=>{
-    cy.get('#button-get-status > button').click()
+    cy.get('#btn-submit').click()
     cy.get('#input-givenName > span').should('exist')
   })
 })
@@ -82,12 +82,12 @@ describe('surname field validation', ()=>{
 
   it('validates valid surname',()=>{
     cy.get('#surname').type('Renard')
-    cy.get('#button-get-status > button').click()
+    cy.get('#btn-submit').click()
     cy.get('#input-surname > span').should('not.exist')
   })
 
   it('validates empty surname error',()=>{
-    cy.get('#button-get-status > button').click()
+    cy.get('#btn-submit').click()
     cy.get('#input-surname > span').should('exist')
   })
 })
@@ -101,12 +101,12 @@ describe('Date of Birth field validation', ()=>{
 
   it('validates valid dateOfBirth',()=>{
     cy.get('#dateOfBirth').type('1982-12-08')
-    cy.get('#button-get-status > button').click()
+    cy.get('#btn-submit').click()
     cy.get('#input-dateOfBirth > span').should('not.exist')
   })
 
   it('validates empty dateOfBirth error',()=>{
-    cy.get('#button-get-status > button').click()
+    cy.get('#btn-submit').click()
     cy.get('#input-dateOfBirth > span').should('exist')
   })
 
@@ -114,7 +114,7 @@ describe('Date of Birth field validation', ()=>{
     const yearPlus1 = new Date(new Date().getFullYear()+1,1,1)
     const testDate = [yearPlus1.getFullYear(),'01','01'].join('-')
     cy.get('#dateOfBirth').type(testDate)
-    cy.get('#button-get-status > button').click()
+    cy.get('#btn-submit').click()
     cy.get('#input-dateOfBirth > span').should('exist')
   })
 })
@@ -128,11 +128,11 @@ describe('responses', ()=>{
     cy.get('#givenName').type('Yanis')
     cy.get('#surname').type('Piérre')
     cy.get('#dateOfBirth').type('1972-07-29')
-    cy.get('#button-get-status > button').click()
+    cy.get('#btn-submit').click()
     cy.get('#response-status').should('exist')
   })
 
-  it('loads result is acessable', ()=>{
+  it('loads result has no detectable a11y violations', ()=>{
     cy.injectAxe();
     cy.wait(500);
     cy.checkA11y()
@@ -146,11 +146,27 @@ describe('responses', ()=>{
     cy.get('#givenName').type('John')
     cy.get('#surname').type('Doe')
     cy.get('#dateOfBirth').type('1990-12-01')
-    cy.get('#button-get-status > button').click()
+    cy.get('#btn-submit').click()
     cy.get('#reponse-no-result').should('exist')
   })
 
-  it('no result is acessable', ()=>{
+  it('no result has no detectable a11y violations', ()=>{
+    cy.injectAxe();
+    cy.wait(500);
+    cy.checkA11y()
+  })
+})
+
+describe('cancel check status', ()=>{
+  it('loads dialog', ()=>{
+    cy.visit('/expectations')
+    cy.get('#confirmBtn button').first().click()
+    cy.visit('/status')
+    cy.get('#btn-cancel').click()
+    cy.get('[role="dialog"]').should('exist')
+  })
+
+  it.skip('cancel check status has no detectable a11y violations', ()=>{
     cy.injectAxe();
     cy.wait(500);
     cy.checkA11y()

--- a/pages/contact.tsx
+++ b/pages/contact.tsx
@@ -1,14 +1,16 @@
 import { FC, useState } from 'react'
 import { GetStaticProps } from 'next'
-import router from 'next/router'
+import { useRouter } from 'next/router'
 import { useTranslation } from 'next-i18next'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import Layout from '../components/Layout'
 import LinkSummary, { LinkSummaryItem } from '../components/LinkSummary'
 import Modal from '../components/Modal'
+import ActionButton from '../components/ActionButton'
 
 const Contact: FC = () => {
   const { t } = useTranslation('contact')
+  const router = useRouter()
   const [modalOpen, setModalOpen] = useState(false)
 
   return (
@@ -26,25 +28,28 @@ const Contact: FC = () => {
           })}
         />
       </div>
-      <div className="py-2">
-        <Modal
-          buttonText={t('back-to-home')}
-          description={t('common:cancel-modal.description')}
-          isOpen={modalOpen}
-          onClick={() => setModalOpen(!modalOpen)}
-          buttons={[
-            {
-              text: t('common:cancel-modal.yes-button'),
-              onClick: () => router.push('/landing'),
-              style: 'primary',
-            },
-            {
-              text: t('common:cancel-modal.no-button'),
-              onClick: () => setModalOpen(!modalOpen),
-            },
-          ]}
+      <div className="my-2">
+        <ActionButton
+          text={t('back-to-home')}
+          onClick={() => setModalOpen(true)}
         />
       </div>
+      <Modal
+        open={modalOpen}
+        actionButtons={[
+          {
+            text: t('common:cancel-modal.yes-button'),
+            onClick: () => router.push('/landing'),
+            style: 'primary',
+          },
+          {
+            text: t('common:cancel-modal.no-button'),
+            onClick: () => setModalOpen(false),
+          },
+        ]}
+      >
+        {t('common:cancel-modal.description')}
+      </Modal>
     </Layout>
   )
 }

--- a/pages/email.tsx
+++ b/pages/email.tsx
@@ -171,44 +171,42 @@ export default function Email() {
             required
             helpMessage={t('help-message.date-of-birth')}
           />
-          <div className="flex flex-wrap">
-            <div className="py-1 pr-2">
-              <ActionButton
-                disabled={isEmailEsrfLoading}
-                type="submit"
-                text={t('email-esrf')}
-                style="primary"
-              />
-            </div>
-            <div className="py-1">
-              <Modal
-                buttonText={t('common:modal.cancel-button')}
-                description={
-                  isIdle
-                    ? t('common:modal.idle')
-                    : t('common:modal.description')
-                }
-                isOpen={modalOpen}
-                onClick={() => setModalOpen(!modalOpen)}
-                buttons={[
-                  {
-                    text: t('common:modal.yes-button'),
-                    onClick: handleOnModalRedirectButtonClick,
-                    style: 'primary',
-                    type: 'button',
-                  },
-                  {
-                    text: t('common:modal.no-button'),
-                    onClick: handleOnModalResetButtonClick,
-                    style: 'default',
-                    type: 'button',
-                  },
-                ]}
-              />
-            </div>
+          <div className="flex gap-2 flex-wrap my-2">
+            <ActionButton
+              id="btn-submit"
+              disabled={isEmailEsrfLoading}
+              type="submit"
+              text={t('email-esrf')}
+              style="primary"
+            />
+            <ActionButton
+              id="btn-cancel"
+              disabled={isEmailEsrfLoading}
+              text={t('common:modal.cancel-button')}
+              onClick={() => setModalOpen(true)}
+            />
           </div>
         </form>
       )}
+      <Modal
+        open={modalOpen}
+        actionButtons={[
+          {
+            text: t('common:modal.yes-button'),
+            onClick: handleOnModalRedirectButtonClick,
+            style: 'primary',
+            type: 'button',
+          },
+          {
+            text: t('common:modal.no-button'),
+            onClick: handleOnModalResetButtonClick,
+            style: 'default',
+            type: 'button',
+          },
+        ]}
+      >
+        {isIdle ? t('common:modal.idle') : t('common:modal.description')}
+      </Modal>
     </Layout>
   )
 }

--- a/pages/status.tsx
+++ b/pages/status.tsx
@@ -289,45 +289,43 @@ const Status: FC = () => {
               required
               helpMessage={t('help-message.date-of-birth')}
             />
-            <div className="flex flex-wrap">
-              <div id="button-get-status" className="py-1 pr-2">
-                <ActionButton
-                  disabled={isCheckStatusLoading}
-                  type="submit"
-                  text={t('check-status')}
-                  style="primary"
-                />
-              </div>
-              <div className="py-1">
-                <Modal
-                  buttonText={t('common:modal.cancel-button')}
-                  description={
-                    isIdle
-                      ? t('common:modal.idle')
-                      : t('common:modal.description')
-                  }
-                  isOpen={modalOpen}
-                  onClick={() => setModalOpen(!modalOpen)}
-                  buttons={[
-                    {
-                      text: t('common:modal.yes-button'),
-                      onClick: handleOnModalRedirectButtonClick,
-                      style: 'primary',
-                      type: 'button',
-                    },
-                    {
-                      text: t('common:modal.no-button'),
-                      onClick: handleOnModalResetButtonClick,
-                      style: 'default',
-                      type: 'button',
-                    },
-                  ]}
-                />
-              </div>
+            <div className="flex gap-2 flex-wrap">
+              <ActionButton
+                id="btn-submit"
+                disabled={isCheckStatusLoading}
+                type="submit"
+                text={t('check-status')}
+                style="primary"
+              />
+              <ActionButton
+                id="btn-cancel"
+                disabled={isCheckStatusLoading}
+                text={t('common:modal.cancel-button')}
+                onClick={() => setModalOpen(true)}
+              />
             </div>
           </form>
         )
       })()}
+      <Modal
+        open={modalOpen}
+        actionButtons={[
+          {
+            text: t('common:modal.yes-button'),
+            onClick: handleOnModalRedirectButtonClick,
+            style: 'primary',
+            type: 'button',
+          },
+          {
+            text: t('common:modal.no-button'),
+            onClick: handleOnModalResetButtonClick,
+            style: 'default',
+            type: 'button',
+          },
+        ]}
+      >
+        {isIdle ? t('common:modal.idle') : t('common:modal.description')}
+      </Modal>
     </Layout>
   )
 }


### PR DESCRIPTION
## [ADO-XXX](https://dev.azure.com/DTS-STN/passport-status/_workitems/edit/xxx)

### Description

List of proposed changes:

- Remove trigger button from Modal component
- Add button disabled styling

### What to test for/How to test

Pages status, email and contact should work as attented.

### Additional Notes

The main motivation behind this it's because the trigger button should be inside the Modal because a modal can be triggered by other events like in our case the user idle event.

I've added a cypress tests when clicking cancel button but at the moment the a11y test is skipped because the modal doesn't pass a11y.
![image](https://user-images.githubusercontent.com/114004123/204296473-1e2ff24c-16ea-4097-9da2-466792c5cda6.png)
