### PR TITLE
Add and integrate reusable IdleTimout component

### DIFF
--- a/components/IdleTimeout.tsx
+++ b/components/IdleTimeout.tsx
@@ -1,0 +1,74 @@
+import { deleteCookie } from 'cookies-next'
+import { useTranslation } from 'next-i18next'
+import { useRouter } from 'next/router'
+import { FC, useState } from 'react'
+import { IIdleTimerProps, useIdleTimer } from 'react-idle-timer'
+import Modal from './Modal'
+
+export interface IdleTimeoutProps
+  extends Pick<IIdleTimerProps, 'promptTimeout'>,
+    Pick<IIdleTimerProps, 'timeout'> {}
+
+const IdleTimeout: FC<IdleTimeoutProps> = ({ promptTimeout, timeout }) => {
+  const { t } = useTranslation('common')
+  const router = useRouter()
+  const [modalOpen, setModalOpen] = useState(false)
+
+  const handleOnIdle = () => {
+    deleteCookie('agreed-to-email-esrf-terms')
+    router.reload()
+  }
+
+  const handleOnIdleContinueSession = () => {
+    setModalOpen(false)
+    // show existing modals
+    document
+      .querySelectorAll('[role="dialog"]')
+      .forEach(function ({ parentElement }) {
+        parentElement?.classList.remove('hidden')
+        parentElement?.classList.add('flex')
+      })
+    reset()
+  }
+
+  const handleOnPrompt = () => {
+    // hide existing modals
+    document
+      .querySelectorAll('[role="dialog"]')
+      .forEach(function ({ parentElement }) {
+        parentElement?.classList.remove('flex')
+        parentElement?.classList.add('hidden')
+      })
+
+    setModalOpen(true)
+  }
+
+  const { reset } = useIdleTimer({
+    onIdle: handleOnIdle,
+    onPrompt: handleOnPrompt,
+    promptTimeout: promptTimeout ?? 5 + 60 * 1000, //5 minutes
+    timeout: timeout ?? 10 * 60 * 1000, //10 minutes
+  })
+
+  return (
+    <Modal
+      open={modalOpen}
+      actionButtons={[
+        {
+          onClick: () => handleOnIdle(),
+          style: 'primary',
+          text: t('modal.idle-end-session'),
+        },
+        {
+          onClick: handleOnIdleContinueSession,
+          style: 'default',
+          text: t('modal.idle-continue-session'),
+        },
+      ]}
+    >
+      {t('modal.idle')}
+    </Modal>
+  )
+}
+
+export default IdleTimeout


### PR DESCRIPTION
## [ADO-XXX](https://dev.azure.com/DTS-STN/passport-status/_workitems/edit/xxx)

### Description

List of proposed changes:

- Move idle timout code duplication into IdleTimeout reusable component

### What to test for/How to test

- You can modify the timeout and promptTimeout IdleTimer options with small values (in milliseconds) when testing. The idle timeout modal should appears like usual. If a modal is already shown then it will be hidden temporarily then if use continue the session the modal will show up again.

### Additional Notes
