### PR TITLE
Remove ESRF validation

### DIFF
--- a/cypress/e2e/status.cy.js
+++ b/cypress/e2e/status.cy.js
@@ -46,12 +46,6 @@ describe('ESRF field validation', ()=>{
     cy.get('#btn-submit').click()
     cy.get('#input-esrf-error').should('exist')
   })
-
-  it('validates invalid length for ESRF', ()=>{
-    cy.get('#esrf').type('1234')
-    cy.get('#btn-submit').click()
-    cy.get('#input-esrf-error').should('exist')
-  })
 })
 
 describe('givenName field validation', ()=>{

--- a/pages/status.tsx
+++ b/pages/status.tsx
@@ -74,11 +74,7 @@ const Status: FC = () => {
   const formik = useFormik<CheckStatusApiRequestQuery>({
     initialValues,
     validationSchema: Yup.object({
-      esrf: Yup.string()
-        .required('esrf.error.required')
-        .max(8, 'esrf.error.length')
-        .trim()
-        .matches(/^[A-Za-z]/, 'esrf.error.starts-with-letter'),
+      esrf: Yup.string().required('esrf.error.required'),
       givenName: Yup.string().required('given-name.error.required'),
       surname: Yup.string().required('surname.error.required'),
       dateOfBirth: Yup.date()

--- a/public/locales/en/status.json
+++ b/public/locales/en/status.json
@@ -12,9 +12,7 @@
   "description": "Fill in the fields below to check the status of your passport application. Make sure your information matches your passport application form.",
   "esrf": {
     "error": {
-      "length": "The file number can have a maximum of 8 alphanumeric characters.",
-      "required": "The file number is required.",
-      "starts-with-letter": "The file number must begin with a letter (e.g. A1234567)."
+      "required": "The file number is required."
     },
     "label": "File number"
   },

--- a/public/locales/fr/status.json
+++ b/public/locales/fr/status.json
@@ -12,9 +12,7 @@
   "description": "Remplissez les champs ci-dessous pour vérifier l'état de votre demande de passeport. Assurez-vous que vos informations correspondent à votre formulaire de demande de passeport.",
   "esrf": {
     "error": {
-      "length": "Le numéro de dossier peut avoir un maximum de 8 caractères alphanumériques.",
-      "required": "Le numéro de dossier est obligatoire.",
-      "starts-with-letter": "Le numéro de dossier doit commencer par une lettre (p. ex. A1234567)."
+      "required": "Le numéro de dossier est obligatoire."
     },
     "label": "Numéro de dossier"
   },


### PR DESCRIPTION
## [ADO-1505](https://dev.azure.com/DTS-STN/passport-status/_workitems/edit/1505)

### Description
Very small PR that removes most of the validation on the ESRF field (no longer checks that it starts with a letter/only contains alphanumeric/is 8 characters long). The only remaining validation on the field is that is is required.

### What to test for/How to test
1. Pull in branch
2. Type `npm run dev`
3. Navigate to `/status`
4. Enter anything into the ESRF field and press check status and confirm that no errors show up.
