### PR TITLE
Fix layout Canada logo style

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -32,11 +32,11 @@ export default function Header(props: HeaderProps) {
       </nav>
 
       <header>
-        <div className="container mx-auto px-4 flex-col flex md:flex md:flex-row justify-between pt-6">
-          <div className="flex flex-row justify-between items-center lg:mt-7">
+        <div className="container mx-auto px-4 flex-col flex md:flex md:flex-row justify-between pt-2.5">
+          <div className="flex flex-row justify-between items-center content-center md:mt-7">
             <a href={props.gocLink}>
               <img
-                className="h-5 w-auto xs:h-6 sm:h-8 md:h-8 lg:h-7 xl:h-8 "
+                className="w-auto h-7 lg:h-8"
                 src={locale === 'en' ? '/sig-blk-en.svg' : '/sig-blk-fr.svg'}
                 alt={
                   locale === 'en'


### PR DESCRIPTION
## [ADO-XXX](https://dev.azure.com/DTS-STN/passport-status/_workitems/edit/xxx)

### Description

List of proposed changes:

- Tweak Canada logo style in layout header to match Canada.ca

### What to test for/How to test

### Additional Notes
