### PR TITLE
Added scroll to top functionality for status page

### DIFF
--- a/pages/email.tsx
+++ b/pages/email.tsx
@@ -13,7 +13,6 @@ import ErrorSummary, {
 import InputField from '../components/InputField'
 import ActionButton from '../components/ActionButton'
 import Modal from '../components/Modal'
-import LinkSummary, { LinkSummaryItem } from '../components/LinkSummary'
 import useEmailEsrf from '../lib/useEmailEsrf'
 import { EmailEsrfApiRequestBody } from '../lib/types'
 import { useIdleTimer } from 'react-idle-timer'

--- a/pages/status.tsx
+++ b/pages/status.tsx
@@ -5,7 +5,6 @@ import {
   useCallback,
   useMemo,
   useState,
-  useEffect,
 } from 'react'
 import { GetStaticProps } from 'next'
 import { useRouter } from 'next/router'

--- a/pages/status.tsx
+++ b/pages/status.tsx
@@ -5,6 +5,7 @@ import {
   useCallback,
   useMemo,
   useState,
+  useEffect,
 } from 'react'
 import { GetStaticProps } from 'next'
 import { useRouter } from 'next/router'
@@ -125,7 +126,6 @@ const Status: FC = () => {
       }
       formik.setStatus(undefined)
       removeCheckStatusResponse()
-      scrollToTop()
     },
     [formik, removeCheckStatusResponse, checkStatusResponse, router]
   )
@@ -137,10 +137,10 @@ const Status: FC = () => {
     [formik]
   )
 
-  //When the page is conditionally rendered it maintains its spot on the page. Calling this will force it to scroll to the top of the page.
-  const scrollToTop = () => {
+  //When the page is conditionally rendered it maintains its spot on the page. When the component mounts and every time checkStatusResponse changes, this will force scroll to the top of the page.
+  useEffect(() => {
     window.scrollTo(0, 0)
-  }
+  }, [checkStatusResponse])
 
   //if the api failed, fail hard to show error page
   if (checkStatusError) throw checkStatusError
@@ -154,7 +154,6 @@ const Status: FC = () => {
       <h1 className="h1">{t('header')}</h1>
       {(() => {
         if (checkStatusResponse !== undefined) {
-          scrollToTop()
           return (
             <>
               <CheckStatusInfo

--- a/pages/status.tsx
+++ b/pages/status.tsx
@@ -5,6 +5,7 @@ import {
   useCallback,
   useMemo,
   useState,
+  useEffect,
 } from 'react'
 import { GetStaticProps } from 'next'
 import { useRouter } from 'next/router'
@@ -125,6 +126,7 @@ const Status: FC = () => {
       }
       formik.setStatus(undefined)
       removeCheckStatusResponse()
+      scrollToTop()
     },
     [formik, removeCheckStatusResponse, checkStatusResponse, router]
   )
@@ -135,6 +137,11 @@ const Status: FC = () => {
     },
     [formik]
   )
+
+  //When the page is conditionally rendered it maintains its spot on the page. Calling this will force it to scroll to the top of the page.
+  const scrollToTop = () => {
+    window.scrollTo(0, 0)
+  }
 
   //if the api failed, fail hard to show error page
   if (checkStatusError) throw checkStatusError
@@ -148,6 +155,7 @@ const Status: FC = () => {
       <h1 className="h1">{t('header')}</h1>
       {(() => {
         if (checkStatusResponse !== undefined) {
+          scrollToTop()
           return (
             <>
               <CheckStatusInfo


### PR DESCRIPTION
## [ADO-1605](https://dev.azure.com/DTS-STN/passport-status/_workitems/edit/1605)

### Description
Currently, if you click `Check Status` on the `/status` page the status information is conditionally rendered. The problem here is that since we aren't actually routing to a new page, our scroll position is maintained when showing the status info. This isn't very noticeable on desktop resolutions but it is very noticeable on mobile resolutions.

My solution was to add a function that scrolls to the top of the page and call this function when the `Previous` button is clicked and before `CheckStatusInfo` is rendered.

### What to test for/How to test
1. Pull in branch
2. Type `npm run dev`
3. In developer tools, set your viewport to a mobile viewport (I used iPhone XR for testing purposes)
4. Navigate to `/status`
5. Fill in form field with dummy data so that `<CheckStatusNoRecord/>` is rendered and ensure your scroll position is at the top of the page
6. Pressing previous should send you back to the pre-filled form with your scroll position at the top of the page
