### PR TITLE
Update content on expectation, landing and email pages

### DIFF
--- a/components/LinkButton.tsx
+++ b/components/LinkButton.tsx
@@ -7,6 +7,7 @@ export interface LinkButtonProps {
   id?: string
   lang?: string
   external?: boolean
+  style?: 'default' | 'primary' | 'super' | 'danger'
 }
 
 const LinkButton: FC<LinkButtonProps> = ({
@@ -15,7 +16,20 @@ const LinkButton: FC<LinkButtonProps> = ({
   id,
   lang,
   external,
+  style,
 }) => {
+  let classStyle =
+    'inline-block text-center align-middle rounded border py-2 px-10 focus:ring-1 focus:ring-offset-2 focus:ring-black focus:text-basic-white '
+  switch (style) {
+    case 'primary':
+      classStyle +=
+        'border-blue-dark bg-blue-dark text-basic-white focus:bg-blue-normal hover:bg-blue-normal active:bg-blue-active shadow-sm'
+      break
+    default:
+      classStyle +=
+        'border-gray-dark bg-gray-normal text-blue-light hover:bg-gray-dark hover:border-l-gray-deep hover:border-t-gray-deep focus:text-blue-light focus:bg-gray-dark shadow-sm border-r-gray-500 border-b-gray-500'
+      break
+  }
   return (
     <Link href={href} passHref>
       <a
@@ -23,7 +37,7 @@ const LinkButton: FC<LinkButtonProps> = ({
         rel={external ? 'noopener noreferrer' : undefined}
         id={id}
         lang={lang}
-        className="font-display border-blue-dark bg-blue-dark text-basic-white hover:bg-blue-normal inline-block text-center align-middle rounded border py-2 px-10 focus:ring-1 focus:ring-offset-2 focus:ring-black focus:text-basic-white focus:bg-blue-normal active:bg-blue-active"
+        className={classStyle}
       >
         {text}
       </a>

--- a/pages/email.tsx
+++ b/pages/email.tsx
@@ -107,10 +107,7 @@ export default function Email() {
           <p className="mb-4">{t('email-confirmation-msg.if-exists')}</p>
           <p className="mb-4">
             {t('email-confirmation-msg.please-contact')}{' '}
-            <span>
-              <b>{t('email-confirmation-msg.phone-number')}</b>
-            </span>
-            .
+            <b>{t('email-confirmation-msg.phone-number')}</b>.
           </p>
           <LinkSummary
             title={t('common:contact-program')}

--- a/pages/email.tsx
+++ b/pages/email.tsx
@@ -101,9 +101,17 @@ export default function Email() {
 
       {isEmailEsrfSuccess ? (
         <>
-          <p className="mb-3">{t('email-confirmation-msg.request-received')}</p>
-          <p className="mb-3">{t('email-confirmation-msg.please-contact')}</p>
-          <p className="mb-3">{t('email-confirmation-msg.call')}</p>
+          <h2 className="my-4">
+            {t('email-confirmation-msg.request-received')}
+          </h2>
+          <p className="mb-4">{t('email-confirmation-msg.if-exists')}</p>
+          <p className="mb-4">
+            {t('email-confirmation-msg.please-contact')}{' '}
+            <span>
+              <b>{t('email-confirmation-msg.phone-number')}</b>
+            </span>
+            .
+          </p>
           <LinkSummary
             title={t('common:contact-program')}
             links={t<string, LinkSummaryItem[]>('common:program-links', {

--- a/pages/expectations.tsx
+++ b/pages/expectations.tsx
@@ -27,18 +27,46 @@ const Expectations: FC = () => {
     >
       <h2>{t('header-purpose')}</h2>
       <div className="my-5">
-        <p>{t('for-applications.p1')}</p>
-        <p>{t('for-applications.p2')}</p>
-        <p>{t('for-applications.p3')}</p>
+        {t('can-check.description')}
+        <ul className="ml-5 list-inside">
+          <li>
+            <span className="font-bold">&#10003; </span>
+            {t('can-check.list.item-1')}
+          </li>
+          <li>
+            <span className="font-bold">&#10003; </span>
+            {t('can-check.list.item-2')}
+          </li>
+        </ul>
       </div>
-      <div>
-        <p>{t('recommend-10-days')}</p>
+      <div className="my-5">
+        {t('available-after.description')}{' '}
+        <ul className="ml-5 list-inside">
+          <li>
+            <span className="font-bold">&#10003; </span>
+            {t('available-after.list.item-1')}
+          </li>
+          <li>
+            <span className="font-bold">&#10003; </span>
+            {t('available-after.list.item-2')}
+          </li>
+        </ul>
+      </div>
+      <div className="my-5">
+        {t('cannot-check.description')}{' '}
+        <ul className="ml-5 list-inside">
+          <li>
+            <span className="font-bold">&#10007; </span>
+            {t('cannot-check.list.item-1')}
+          </li>
+          <li>
+            <span className="font-bold">&#10007; </span>
+            {t('cannot-check.list.item-2')}
+          </li>
+        </ul>
       </div>
       <div className="my-5 font-bold">
         <p>{t('do-not-travel')}</p>
-      </div>
-      <div className="text-red-600">
-        <p>{t('unsupported-tools')}</p>
       </div>
       <h2 className="my-8">{t('header-privacy')}</h2>
       <p>{t('description-privacy')}</p>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -36,12 +36,14 @@ const Index = () => {
                 text="English"
                 id="english-button"
                 lang="en"
+                style="primary"
               />
               <LinkButton
                 href="/fr/expectations"
                 text="Français"
                 id="french-button"
                 lang="fr"
+                style="primary"
               />
             </div>
           </div>

--- a/pages/landing.tsx
+++ b/pages/landing.tsx
@@ -17,11 +17,15 @@ const Landing: FC = () => {
       <h1 className="mb-4">{t('header')}</h1>
       <h2 className="my-14">{t('description')}</h2>
       <div className="flex justify-center flex-wrap text-xl gap-4">
+        <div id="with-esrf">
+          <LinkButton
+            href="/status"
+            text={t('with-esrf')}
+            style="primary"
+          ></LinkButton>
+        </div>
         <div id="without-esrf">
           <LinkButton href="/email" text={t('without-esrf')}></LinkButton>
-        </div>
-        <div id="with-esrf">
-          <LinkButton href="/status" text={t('with-esrf')}></LinkButton>
         </div>
       </div>
     </Layout>

--- a/pages/landing.tsx
+++ b/pages/landing.tsx
@@ -17,16 +17,18 @@ const Landing: FC = () => {
       <h1 className="mb-4">{t('header')}</h1>
       <h2 className="my-14">{t('description')}</h2>
       <div className="flex justify-center flex-wrap text-xl gap-4">
-        <div id="with-esrf">
-          <LinkButton
-            href="/status"
-            text={t('with-esrf')}
-            style="primary"
-          ></LinkButton>
-        </div>
-        <div id="without-esrf">
-          <LinkButton href="/email" text={t('without-esrf')}></LinkButton>
-        </div>
+        <LinkButton
+          href="/status"
+          text={t('with-esrf')}
+          style="primary"
+          id="with-esrf"
+        ></LinkButton>
+
+        <LinkButton
+          href="/email"
+          text={t('without-esrf')}
+          id="without-esrf"
+        ></LinkButton>
       </div>
     </Layout>
   )

--- a/public/locales/en/email.json
+++ b/public/locales/en/email.json
@@ -1,6 +1,6 @@
 {
-  "header": "Get my file number (ESRF)",
-  "description": "Please enter the following required feilds, as entered on your passport application form, to have your file number (ESRF) emailed to the email address on file.",
+  "header": "Get my file number",
+  "description": "Fill in the fields below to get your file number. Make sure your information matches your passport application form. We'll then email the file number to the email address on file.",
   "email": {
     "label": "Email address",
     "error": {
@@ -31,9 +31,10 @@
   "email-esrf": "Email my file number (ESRF)",
   "email-sent-confirmation": "An email has been sent if there was a match in our records with the file number (ESRF).",
   "email-confirmation-msg": {
-    "request-received": "We have received your request. If you have submitted a passport application and we are able to locate your file, you will receive an email containing your File Number.",
-    "please-contact": "If you do not receive an email containing your File Number within the next 24 hrs, please contact Service Canada:",
-    "call": "Call: Passport Call Centre (insert phone #)."
+    "request-received": "Your request to get the file number has been received",
+    "if-exists": "If we're able to locate the file with the information you gave us, we'll send you an email with the file number.",
+    "please-contact": "You should receive the email within 30 minutes. If you don't receive it, call the passport call centre at ",
+    "phone-number": "1-800-567-6868"
   },
   "page-unauth": {
     "header": "Page Unauthorized",
@@ -41,9 +42,9 @@
     "button": "Privacy and Email terms"
   },
   "help-message": {
-    "email": "Provide your full email address as provided on the passport application form. If this is a request for a child application, please provide the full email address as provided on the passport application form for the applicant parent/guardian.",
-    "given-name": "Please use the given name(s) exactly as provided on your passport application. If this is a request for a child passport application, please use the child’s given name(s) as provided on the passport application. Please note that the given name(s) provided may have been updated to reflect the first given name(s) on your proof of Canadian citizenship or supporting identification.",
-    "surname": "Please use the last name exactly as provided on your passport application. If this is a request for a child passport application, please use the child’s last name as provided on the passport application. Please note that the surname provided may have been updated to reflect the surname on your proof of Canadian citizenship or supporting identification.",
-    "date-of-birth": "Please provide your date of birth as provided on your passport application. If this is a request for a child passport application, please use the child’s date of birth as provided on the passport application. Please note that the date of birth provided may have been updated to reflect the date of birth on your proof of Canadian citizenship."
+    "email": "Provide your full email address as provided on the passport application form. For child applications, provide the full email address for the applicant parent or legal guardian exactly as provided on the passport application.",
+    "given-name": "Please use the given name(s) exactly as provided on your passport application. For child applications, provide the child's given name(s) as provided on the passport application. Please note that the given name(s) provided may have been updated to reflect the first given name(s) on your proof of Canadian citizenship or supporting identification.",
+    "surname": "Please use the last name exactly as provided on your passport application. For child applications, provide the child's last name as provided on the passport application. Please note that the surname provided may have been updated to reflect the surname on your proof of Canadian citizenship or supporting identification.",
+    "date-of-birth": "Please provide your date of birth as provided on your passport application. For child applications, provide the child's date of birth as provided on the passport application. Please note that the date of birth provided may have been updated to reflect the date of birth on your proof of Canadian citizenship."
   }
 }

--- a/public/locales/en/expectations.json
+++ b/public/locales/en/expectations.json
@@ -1,15 +1,28 @@
 {
-  "header-purpose": "Purpose",
+  "header-purpose": "Check the status of your passport application",
   "header-privacy": "Privacy",
-  "description-purpose": "The purpose of this tool is to verify the status of your passport application given some basic information",
+  "can-check": {
+    "description": "You can get the status of your passport application online if you submitted your passport application either:",
+    "list": {
+      "item-1": "in person or by mail within Canada or",
+      "item-2": "by mail from the U.S."
+    }
+  },
+  "available-after": {
+    "description": "We update the status of applications daily. The status of your application is available after:",
+    "list": {
+      "item-1": "5 days if you applied in person or",
+      "item-2": "10 days if you applied by mail"
+    }
+  },
+  "cannot-check": {
+    "description": "You can't look up the status of a passport application online if you:",
+    "list": {
+      "item-1": "applied for a passport outside of Canada and the United States or",
+      "item-2": "applied for a special or diplomatic passport"
+    }
+  },
   "description-privacy": "Have you read and agree to the privacy and terms of service?",
   "button-agree": "I have read and understand",
-  "for-applications": {
-    "p1": "For applications submitted in person or by mail within Canada or mailed to Canada from the US ",
-    "p2": "Recover the ESRF only if a valid email address was included on the application (Post July 2022)",
-    "p3": "Information only updated on a daily basis not real-time."
-  },
-  "recommend-10-days": "Recommend that status checker is only used 10 days after application has been sent. Please refer to (Link to service standards/processing times website) for processing times.",
-  "do-not-travel": "You should not finalize any travel plans until you have the passport. We are not liable for any losses if you do not receive it in time for your travel.",
-  "unsupported-tools": "(not finalized) List of tools that the app does not support: anything overseas (GAC) or IRCC (refugee travel doc, diplomatic passports) or any consulate cases in US or anywhere, but will include applications mailed from US"
+  "do-not-travel": "You should not finalize any travel plans until you have the passport. We are not liable for any losses if you do not receive it in time for your travel."
 }

--- a/public/locales/en/landing.json
+++ b/public/locales/en/landing.json
@@ -1,6 +1,6 @@
 {
-  "header": "Passport Status Check",
-  "description": "In order to better serve you, please select the option below that best suits you",
-  "with-esrf": "I have my file number (ESRF)",
-  "without-esrf": "I don't have my file number (ESRF)"
+  "header": "Passport application status checker",
+  "description": "Do you have your passport application file number?",
+  "with-esrf": "I have my file number",
+  "without-esrf": "I don't have my file number"
 }

--- a/public/locales/en/status.json
+++ b/public/locales/en/status.json
@@ -9,7 +9,7 @@
   },
   "check-again": "To check the status of another application, click the button below:",
   "check-status": "Check Status",
-  "description": "Use this service with your file number (ESRF) to check the status of your passport application.",
+  "description": "Fill in the fields below to check the status of your passport application. Make sure your information matches your passport application form.",
   "esrf": {
     "error": {
       "length": "The file number can have a maximum of 8 alphanumeric characters.",
@@ -80,8 +80,8 @@
   },
   "help-message": {
     "esrf": "When submitting your application in-person, you are provided with a File Number. The File Number begins with at least 1 letter and has a maximum of 8 total characters. (Examples of possible formats: “A1234567” or “AA123456” or “A123456” or “AA12345”)",
-    "given-name": "Please use the given name(s) exactly as provided on your passport application. If this is a request for a child passport application, please use the child’s given name(s) as provided on the passport application. Please note that the given name(s) provided may have been updated to reflect the first given name(s) on your proof of Canadian citizenship or supporting identification.",
-    "surname": "Please use the last name exactly as provided on your passport application. If this is a request for a child passport application, please use the child’s last name as provided on the passport application. Please note that the surname provided may have been updated to reflect the surname on your proof of Canadian citizenship or supporting identification.",
-    "date-of-birth": "Please provide your date of birth as provided on your passport application. If this is a request for a child passport application, please use the child’s date of birth as provided on the passport application. Please note that the date of birth provided may have been updated to reflect the date of birth on your proof of Canadian citizenship."
+    "given-name": "Please use the given name(s) exactly as provided on your passport application. For child applications, provide the child's given name(s) as provided on the passport application. Please note that the given name(s) provided may have been updated to reflect the first given name(s) on your proof of Canadian citizenship or supporting identification.",
+    "surname": "Please use the last name exactly as provided on your passport application. For child applications, provide the child's last name as provided on the passport application. Please note that the surname provided may have been updated to reflect the surname on your proof of Canadian citizenship or supporting identification.",
+    "date-of-birth": "Please provide your date of birth as provided on your passport application. For child applications, provide the child's date of birth as provided on the passport application. Please note that the date of birth provided may have been updated to reflect the date of birth on your proof of Canadian citizenship."
   }
 }

--- a/public/locales/fr/email.json
+++ b/public/locales/fr/email.json
@@ -1,6 +1,6 @@
 {
   "header": "Obtenir mon numéro de dossier",
-  "description": "Remplissez les champs ci-dessous pour obtenir votre numéro de dossier. Assurez-vous que vos informations correspondent à votre formulaire de demande de passeport. Nous enverrons ensuite le numéro de dossier par e-mail à l'adresse e-mail enregistrée.",
+  "description": "Remplissez les champs ci-dessous pour obtenir votre numéro de dossier. Assurez-vous que vos informations correspondent à votre formulaire de demande de passeport. Nous enverrons ensuite le numéro de dossier par courriel à l'adresse courriel enregistrée.",
   "email": {
     "label": "Adresse courriel",
     "error": {
@@ -32,8 +32,8 @@
   "email-sent-confirmation": "Un courriel a été envoyé s'il y avait une correspondance dans nos dossiers avec le numéro de dossier (FEDS).",
   "email-confirmation-msg": {
     "request-received": "Votre demande d'obtention du numéro de dossier a été reçue",
-    "if-exists": "Si nous sommes en mesure de localiser le dossier avec les informations que vous nous avez fournies, nous vous enverrons un e-mail avec le numéro de dossier.",
-    "please-contact": "Vous devriez recevoir l'e-mail dans les 30 minutes. Si vous ne le recevez pas, appelez le centre d'appel des passeports au ",
+    "if-exists": "Si nous sommes en mesure de localiser le dossier avec les informations que vous nous avez fournies, nous vous enverrons un courriel avec le numéro de dossier.",
+    "please-contact": "Vous devriez recevoir un courriel dans les 30 minutes. Si vous ne le recevez pas, appelez le centre d'appel des passeports au ",
     "phone-number": "1-800-567-6868"
   },
   "page-unauth": {
@@ -42,7 +42,7 @@
     "button": "Conditions de confidentialité et de courriel"
   },
   "help-message": {
-    "email": "Fournissez votre adresse courriel complète comme indiqué sur le formulaire de demande de passeport. Pour les demandes d'enfants, fournissez l'adresse e-mail complète du parent ou du tuteur légal du demandeur exactement comme indiqué sur la demande de passeport.",
+    "email": "Fournissez votre adresse courriel complète comme indiqué sur le formulaire de demande de passeport. Pour les demandes d'enfants, fournissez l'adresse courriel complète du parent ou du tuteur légal du demandeur exactement comme indiqué sur la demande de passeport.",
     "given-name": "Veuillez utiliser le(s) prénom(s) exactement comme indiqué sur votre demande de passeport. Pour les demandes d'enfants, indiquez le(s) prénom(s) de l'enfant tel qu'indiqué sur la demande de passeport. Veuillez noter que le(s) prénom(s) fourni(s) peuvent avoir été mis à jour pour refléter le(s) premier(s) prénom(s) sur votre preuve de citoyenneté canadienne ou pièce d'identité à l'appui.",
     "surname": "Veuillez utiliser le nom de famille exactement comme indiqué sur votre demande de passeport. Pour les demandes d'enfant, indiquez le nom de famille de l'enfant tel qu'indiqué sur la demande de passeport. Veuillez noter que le nom de famille fourni peut avoir été mis à jour pour refléter le nom de famille sur votre preuve de citoyenneté canadienne ou pièce d'identité à l'appui.",
     "date-of-birth": "Veuillez indiquer votre date de naissance telle qu'elle figure sur votre demande de passeport. Pour les demandes d'enfant, indiquez la date de naissance de l'enfant comme indiqué sur la demande de passeport. Veuillez noter que la date de naissance fournie peut avoir été mise à jour pour refléter la date de naissance sur votre preuve de citoyenneté canadienne."

--- a/public/locales/fr/email.json
+++ b/public/locales/fr/email.json
@@ -1,6 +1,6 @@
 {
-  "header": "Obtenir mon numéro de dossier (FEDS)",
-  "description": "Veuillez saisir les champs obligatoires suivants, tels qu'ils figurent sur votre formulaire de demande de passeport, pour que votre numéro de dossier (FEDS) soit envoyé par courriel à l'adresse courriel au dossier.",
+  "header": "Obtenir mon numéro de dossier",
+  "description": "Remplissez les champs ci-dessous pour obtenir votre numéro de dossier. Assurez-vous que vos informations correspondent à votre formulaire de demande de passeport. Nous enverrons ensuite le numéro de dossier par e-mail à l'adresse e-mail enregistrée.",
   "email": {
     "label": "Adresse courriel",
     "error": {
@@ -31,9 +31,10 @@
   "email-esrf": "Envoyer mon numéro de dossier (FEDS)",
   "email-sent-confirmation": "Un courriel a été envoyé s'il y avait une correspondance dans nos dossiers avec le numéro de dossier (FEDS).",
   "email-confirmation-msg": {
-    "request-received": "Nous avons reçu votre demande. Si vous avez soumis une demande de passeport et que nous sommes en mesure de localiser votre dossier, vous recevrez un courriel contenant votre numéro de dossier.",
-    "please-contact": "Si vous ne recevez pas un courriel contenant votre numéro de dossier dans les prochaines 24 heures, veuillez contacter Service Canada:",
-    "call": "Appelez: Centre d'appels pour les passeports (insérer le numéro de téléphone)."
+    "request-received": "Votre demande d'obtention du numéro de dossier a été reçue",
+    "if-exists": "Si nous sommes en mesure de localiser le dossier avec les informations que vous nous avez fournies, nous vous enverrons un e-mail avec le numéro de dossier.",
+    "please-contact": "Vous devriez recevoir l'e-mail dans les 30 minutes. Si vous ne le recevez pas, appelez le centre d'appel des passeports au ",
+    "phone-number": "1-800-567-6868"
   },
   "page-unauth": {
     "header": "Page non-autorisée",
@@ -41,9 +42,9 @@
     "button": "Conditions de confidentialité et de courriel"
   },
   "help-message": {
-    "email": "Fournissez votre adresse courriel complète comme indiqué sur le formulaire de demande de passeport. S'il s'agit d'une demande pour un enfant, veuillez fournir l'adresse courriel complète indiquée sur le formulaire de demande de passeport pour le parent/tuteur demandeur.",
-    "given-name": "Veuillez utiliser le(s) prénom(s) exactement comme indiqué sur votre demande de passeport. S'il s'agit d'une demande de passeport pour enfant, veuillez utiliser le(s) prénom(s) de l'enfant tel qu'il(s) figure(ent) sur la demande de passeport. Veuillez noter que le(s) prénom(s) fourni(s) peut avoir été mis à jour pour refléter le(s) premier prénom(s) sur votre preuve de citoyenneté canadienne ou pièce d'identité à l'appui.",
-    "surname": "Veuillez utiliser le nom de famille exactement comme indiqué sur votre demande de passeport. S'il s'agit d'une demande de passeport pour enfant, veuillez utiliser le nom de famille de l'enfant tel qu'il figure sur la demande de passeport. Veuillez noter que le nom de famille fourni peut avoir été mis à jour pour refléter le nom de famille sur votre preuve de citoyenneté canadienne ou pièce d'identité à l'appui.",
-    "date-of-birth": "Veuillez indiquer votre date de naissance telle qu'elle figure sur votre demande de passeport. S'il s'agit d'une demande de passeport pour enfant, veuillez utiliser la date de naissance de l'enfant indiquée sur la demande de passeport. Veuillez noter que la date de naissance fournie peut avoir été mise à jour pour refléter la date de naissance sur votre preuve de citoyenneté canadienne."
+    "email": "Fournissez votre adresse courriel complète comme indiqué sur le formulaire de demande de passeport. Pour les demandes d'enfants, fournissez l'adresse e-mail complète du parent ou du tuteur légal du demandeur exactement comme indiqué sur la demande de passeport.",
+    "given-name": "Veuillez utiliser le(s) prénom(s) exactement comme indiqué sur votre demande de passeport. Pour les demandes d'enfants, indiquez le(s) prénom(s) de l'enfant tel qu'indiqué sur la demande de passeport. Veuillez noter que le(s) prénom(s) fourni(s) peuvent avoir été mis à jour pour refléter le(s) premier(s) prénom(s) sur votre preuve de citoyenneté canadienne ou pièce d'identité à l'appui.",
+    "surname": "Veuillez utiliser le nom de famille exactement comme indiqué sur votre demande de passeport. Pour les demandes d'enfant, indiquez le nom de famille de l'enfant tel qu'indiqué sur la demande de passeport. Veuillez noter que le nom de famille fourni peut avoir été mis à jour pour refléter le nom de famille sur votre preuve de citoyenneté canadienne ou pièce d'identité à l'appui.",
+    "date-of-birth": "Veuillez indiquer votre date de naissance telle qu'elle figure sur votre demande de passeport. Pour les demandes d'enfant, indiquez la date de naissance de l'enfant comme indiqué sur la demande de passeport. Veuillez noter que la date de naissance fournie peut avoir été mise à jour pour refléter la date de naissance sur votre preuve de citoyenneté canadienne."
   }
 }

--- a/public/locales/fr/expectations.json
+++ b/public/locales/fr/expectations.json
@@ -1,15 +1,28 @@
 {
-  "header-purpose": "Objectif de l'application",
+  "header-purpose": "Vérifiez l'état de votre demande de passeport",
   "header-privacy": "Confidentialité",
-  "description-purpose": "Le but de cet outil est de vérifier le statut de votre demande de passeport à partir de quelques informations de base.",
+  "can-check": {
+    "description": "Vous pouvez obtenir le statut de votre demande de passeport en ligne si vous avez soumis votre demande de passeport soit\u00a0:",
+    "list": {
+      "item-1": "en personne ou par la poste au Canada ou",
+      "item-2": "par courrier depuis les États-Unis"
+    }
+  },
+  "available-after": {
+    "description": "Nous mettons à jour quotidiennement l'état des candidatures. Le statut de votre candidature est disponible après\u00a0:",
+    "list": {
+      "item-1": "5 jours si vous avez postulé en personne ou",
+      "item-2": "10 jours si vous avez postulé par courrier"
+    }
+  },
+  "cannot-check": {
+    "description": "Vous ne pouvez pas consulter l'état d'une demande de passeport en ligne si vous\u00a0:",
+    "list": {
+      "item-1": "demandé un passeport à l'extérieur du Canada et des États-Unis ou",
+      "item-2": "demandé un passeport spécial ou diplomatique"
+    }
+  },
   "description-privacy": "Avez-vous lu et accepté les conditions d'utilisation et de confidentialité?",
   "button-agree": "J'ai lu et j'accept",
-  "for-applications": {
-    "p1": "For applications submitted in person or by mail within Canada or mailed to Canada from the US ",
-    "p2": "Recover the ESRF only if a valid email address was included on the application (Post July 2022)",
-    "p3": "Information only updated on a daily basis not real-time."
-  },
-  "recommend-10-days": "Recommend that status checker is only used 10 days after application has been sent. Please refer to (Link to service standards/processing times website) for processing times.",
-  "do-not-travel": "You should not finalize any travel plans until you have the passport. We are not liable for any losses if you do not receive it in time for your travel.",
-  "unsupported-tools": "(not finalized) List of tools that the app does not support: anything overseas (GAC) or IRCC (refugee travel doc, diplomatic passports) or any consulate cases in US or anywhere, but will include applications mailed from US"
+  "do-not-travel": "Vous ne devez finaliser aucun projet de voyage tant que vous n'avez pas le passeport. Nous ne sommes pas responsables des pertes si vous ne le recevez pas à temps pour votre voyage."
 }

--- a/public/locales/fr/landing.json
+++ b/public/locales/fr/landing.json
@@ -1,6 +1,6 @@
 {
-  "header": "Vérification du statut du passeport",
-  "description": "Afin de mieux vous servir, veuillez sélectionner l'option ci-dessous qui vous convient le mieux.",
-  "with-esrf": "J'ai mon numéro de dossier (FEDS)",
-  "without-esrf": "Je n'ai pas mon numéro de dossier (FEDS)"
+  "header": "Vérificateur de statut de demande de passeport",
+  "description": "Avez-vous votre numéro de dossier de demande de passeport?",
+  "with-esrf": "J'ai mon numéro de dossier",
+  "without-esrf": "Je n'ai pas mon numéro de dossier"
 }

--- a/public/locales/fr/status.json
+++ b/public/locales/fr/status.json
@@ -9,7 +9,7 @@
   },
   "check-again": "Pour vérifier l'état d'une autre demande, cliquez sur le bouton ci-dessous\u00a0:",
   "check-status": "Vérifier l'état",
-  "description": "Utilisez ce service avec votre numéro de dossier (FEDS) pour vérifier le statut de votre demande de passeport.",
+  "description": "Remplissez les champs ci-dessous pour vérifier l'état de votre demande de passeport. Assurez-vous que vos informations correspondent à votre formulaire de demande de passeport.",
   "esrf": {
     "error": {
       "length": "Le numéro de dossier peut avoir un maximum de 8 caractères alphanumériques.",
@@ -80,8 +80,8 @@
   },
   "help-message": {
     "esrf": "Lorsque vous soumettez votre demande en personne, vous recevez un numéro de dossier. Le numéro de dossier commence par au moins 1 lettre et comporte un maximum de 8 caractères au total. (Exemples de formats possibles : « A1234567 » ou « AA123456 » ou « A123456 » ou « AA12345 »)",
-    "given-name": "Veuillez utiliser le(s) prénom(s) exactement comme indiqué sur votre demande de passeport. S'il s'agit d'une demande de passeport pour enfant, veuillez utiliser le(s) prénom(s) de l'enfant tel qu'il(s) figure(ent) sur la demande de passeport. Veuillez noter que le(s) prénom(s) fourni(s) peut avoir été mis à jour pour refléter le(s) premier prénom(s) sur votre preuve de citoyenneté canadienne ou pièce d'identité à l'appui.",
-    "surname": "Veuillez utiliser le nom de famille exactement comme indiqué sur votre demande de passeport. S'il s'agit d'une demande de passeport pour enfant, veuillez utiliser le nom de famille de l'enfant tel qu'il figure sur la demande de passeport. Veuillez noter que le nom de famille fourni peut avoir été mis à jour pour refléter le nom de famille sur votre preuve de citoyenneté canadienne ou pièce d'identité à l'appui.",
-    "date-of-birth": "Veuillez indiquer votre date de naissance telle qu'elle figure sur votre demande de passeport. S'il s'agit d'une demande de passeport pour enfant, veuillez utiliser la date de naissance de l'enfant indiquée sur la demande de passeport. Veuillez noter que la date de naissance fournie peut avoir été mise à jour pour refléter la date de naissance sur votre preuve de citoyenneté canadienne."
+    "given-name": "Veuillez utiliser le(s) prénom(s) exactement comme indiqué sur votre demande de passeport. Pour les demandes d'enfants, indiquez le(s) prénom(s) de l'enfant tel qu'indiqué sur la demande de passeport. Veuillez noter que le(s) prénom(s) fourni(s) peuvent avoir été mis à jour pour refléter le(s) premier(s) prénom(s) sur votre preuve de citoyenneté canadienne ou pièce d'identité à l'appui.",
+    "surname": "Veuillez utiliser le nom de famille exactement comme indiqué sur votre demande de passeport. Pour les demandes d'enfant, indiquez le nom de famille de l'enfant tel qu'indiqué sur la demande de passeport. Veuillez noter que le nom de famille fourni peut avoir été mis à jour pour refléter le nom de famille sur votre preuve de citoyenneté canadienne ou pièce d'identité à l'appui.",
+    "date-of-birth": "Veuillez indiquer votre date de naissance telle qu'elle figure sur votre demande de passeport. Pour les demandes d'enfant, indiquez la date de naissance de l'enfant comme indiqué sur la demande de passeport. Veuillez noter que la date de naissance fournie peut avoir été mise à jour pour refléter la date de naissance sur votre preuve de citoyenneté canadienne."
   }
 }


### PR DESCRIPTION
## [ADO-XXX](https://dev.azure.com/DTS-STN/passport-status/_workitems/edit/xxx)

### Description

As per the forwarded email from Stefan, this PR updates the content on `/expectations`, `/landing`, and `/email` pages. I've also updated the `LinkButton` component to have primary and secondary styling (reusing what is present in `ActionButton`) to align with the updated page design from Kevin Ball.

### What to test for/How to test
1. Pull in branch
2. Type `npm run dev`
3. Navigate to `/expectations`, `/landing`, and `/email` and ensure content shows up as expected on each page.

### Additional Notes
This does not include the content changes to the description text for each status code, that will be in another PR. The document sent to us for the page changes have a box signifying a placeholder image meant to show a reference image with the file number highlighted. Since we don't have anything for this right now I've left this out.
