### PR TITLE
Add error summary scroll and focus on field errors

### DIFF
--- a/__tests__/components/ErrorSummary.test.tsx
+++ b/__tests__/components/ErrorSummary.test.tsx
@@ -6,6 +6,11 @@ import ErrorSummary from '../../components/ErrorSummary'
 expect.extend(toHaveNoViolations)
 
 describe('ErrorSummary', () => {
+  /**
+   * @see https://stackoverflow.com/a/60225417
+   */
+  window.HTMLElement.prototype.scrollIntoView = jest.fn()
+
   const { container } = render(
     <ErrorSummary
       id="id"

--- a/__tests__/pages/email.test.tsx
+++ b/__tests__/pages/email.test.tsx
@@ -5,10 +5,13 @@ import Email from '../../pages/email'
 
 expect.extend(toHaveNoViolations)
 
-jest.mock('../../components/Layout')
-jest.mock('../../components/InputField')
 jest.mock('../../components/ActionButton')
-
+jest.mock('../../components/ErrorSummary', () => ({
+  default: jest.fn(),
+  getErrorSummaryItems: jest.fn(() => []),
+}))
+jest.mock('../../components/InputField')
+jest.mock('../../components/Layout')
 jest.mock('../../lib/useEmailEsrf', () => {
   return jest.fn(() => ({
     isLoading: false,
@@ -17,11 +20,6 @@ jest.mock('../../lib/useEmailEsrf', () => {
     mutate: jest.fn(),
   }))
 })
-
-jest.mock('../../components/ErrorSummary', () => ({
-  GetErrorSummary: () => [],
-  default: jest.fn(),
-}))
 
 describe('Check status page', () => {
   it('should render the page', () => {

--- a/__tests__/pages/status.test.tsx
+++ b/__tests__/pages/status.test.tsx
@@ -5,12 +5,14 @@ import Status from '../../pages/status'
 
 expect.extend(toHaveNoViolations)
 
-jest.mock('../../components/Layout')
-jest.mock('../../components/CheckStatusInfo')
-jest.mock('../../components/ErrorSummary')
-jest.mock('../../components/InputField')
 jest.mock('../../components/ActionButton')
-
+jest.mock('../../components/CheckStatusInfo')
+jest.mock('../../components/ErrorSummary', () => ({
+  default: jest.fn(),
+  getErrorSummaryItems: jest.fn(() => []),
+}))
+jest.mock('../../components/InputField')
+jest.mock('../../components/Layout')
 jest.mock('../../lib/useCheckStatus', () => ({
   useCheckStatus: () => ({
     isLoading: false,

--- a/components/ErrorSummary.tsx
+++ b/components/ErrorSummary.tsx
@@ -1,6 +1,6 @@
 import { FormikErrors } from 'formik'
 import { TFunction } from 'next-i18next'
-import { FC } from 'react'
+import { FC, useEffect } from 'react'
 
 export interface ErrorSummaryItem {
   feildId: string
@@ -21,7 +21,10 @@ export const getErrorSummaryItem = (
   errorMessage,
 })
 
-export function GetErrorSummary<T>(formErrors: FormikErrors<T>, t: TFunction) {
+export const getErrorSummaryItems = <T extends unknown>(
+  formErrors: FormikErrors<T>,
+  t: TFunction
+) => {
   return Object.keys(formErrors)
     .filter((key) => !!formErrors[key as keyof typeof formErrors])
     .map((key) =>
@@ -32,9 +35,25 @@ export function GetErrorSummary<T>(formErrors: FormikErrors<T>, t: TFunction) {
     )
 }
 
+export const goToErrorSummary = (errorSummaryId: string) => {
+  const errorSummaryEl = document.querySelector<HTMLElement>(
+    `#${errorSummaryId}`
+  )
+  errorSummaryEl?.scrollIntoView({ behavior: 'smooth', block: 'center' })
+  errorSummaryEl?.focus()
+}
+
 const ErrorSummary: FC<ErrorSummaryProps> = ({ id, errors, summary }) => {
+  useEffect(() => {
+    goToErrorSummary(id)
+  }, [id])
+
   return (
-    <section id={id} className="border-l-6 border-accent-error mb-5 p-5">
+    <section
+      id={id}
+      className="border-l-6 border-accent-error mb-5 p-5"
+      tabIndex={-1}
+    >
       <h2 className="text-2xl font-bold mb-3">{summary}</h2>
       <ul className="list-disc space-y-2 pl-10">
         {errors.map(({ feildId, errorMessage }, index) => (

--- a/pages/status.tsx
+++ b/pages/status.tsx
@@ -11,7 +11,7 @@ import { GetStaticProps } from 'next'
 import { useRouter } from 'next/router'
 import { useTranslation } from 'next-i18next'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
-import { useFormik } from 'formik'
+import { useFormik, validateYupSchema, yupToFormErrors } from 'formik'
 import * as Yup from 'yup'
 import { CheckStatusApiRequestQuery } from '../lib/types'
 import { useCheckStatus } from '../lib/useCheckStatus'
@@ -20,7 +20,8 @@ import InputField from '../components/InputField'
 import ActionButton from '../components/ActionButton'
 import ErrorSummary, {
   ErrorSummaryItem,
-  getErrorSummaryItem,
+  getErrorSummaryItems,
+  goToErrorSummary,
 } from '../components/ErrorSummary'
 import LinkSummary, { LinkSummaryItem } from '../components/LinkSummary'
 import CheckStatusInfo from '../components/CheckStatusInfo'
@@ -34,6 +35,15 @@ const initialValues: CheckStatusApiRequestQuery = {
   givenName: '',
   surname: '',
 }
+
+const validationSchema = Yup.object({
+  esrf: Yup.string().required('esrf.error.required'),
+  givenName: Yup.string().required('given-name.error.required'),
+  surname: Yup.string().required('surname.error.required'),
+  dateOfBirth: Yup.date()
+    .required('date-of-birth.error.required')
+    .max(new Date(), 'date-of-birth.error.current'),
+})
 
 const Status: FC = () => {
   const { t } = useTranslation('status')
@@ -68,54 +78,51 @@ const Status: FC = () => {
     }
   }, [isIdle, resetIdleTimer])
 
-  const lsItems = t<string, LinkSummaryItem[]>('common:program-links', {
-    returnObjects: true,
-  })
-
-  const formik = useFormik<CheckStatusApiRequestQuery>({
+  const {
+    errors: formikErrors,
+    handleChange: handleFormikChange,
+    handleSubmit: handleFormikSubmit,
+    setFieldValue: setFormikFieldValue,
+    setStatus: setFormikStatus,
+    status: formikStatus,
+    values: formikValues,
+  } = useFormik<CheckStatusApiRequestQuery>({
     initialValues,
-    validationSchema: Yup.object({
-      esrf: Yup.string().required('esrf.error.required'),
-      givenName: Yup.string().required('given-name.error.required'),
-      surname: Yup.string().required('surname.error.required'),
-      dateOfBirth: Yup.date()
-        .required('date-of-birth.error.required')
-        .max(new Date(), 'date-of-birth.error.current'),
-    }),
-    validateOnBlur: false,
-    validateOnChange: false,
-    validateOnMount: false,
-    onReset: (_, { setStatus }) => {
-      setStatus(undefined)
-      removeCheckStatusResponse()
-    },
     onSubmit: (_, { setStatus }) => {
       setStatus('submitted')
     },
+    validate: async (values) => {
+      // manually validate with yup, scroll and focus error summary section element on errors
+      try {
+        await validateYupSchema(values, validationSchema)
+        // empty errors
+        return {}
+      } catch (yupError) {
+        goToErrorSummary('error-summary-get-status')
+        return yupToFormErrors(yupError)
+      }
+    },
+    validateOnBlur: false,
+    validateOnChange: false,
+    validateOnMount: false,
   })
 
   const {
-    isLoading: isCheckStatusLoading,
-    error: checkStatusError,
     data: checkStatusResponse,
+    error: checkStatusError,
+    isLoading: isCheckStatusLoading,
     remove: removeCheckStatusResponse,
   } = useCheckStatus(
-    formik.status === 'submitted' ? formik.values : initialValues,
+    formikStatus === 'submitted' ? formikValues : initialValues,
     {
-      enabled: formik.status === 'submitted',
+      enabled: formikStatus === 'submitted',
     }
   )
 
-  const errorSummary = useMemo<ErrorSummaryItem[]>(() => {
-    return Object.keys(formik.errors)
-      .filter((key) => !!formik.errors[key as keyof typeof formik.errors])
-      .map((key) =>
-        getErrorSummaryItem(
-          key,
-          t(formik.errors[key as keyof typeof formik.errors] as string)
-        )
-      )
-  }, [formik, t])
+  const errorSummaryItems = useMemo<ErrorSummaryItem[]>(
+    () => getErrorSummaryItems(formikErrors, t),
+    [formikErrors, t]
+  )
 
   const handleOnGoBackClick: MouseEventHandler<HTMLButtonElement> = useCallback(
     async (e) => {
@@ -124,17 +131,17 @@ const Status: FC = () => {
         await router.push('/landing')
         return
       }
-      formik.setStatus(undefined)
+      setFormikStatus(undefined)
       removeCheckStatusResponse()
     },
-    [formik, removeCheckStatusResponse, checkStatusResponse, router]
+    [checkStatusResponse, setFormikStatus, removeCheckStatusResponse, router]
   )
 
   const handleOnESRFChange: ChangeEventHandler<HTMLInputElement> = useCallback(
     ({ target }) => {
-      formik.setFieldValue(target.name, target.value.replace(/[^a-z0-9]/gi, ''))
+      setFormikFieldValue(target.name, target.value.replace(/[^a-z0-9]/gi, ''))
     },
-    [formik]
+    [setFormikFieldValue]
   )
 
   //When the page is conditionally rendered it maintains its spot on the page. When the component mounts and every time checkStatusResponse changes, this will force scroll to the top of the page.
@@ -172,27 +179,29 @@ const Status: FC = () => {
               />
               <LinkSummary
                 title={t('common:contact-program')}
-                links={lsItems}
+                links={t<string, LinkSummaryItem[]>('common:program-links', {
+                  returnObjects: true,
+                })}
               ></LinkSummary>
             </>
           )
         }
 
         return (
-          <form onSubmit={formik.handleSubmit} id="form-get-status">
+          <form onSubmit={handleFormikSubmit} id="form-get-status">
             <p>{t('header-messages.fill-in-field')}</p>
             <p>
               <strong>{t('header-messages.matches')}</strong>
             </p>
             <p>{t('header-messages.for-child')}</p>
             <p>{t('header-messages.passport-officer')}</p>
-            {errorSummary.length > 0 && (
+            {errorSummaryItems.length > 0 && (
               <ErrorSummary
                 id="error-summary-get-status"
                 summary={t('common:found-errors', {
-                  count: errorSummary.length,
+                  count: errorSummaryItems.length,
                 })}
-                errors={errorSummary}
+                errors={errorSummaryItems}
               />
             )}
             <InputField
@@ -200,8 +209,8 @@ const Status: FC = () => {
               name="esrf"
               label={t('esrf.label')}
               onChange={handleOnESRFChange}
-              value={formik.values.esrf}
-              errorMessage={formik.errors.esrf && t(formik.errors.esrf)}
+              value={formikValues.esrf}
+              errorMessage={formikErrors.esrf && t(formikErrors.esrf)}
               textRequired={t('common:required')}
               required
             />
@@ -209,11 +218,9 @@ const Status: FC = () => {
               id="givenName"
               name="givenName"
               label={t('given-name.label')}
-              onChange={formik.handleChange}
-              value={formik.values.givenName}
-              errorMessage={
-                formik.errors.givenName && t(formik.errors.givenName)
-              }
+              onChange={handleFormikChange}
+              value={formikValues.givenName}
+              errorMessage={formikErrors.givenName && t(formikErrors.givenName)}
               textRequired={t('common:required')}
               required
             />
@@ -221,9 +228,9 @@ const Status: FC = () => {
               id="surname"
               name="surname"
               label={t('surname.label')}
-              onChange={formik.handleChange}
-              value={formik.values.surname}
-              errorMessage={formik.errors.surname && t(formik.errors.surname)}
+              onChange={handleFormikChange}
+              value={formikValues.surname}
+              errorMessage={formikErrors.surname && t(formikErrors.surname)}
               textRequired={t('common:required')}
               required
             />
@@ -232,10 +239,10 @@ const Status: FC = () => {
               name="dateOfBirth"
               type="date"
               label={t('date-of-birth.label')}
-              onChange={formik.handleChange}
-              value={formik.values.dateOfBirth}
+              onChange={handleFormikChange}
+              value={formikValues.dateOfBirth}
               errorMessage={
-                formik.errors.dateOfBirth && t(formik.errors.dateOfBirth)
+                formikErrors.dateOfBirth && t(formikErrors.dateOfBirth)
               }
               textRequired={t('common:required')}
               max={'9999-12-31'}


### PR DESCRIPTION
## [ADO-XXX](https://dev.azure.com/DTS-STN/passport-status/_workitems/edit/xxx)

### Description

List of proposed changes:

- Add error summary scrolling and focusing on form validation errors.

### What to test for/How to test

Load the application and navigate and submit forms. The error summary should be scrolled into view and focus to help with keyboard navigation.

### Additional Notes
