### PR TITLE
Standardize list style

### DIFF
--- a/components/CheckStatusResponses/CheckStatusNoRecord.tsx
+++ b/components/CheckStatusResponses/CheckStatusNoRecord.tsx
@@ -8,12 +8,12 @@ export const CheckStatusNoRecord: FC<{}> = () => {
       <p data-testid="no-record">
         {t('no-record.cannot-give-status.description')}
       </p>
-      <ul className="list-disc list-inside ml-4 mb-3 space-y-2">
+      <ul className="list-disc space-y-2 pl-10 mb-3">
         <li>{t('no-record.cannot-give-status.list.item-1')}</li>
         <li>{t('no-record.cannot-give-status.list.item-2')}</li>
       </ul>
       <p>{t('no-record.available-after.description')}</p>
-      <ul className="list-inside ml-4 mb-3 space-y-2">
+      <ul className="space-y-2 pl-4 mb-3">
         <IconListItem
           icon="check-mark"
           text={t('no-record.available-after.list.item-1')}
@@ -49,7 +49,7 @@ interface IconListItemProps {
 
 const IconListItem: FC<IconListItemProps> = ({ icon, text }) => {
   return (
-    <li className="flex flex-nowrap gap-3">
+    <li className="flex flex-nowrap gap-2">
       <div className="font-bold">
         {icon === 'check-mark' ? <>&#10003;</> : <>&#10007;</>}
       </div>

--- a/components/ErrorSummary.tsx
+++ b/components/ErrorSummary.tsx
@@ -34,12 +34,9 @@ export function GetErrorSummary<T>(formErrors: FormikErrors<T>, t: TFunction) {
 
 const ErrorSummary: FC<ErrorSummaryProps> = ({ id, errors, summary }) => {
   return (
-    <section
-      id={id}
-      className="border-l-6 border-accent-error mb-5 ml-2.5 pl-4"
-    >
-      <h2 className="text-2xl font-bold mb-3 pt-5">{summary}</h2>
-      <ul className="list-disc list-inside space-y-2 pb-5 ml-4">
+    <section id={id} className="border-l-6 border-accent-error mb-5 p-5">
+      <h2 className="text-2xl font-bold mb-3">{summary}</h2>
+      <ul className="list-disc space-y-2 pl-10">
         {errors.map(({ feildId, errorMessage }, index) => (
           <li key={index}>
             <a className="visited:text-link-default" href={`#${feildId}`}>

--- a/components/LinkSummary.tsx
+++ b/components/LinkSummary.tsx
@@ -16,7 +16,7 @@ const LinkSummary: FC<LinkSummaryProps> = ({ title, links }) => {
   return (
     <section className="mt-5">
       <p>{title}</p>
-      <ul className="list-disc list-inside ml-4 mb-3 space-y-2">
+      <ul className="list-disc space-y-2 pl-10 mb-3">
         {links.map(({ href, text, external }, index) => (
           <li key={index}>
             <Link href={href} passHref>

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -28,7 +28,7 @@ const Custom404 = () => {
             deleted, but hopefully we can help you find what you&#39;re looking
             for. What next?
           </p>
-          <ul className="list-disc pl-10 space-y-2">
+          <ul className="list-disc space-y-2 pl-10">
             <li>
               Return to the{' '}
               <Link href="/" locale="default">
@@ -57,7 +57,7 @@ const Custom404 = () => {
             qu&#39;une page ait été déplacée ou supprimée. Heureusement, nous
             pouvons vous aider à trouver ce que vous cherchez. Que faire?
           </p>
-          <ul className="list-disc pl-10 space-y-2">
+          <ul className="list-disc space-y-2 pl-10">
             <li>
               Retournez à la{' '}
               <Link href="/" locale="default">

--- a/pages/_error.tsx
+++ b/pages/_error.tsx
@@ -44,7 +44,7 @@ const Error: NextPage<ErrorProps> = ({ statusCode }) => {
             computer or Internet connection but a problem with our website&#39;s
             server. What next?
           </p>
-          <ul className="list-disc list-inside space-y-2 mb-3">
+          <ul className="list-disc space-y-2 pl-10 mb-3">
             <li>Try refreshing the page or try again later;</li>
             <li>
               Return to the{' '}
@@ -79,7 +79,7 @@ const Error: NextPage<ErrorProps> = ({ statusCode }) => {
             d&#39;un problème avec votre ordinateur ou Internet, mais plutôt
             avec le serveur de notre site Web. Que faire?
           </p>
-          <ul className="list-disc list-inside space-y-2 mb-3">
+          <ul className="list-disc space-y-2 pl-10 mb-3">
             <li>Actualisez la page ou réessayez plus tard;</li>
             <li>
               Retournez à la{' '}

--- a/pages/expectations.tsx
+++ b/pages/expectations.tsx
@@ -25,28 +25,30 @@ const Expectations: FC = () => {
       header={t('common:header', { returnObjects: true })}
       footer={t('common:footer', { returnObjects: true })}
     >
-      <h1 className="h1">{t('header-purpose')}</h1>
-      <p className="mt-8">{t('can-check.description')}</p>
-      <ul className="ml-4 mb-3 space-y-2">
-        <IconListItem icon="check-mark" text={t('can-check.list.item-1')} />
-        <IconListItem icon="check-mark" text={t('can-check.list.item-2')} />
-      </ul>
-      <p>{t('available-after.description')}</p>
-      <ul className="ml-4 mb-3 space-y-2">
-        <IconListItem
-          icon="check-mark"
-          text={t('available-after.list.item-1')}
-        />
-        <IconListItem
-          icon="check-mark"
-          text={t('available-after.list.item-2')}
-        />
-      </ul>
-      <p>{t('cannot-check.description')}</p>
-      <ul className="ml-4 mb-3 space-y-2">
-        <IconListItem icon="cross" text={t('cannot-check.list.item-1')} />
-        <IconListItem icon="cross" text={t('cannot-check.list.item-2')} />
-      </ul>
+      <h1 className="h1 mb-8">{t('header-purpose')}</h1>
+      <div className="my-8">
+        <p>{t('can-check.description')}</p>
+        <ul className="space-y-2 pl-4 mb-3">
+          <IconListItem icon="check-mark" text={t('can-check.list.item-1')} />
+          <IconListItem icon="check-mark" text={t('can-check.list.item-2')} />
+        </ul>
+        <p>{t('available-after.description')}</p>
+        <ul className="space-y-2 pl-4 mb-3">
+          <IconListItem
+            icon="check-mark"
+            text={t('available-after.list.item-1')}
+          />
+          <IconListItem
+            icon="check-mark"
+            text={t('available-after.list.item-2')}
+          />
+        </ul>
+        <p>{t('cannot-check.description')}</p>
+        <ul className="space-y-2 pl-4">
+          <IconListItem icon="cross" text={t('cannot-check.list.item-1')} />
+          <IconListItem icon="cross" text={t('cannot-check.list.item-2')} />
+        </ul>
+      </div>
       <p>
         <strong>{t('do-not-travel')}</strong>
       </p>
@@ -70,7 +72,7 @@ interface IconListItemProps {
 
 const IconListItem: FC<IconListItemProps> = ({ icon, text }) => {
   return (
-    <li className="flex flex-nowrap gap-3">
+    <li className="flex flex-nowrap gap-2">
       <div className="font-bold">
         {icon === 'check-mark' ? <>&#10003;</> : <>&#10007;</>}
       </div>


### PR DESCRIPTION
## [ADO-XXX](https://dev.azure.com/DTS-STN/passport-status/_workitems/edit/xxx)

### Description

List of proposed changes:

- Standarize lists style
-

### What to test for/How to test

### Additional Notes

Using `list-inside` class wrap the list item content under the bullet.

![image](https://user-images.githubusercontent.com/114004123/205709000-91649b6f-84b5-4698-89f4-5e4fdb9c09e7.png)

It's preferable to make the content wrap where the content start.

![image](https://user-images.githubusercontent.com/114004123/205708877-ef41d5c5-0cf2-4f63-8391-75e6b2497c68.png)

