### PR TITLE
Fix 404 and error pages a11y

### DIFF
--- a/components/ErrorSummary.tsx
+++ b/components/ErrorSummary.tsx
@@ -38,7 +38,7 @@ const ErrorSummary: FC<ErrorSummaryProps> = ({ id, errors, summary }) => {
       id={id}
       className="border-l-6 border-accent-error mb-5 ml-2.5 pl-4"
     >
-      <h2 className="text-2xl pt-5">{summary}</h2>
+      <h2 className="text-2xl font-bold mb-3 pt-5">{summary}</h2>
       <ul className="list-disc list-inside space-y-2 pb-5 ml-4">
         {errors.map(({ feildId, errorMessage }, index) => (
           <li key={index}>

--- a/cypress/e2e/404.cy.js
+++ b/cypress/e2e/404.cy.js
@@ -1,0 +1,20 @@
+/// <reference types="cypress" />
+
+describe('not found page loads', () => {
+  beforeEach(() => {
+    cy.visit('/expectations')
+    cy.get('#confirmBtn button').first().click()
+    cy.request({url: '/404', failOnStatusCode: false}).its('status').should('equal', 404)
+    cy.visit('/404', {failOnStatusCode: false})
+  })
+
+  it('displays the not found page', () => {
+    cy.location('pathname').should('equal', "/en/404")
+  })
+
+  it('has no detectable a11y violations on load', () => {
+    cy.injectAxe();
+    cy.wait(500);
+    cy.checkA11y()
+  })
+})

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -12,20 +12,27 @@ const Custom404 = () => {
         }
         title={'Not Found | Pas trouvé - Canada.ca'}
       />
+      <h1 className="sr-only" lang="en">
+        Not Found
+      </h1>
+      <span className="sr-only">
+        {' '}
+        / <span lang="fr">Pas trouvé</span>
+      </span>
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 lg:gap-8">
         <div lang="en">
-          <h1 className="text-2xl">We couldn&#39;t find that Web page</h1>
-          <h2>Error 404</h2>
+          <h2 className="h1">We couldn&#39;t find that Web page</h2>
+          <p className="h2">Error 404</p>
           <p>
             We&#39;re sorry you ended up here. Sometimes a page gets moved or
             deleted, but hopefully we can help you find what you&#39;re looking
             for. What next?
           </p>
-          <ul className="list-disc list-inside space-y-2 mb-3">
+          <ul className="list-disc pl-10 space-y-2">
             <li>
               Return to the{' '}
               <Link href="/" locale="default">
-                <a className="text-cyan-600 underline hover:text-link-selected">
+                <a className="underline text-link-default hover:text-link-selected focus:text-link-selected visited:text-link-visited">
                   home page
                 </a>
               </Link>
@@ -34,7 +41,7 @@ const Custom404 = () => {
             <li>
               <a
                 href="https://www.canada.ca/en/contact.html"
-                className="text-cyan-600 underline hover:text-link-selected"
+                className="underline text-link-default hover:text-link-selected focus:text-link-selected visited:text-link-visited"
               >
                 Contact us
               </a>{' '}
@@ -43,18 +50,18 @@ const Custom404 = () => {
           </ul>
         </div>
         <div lang="fr">
-          <h1 className="text-2xl">Nous ne pouvons trouver cette page Web</h1>
-          <h2>Erreur 404</h2>
+          <h2 className="h1">Nous ne pouvons trouver cette page Web</h2>
+          <p className="h2">Erreur 404</p>
           <p>
             Nous sommes désolés que vous ayez abouti ici. Il arrive parfois
             qu&#39;une page ait été déplacée ou supprimée. Heureusement, nous
             pouvons vous aider à trouver ce que vous cherchez. Que faire?
           </p>
-          <ul className="list-disc list-inside space-y-2 mb-3">
+          <ul className="list-disc pl-10 space-y-2">
             <li>
               Retournez à la{' '}
               <Link href="/" locale="default">
-                <a className="text-cyan-600 underline hover:text-link-selected">
+                <a className="underline text-link-default hover:text-link-selected focus:text-link-selected visited:text-link-visited">
                   page d&#39;accueil
                 </a>
               </Link>
@@ -63,7 +70,7 @@ const Custom404 = () => {
             <li>
               <a
                 href="https://www.canada.ca/fr/contact.html"
-                className="text-cyan-600 underline hover:text-link-selected"
+                className="underline text-link-default hover:text-link-selected focus:text-link-selected visited:text-link-visited"
               >
                 Communiquez avec nous
               </a>{' '}

--- a/pages/_error.tsx
+++ b/pages/_error.tsx
@@ -21,14 +21,24 @@ const Error: NextPage<ErrorProps> = ({ statusCode }) => {
             : 'Service Unavailable | Service indisponible - Canada.ca'
         }
       />
+      <h1 className="sr-only" lang="en">
+        {statusCode === 500 ? 'Internal Server Error' : 'Service Unavailable'}
+      </h1>
+      <span className="sr-only">
+        {' '}
+        /{' '}
+        <span lang="fr">
+          {statusCode === 500
+            ? 'Erreur de serveur interne'
+            : 'Service indisponible'}
+        </span>
+      </span>
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 lg:gap-8">
         <div lang="en">
-          <h1 className="text-2xl">
-            We&#39;re having a problem with that page
-          </h1>
-          <h2>
+          <h2 className="h1">We&#39;re having a problem with that page</h2>
+          <p className="h2">
             {statusCode ? `Error ${statusCode}` : 'An error occurred on client'}
-          </h2>
+          </p>
           <p>
             We expect the problem to be fixed shortly. It&#39;s not your
             computer or Internet connection but a problem with our website&#39;s
@@ -39,7 +49,7 @@ const Error: NextPage<ErrorProps> = ({ statusCode }) => {
             <li>
               Return to the{' '}
               <Link href="/">
-                <a className="text-cyan-600 underline hover:text-link-selected">
+                <a className="underline text-link-default hover:text-link-selected focus:text-link-selected visited:text-link-visited">
                   home page
                 </a>
               </Link>
@@ -48,7 +58,7 @@ const Error: NextPage<ErrorProps> = ({ statusCode }) => {
             <li>
               <a
                 href="https://www.canada.ca/en/contact.html"
-                className="text-cyan-600 underline hover:text-link-selected"
+                className="underline text-link-default hover:text-link-selected focus:text-link-selected visited:text-link-visited"
               >
                 Contact us
               </a>
@@ -58,14 +68,12 @@ const Error: NextPage<ErrorProps> = ({ statusCode }) => {
           <p>Thank you for your patience.</p>
         </div>
         <div lang="fr">
-          <h1 className="text-2xl">
-            Nous éprouvons des difficultés avec cette page
-          </h1>
-          <h2>
+          <h2 className="h1">Nous éprouvons des difficultés avec cette page</h2>
+          <p className="h2">
             {statusCode
               ? `Erreur ${statusCode}`
               : 'Erreur produite sur le client'}
-          </h2>
+          </p>
           <p>
             Nous espérons résoudre le problème sous peu. Il ne s&#39;agit pas
             d&#39;un problème avec votre ordinateur ou Internet, mais plutôt
@@ -76,7 +84,7 @@ const Error: NextPage<ErrorProps> = ({ statusCode }) => {
             <li>
               Retournez à la{' '}
               <Link href="/">
-                <a className="text-cyan-600 underline hover:text-link-selected">
+                <a className="underline text-link-default hover:text-link-selected focus:text-link-selected visited:text-link-visited">
                   page d&#39;accueil
                 </a>
               </Link>
@@ -85,7 +93,7 @@ const Error: NextPage<ErrorProps> = ({ statusCode }) => {
             <li>
               <a
                 href="https://www.canada.ca/fr/contact.html"
-                className="text-cyan-600 underline hover:text-link-selected"
+                className="underline text-link-default hover:text-link-selected focus:text-link-selected visited:text-link-visited"
               >
                 Communiquez avec nous
               </a>{' '}

--- a/pages/contact.tsx
+++ b/pages/contact.tsx
@@ -19,36 +19,34 @@ const Contact: FC = () => {
       header={t('common:header', { returnObjects: true })}
       footer={t('common:footer', { returnObjects: true })}
     >
-      <h1 className="mb-4">{t('header')}</h1>
-      <h2 className="my-14">{t('description')}</h2>
-      <div id="contact-links" className="text-2xl">
+      <h1 className="h1">{t('header')}</h1>
+      <div id="contact-links" className="mb-5">
         <LinkSummary
+          title={t('description')}
           links={t<string, LinkSummaryItem[]>('common:program-links', {
             returnObjects: true,
           })}
         />
       </div>
-      <div className="my-2">
-        <ActionButton
-          text={t('back-to-home')}
-          onClick={() => setModalOpen(true)}
-        />
-      </div>
+      <ActionButton
+        text={t('back-to-home')}
+        onClick={() => setModalOpen(true)}
+      />
       <Modal
         open={modalOpen}
         actionButtons={[
           {
-            text: t('common:cancel-modal.yes-button'),
+            text: t('common:modal.yes-button'),
             onClick: () => router.push('/landing'),
             style: 'primary',
           },
           {
-            text: t('common:cancel-modal.no-button'),
+            text: t('common:modal.no-button'),
             onClick: () => setModalOpen(false),
           },
         ]}
       >
-        {t('common:cancel-modal.description')}
+        {t('common:modal.description')}
       </Modal>
     </Layout>
   )

--- a/pages/email.tsx
+++ b/pages/email.tsx
@@ -98,11 +98,11 @@ export default function Email() {
       header={t('common:header', { returnObjects: true })}
       footer={t('common:footer', { returnObjects: true })}
     >
-      <h1>{t('header')}</h1>
+      <h1 className="h1">{t('header')}</h1>
 
       {isEmailEsrfSuccess ? (
         <>
-          <h2>{t('email-confirmation-msg.request-received')}</h2>
+          <h2 className="h2">{t('email-confirmation-msg.request-received')}</h2>
           <p>{t('email-confirmation-msg.if-exists')}</p>
           <p>
             {t('email-confirmation-msg.please-contact')}{' '}

--- a/pages/expectations.tsx
+++ b/pages/expectations.tsx
@@ -25,7 +25,7 @@ const Expectations: FC = () => {
       header={t('common:header', { returnObjects: true })}
       footer={t('common:footer', { returnObjects: true })}
     >
-      <h1>{t('header-purpose')}</h1>
+      <h1 className="h1">{t('header-purpose')}</h1>
       <p className="mt-8">{t('can-check.description')}</p>
       <ul className="ml-4 mb-3 space-y-2">
         <IconListItem icon="check-mark" text={t('can-check.list.item-1')} />
@@ -50,7 +50,7 @@ const Expectations: FC = () => {
       <p>
         <strong>{t('do-not-travel')}</strong>
       </p>
-      <h2>{t('header-privacy')}</h2>
+      <h2 className="h2">{t('header-privacy')}</h2>
       <p>{t('description-privacy')}</p>
       <div id="confirmBtn">
         <ActionButton

--- a/pages/landing.tsx
+++ b/pages/landing.tsx
@@ -14,29 +14,27 @@ const Landing: FC = () => {
       header={t('common:header', { returnObjects: true })}
       footer={t('common:footer', { returnObjects: true })}
     >
-      <h1>{t('header')}</h1>
-      <div className="mt-8">
-        <p>{t('description')}</p>
-        <div className="flex flex-wrap gap-4">
-          <div className="w-full lg:w-4/12">
-            <LinkButton
-              href="/status"
-              text={t('with-esrf')}
-              fullWidth
-              size="lg"
-              style="primary"
-              id="with-esrf"
-            />
-          </div>
-          <div className="w-full lg:w-4/12">
-            <LinkButton
-              href="/email"
-              text={t('without-esrf')}
-              fullWidth
-              size="lg"
-              id="without-esrf"
-            />
-          </div>
+      <h1 className="h1">{t('header')}</h1>
+      <p>{t('description')}</p>
+      <div className="flex flex-wrap gap-4">
+        <div className="w-full lg:w-4/12">
+          <LinkButton
+            href="/status"
+            text={t('with-esrf')}
+            fullWidth
+            size="lg"
+            style="primary"
+            id="with-esrf"
+          />
+        </div>
+        <div className="w-full lg:w-4/12">
+          <LinkButton
+            href="/email"
+            text={t('without-esrf')}
+            fullWidth
+            size="lg"
+            id="without-esrf"
+          />
         </div>
       </div>
     </Layout>

--- a/pages/status.tsx
+++ b/pages/status.tsx
@@ -149,7 +149,7 @@ const Status: FC = () => {
       header={t('common:header', { returnObjects: true })}
       footer={t('common:footer', { returnObjects: true })}
     >
-      <h1 className="mb-4">{t('header')}</h1>
+      <h1 className="h1">{t('header')}</h1>
       {(() => {
         if (checkStatusResponse !== undefined) {
           return (

--- a/public/locales/en/contact.json
+++ b/public/locales/en/contact.json
@@ -1,5 +1,5 @@
 {
   "header": "Contact Us",
-  "description": "Didn't find what you were looking for? Get in touch with us using the link below or see our other services",
+  "description": "Didn't find what you were looking for? Get in touch with us using the link below or see our other services:",
   "back-to-home": "Return to home page"
 }

--- a/public/locales/fr/contact.json
+++ b/public/locales/fr/contact.json
@@ -1,5 +1,5 @@
 {
   "header": "Contactez-nous",
-  "description": "Vous n'avez pas trouvé ce que vous cherchiez ? Contactez-nous en utilisant le lien ci-dessous ou consultez nos autres services",
+  "description": "Vous n'avez pas trouvé ce que vous cherchiez? Contactez-nous en utilisant le lien ci-dessous ou consultez nos autres services\u00a0:",
   "back-to-home": "Retournez à la page d'accueil"
 }

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -24,27 +24,33 @@
     @apply font-body
   }
 
-  h1, h2, h3, h4 {
+  .h4 {
     @apply font-bold;
     @apply font-display;
   }
 
-  h3 {
+  .h3 {
+    @apply font-bold;
+    @apply font-display;
     @apply text-2xl;
   }
 
-  h2 {
+  .h2 {
+    @apply font-bold;
+    @apply font-display;
     @apply text-3xl;
     @apply mt-8;
     @apply mb-3;
   }
 
-  h1 {
+  .h1 {
+    @apply font-bold;
+    @apply font-display;
     @apply text-4xl;
     @apply mt-9;
-    @apply mb-2;
+    @apply mb-3;
   }
-  h1::after {
+  .h1::after {
     content: "";
     display: block;
     width: 70px;
@@ -63,7 +69,7 @@
     @apply text-link-default;
     @apply underline;
   }
-  main > a:hover, a:focus {
+  main > a:hover, main a:focus {
     @apply text-link-selected;
   }
   main > a:visited {


### PR DESCRIPTION
Use heading classes instead of element css style

## [ADO-XXX](https://dev.azure.com/DTS-STN/passport-status/_workitems/edit/xxx)

### Description

List of proposed changes:

- Fix 404 and error page a11y
- Change element css style with class style for headings

### What to test for/How to test

I've created a cypress test to detects a11y issues for 404 page. That part should be covered.

### Additional Notes

I needed to move away from css element style to class style for headings since the 404 page requires `h1` style on `h2` html tag. It's a common pattern with MUI framework.
