### PR TITLE
Fix status messaging for Being Processed status

### DIFF
--- a/components/CheckStatusResponses/CheckStatusFileBeingProcessed.tsx
+++ b/components/CheckStatusResponses/CheckStatusFileBeingProcessed.tsx
@@ -7,12 +7,14 @@ export const CheckStatusFileBeingProcessed: FC<{}> = () => {
     <>
       <p data-testid="being-processed">{t('being-processed.received')}</p>
       <p>{t('being-processed.we-will-contact')}</p>
+      <p className="mt-6 text-blue-light">{t('being-processed.more-info')}</p>
       <p>
-        {t('status-check-numerous-attempts.description')}
-        <a href={t('status-check-numerous-attempts.service-standard.href')}>
-          {t('status-check-numerous-attempts.service-standard.text')}
+        {t('status-check-contact.description-being-processed.segment-1')}
+        <a href={t('status-check-contact.service-standard.href')}>
+          {t('status-check-contact.service-standard.text')}
         </a>
-        {t('status-check-numerous-attempts.can-call')}
+        {t('status-check-contact.description-being-processed.segment-2')}
+        {t('status-check-contact.can-call')}
         <b>{t('common:phone-number')}</b>.
       </p>
       <p>

--- a/components/CheckStatusResponses/CheckStatusNoRecord.tsx
+++ b/components/CheckStatusResponses/CheckStatusNoRecord.tsx
@@ -25,11 +25,11 @@ export const CheckStatusNoRecord: FC<{}> = () => {
       </ul>
       <p>{t('no-record.double-check')}</p>
       <p>
-        {t('status-check-numerous-attempts.description')}
-        <a href={t('status-check-numerous-attempts.service-standard.href')}>
-          {t('status-check-numerous-attempts.service-standard.text')}
+        {t('status-check-contact.description-no-record')}
+        <a href={t('status-check-contact.service-standard.href')}>
+          {t('status-check-contact.service-standard.text')}
         </a>
-        {t('status-check-numerous-attempts.can-call')}
+        {t('status-check-contact.can-call')}
         <b>{t('common:phone-number')}</b>.
       </p>
       <p>

--- a/public/locales/en/status.json
+++ b/public/locales/en/status.json
@@ -95,7 +95,8 @@
   },
   "being-processed": {
     "received": "We've received your application and have started processing it.",
-    "we-will-contact": "If we need any further information, we'll contact you by email or telephone. Service Canada will not use text messages or instant messages to start a conversation with you about your passport application."
+    "we-will-contact": "If we need any further information, we'll contact you by email or telephone. Service Canada will not use text messages or instant messages to start a conversation with you about your passport application.",
+    "more-info": "More information"
   },
   "ready-for-pickup": {
     "has-been-printed": "The passport has been printed. Check your receipt to confirm when and where to pick up the passport.",
@@ -114,8 +115,12 @@
     "cannot-process": "We have reviewed your application and can't process it further.",
     "explanation": "We're sending you a letter explaining why, as well as your supporting documents. You should get these within the next few weeks."
   },
-  "status-check-numerous-attempts": {
-    "description": "If after numerous attempts you are unable to access the status of your application online, or if your application is taking longer than the ",
+  "status-check-contact": {
+    "description-no-record": "If after numerous attempts you are unable to access the status of your application online, or if your application is taking longer than the ",
+    "description-being-processed": {
+      "segment-1": "If your application is taking longer than the ",
+      "segment-2": " to process"
+    },
     "service-standard": {
       "text": "service standard",
       "href": "https://www.canada.ca/en/immigration-refugees-citizenship/services/canadian-passports/check-passport-travel-document-application.html"

--- a/public/locales/fr/status.json
+++ b/public/locales/fr/status.json
@@ -95,7 +95,8 @@
   },
   "being-processed": {
     "received": "Nous avons reçu votre candidature et avons commencé à la traiter.",
-    "we-will-contact": "Si nous avons besoin de plus amples informations, nous vous contacterons par e-mail ou par téléphone. Service Canada n'utilisera pas de messages texte ou de messages instantanés pour entamer une conversation avec vous au sujet de votre demande de passeport."
+    "we-will-contact": "Si nous avons besoin de plus amples informations, nous vous contacterons par e-mail ou par téléphone. Service Canada n'utilisera pas de messages texte ou de messages instantanés pour entamer une conversation avec vous au sujet de votre demande de passeport.",
+    "more-info": "Plus d'information"
   },
   "ready-for-pickup": {
     "has-been-printed": "Le passeport a été imprimé. Vérifiez votre reçu pour confirmer quand et où retirer le passeport.",
@@ -114,8 +115,12 @@
     "cannot-process": "Nous avons examiné votre candidature et ne pouvons plus la traiter.",
     "explanation": "Nous vous envoyons une lettre expliquant pourquoi, ainsi que vos pièces justificatives. Vous devriez les recevoir dans les prochaines semaines."
   },
-  "status-check-numerous-attempts": {
-    "description": "Si après de nombreuses tentatives vous ne parvenez pas à accéder au statut de votre candidature en ligne, ou si votre candidature prend plus de temps que prévu ",
+  "status-check-contact": {
+    "description-no-record": "Si après de nombreuses tentatives vous ne parvenez pas à accéder au statut de votre candidature en ligne, ou si votre candidature prend plus de temps que prévu ",
+    "description-being-processed": {
+      "segment-1": "Si votre demande prend plus de temps que le ",
+      "segment-2": " à traiter"
+    },
     "service-standard": {
       "text": "norme de service",
       "href": "https://www.canada.ca/fr/immigration-refugies-citoyennete/services/passeports-canadiens/verifier-demande-passeports-documents-voyage.html"

--- a/public/locales/fr/status.json
+++ b/public/locales/fr/status.json
@@ -28,7 +28,7 @@
   "status": {
     "1": {
       "label": "Être en cours de traitement",
-      "description": "Votre candidature a été reçue et est en cours. Si de plus amples informations sont nécessaires, nous vous contacterons."
+      "description": "Votre demande a été reçue et est en cours. Si de plus amples informations sont nécessaires, nous vous contacterons."
     },
     "2": {
       "label": "Émis et prêt pour le ramassage",
@@ -53,7 +53,7 @@
       "description": "Si vous voyez cela, c'est que quelque chose s'est mal passé."
     }
   },
-  "status-is": "Le dernier statut de votre candidature selon nos dossiers est\u00a0:",
+  "status-is": "Le dernier statut de votre demande selon nos dossiers est\u00a0:",
   "surname": {
     "error": {
       "required": "Le nom de famille est obligatoire."
@@ -78,14 +78,14 @@
   },
   "no-record": {
     "cannot-give-status": {
-      "description": "Nous ne pouvons pas vous donner le statut de votre candidature pour le moment car\u00a0:",
+      "description": "Nous ne pouvons pas vous donner le statut de votre demande pour le moment car\u00a0:",
       "list": {
         "item-1": "les informations que vous nous avez fournies ne correspondent pas aux informations de notre système ou",
-        "item-2": "nous avons reçu votre candidature, mais nous n'avons pas encore commencé à la traiter"
+        "item-2": "nous avons reçu votre demande, mais nous n'avons pas encore commencé à la traiter"
       }
     },
     "available-after": {
-      "description": "Le statut de votre candidature est disponible après\u00a0:",
+      "description": "Le statut de votre demande est disponible après\u00a0:",
       "list": {
         "item-1": "5 jours si vous avez postulé en personne ou",
         "item-2": "10 jours si vous avez postulé par courrier"
@@ -94,7 +94,7 @@
     "double-check": "Vérifiez vos informations et réessayez. Si votre application est toujours introuvable, vous pouvez réessayer demain. Nos dossiers sont mis à jour quotidiennement."
   },
   "being-processed": {
-    "received": "Nous avons reçu votre candidature et avons commencé à la traiter.",
+    "received": "Nous avons reçu votre demande et avons commencé à la traiter.",
     "we-will-contact": "Si nous avons besoin de plus amples informations, nous vous contacterons par e-mail ou par téléphone. Service Canada n'utilisera pas de messages texte ou de messages instantanés pour entamer une conversation avec vous au sujet de votre demande de passeport.",
     "more-info": "Plus d'information"
   },
@@ -112,13 +112,13 @@
     "supporting-documents": "Vous recevrez votre passeport et les pièces justificatives dans la même enveloppe."
   },
   "not-acceptable": {
-    "cannot-process": "Nous avons examiné votre candidature et ne pouvons plus la traiter.",
+    "cannot-process": "Nous avons examiné votre demande et ne pouvons plus la traiter.",
     "explanation": "Nous vous envoyons une lettre expliquant pourquoi, ainsi que vos pièces justificatives. Vous devriez les recevoir dans les prochaines semaines."
   },
   "status-check-contact": {
-    "description-no-record": "Si après de nombreuses tentatives vous ne parvenez pas à accéder au statut de votre candidature en ligne, ou si votre candidature prend plus de temps que prévu ",
+    "description-no-record": "Si après de nombreuses tentatives vous ne parvenez pas à accéder au statut de votre demande en ligne, ou si votre demande prend plus de temps que la ",
     "description-being-processed": {
-      "segment-1": "Si votre demande prend plus de temps que le ",
+      "segment-1": "Si votre demande prend plus de temps que la ",
       "segment-2": " à traiter"
     },
     "service-standard": {


### PR DESCRIPTION
## [ADO-1794](https://dev.azure.com/DTS-STN/passport-status/_workitems/edit/1794)

### Description

It was pointed out that some of the status messaging had crossed over from the messaging shown for the No Record status, so this PR fixes that and adds the missing "More Information" text as well.

### What to test for/How to test
1. Pull in branch
2. Type `npm run dev`
3. Navigate to `/status`
4. Enter in the following data:
```
File Number: A072AC36
Given name: Juliette
Surname: Noél
DOB: 1960-12-17
```
5. Confirm the status messaging matches what is in the ADO task
