### PR TITLE
update modal styling and add countdown timer

### DIFF
--- a/__tests__/components/Modal.test.tsx
+++ b/__tests__/components/Modal.test.tsx
@@ -7,17 +7,22 @@ expect.extend(toHaveNoViolations)
 
 describe('Modal', () => {
   const { container } = render(
-    <Modal open actionButtons={[{ text: 'button text' }]}>
-      <p>content</p>
-    </Modal>
+    <Modal
+      open
+      actionButtons={[{ text: 'button text' }]}
+      header={'header'}
+      description={'description'}
+    />
   )
 
   it('renders', () => {
     const sut = screen.getByRole('dialog')
-    const content = screen.getByText('content')
+    const header = screen.getByText('header')
+    const description = screen.getByText('description')
     const actionButton = screen.getByText('button text')
     expect(sut).toBeInTheDocument()
-    expect(content).toBeInTheDocument()
+    expect(header).toBeInTheDocument()
+    expect(description).toBeInTheDocument()
     expect(actionButton).toBeInTheDocument()
   })
 

--- a/__tests__/components/Modal.test.tsx
+++ b/__tests__/components/Modal.test.tsx
@@ -7,12 +7,9 @@ expect.extend(toHaveNoViolations)
 
 describe('Modal', () => {
   const { container } = render(
-    <Modal
-      open
-      actionButtons={[{ text: 'button text' }]}
-      header={'header'}
-      description={'description'}
-    />
+    <Modal open actionButtons={[{ text: 'button text' }]} header={'header'}>
+      <p>description</p>
+    </Modal>
   )
 
   it('renders', () => {

--- a/components/IdleTimeout.tsx
+++ b/components/IdleTimeout.tsx
@@ -48,7 +48,7 @@ const IdleTimeout: FC<IdleTimeoutProps> = ({ promptTimeout, timeout }) => {
     onIdle: handleOnIdle,
     onPrompt: handleOnPrompt,
     promptTimeout: promptTimeout ?? 5 * 60 * 1000, //5 minutes
-    timeout: timeout ?? 10, //10 minutes
+    timeout: timeout ?? 10 * 60 * 1000, //10 minutes
   })
 
   const tick = useCallback(() => {
@@ -70,17 +70,17 @@ const IdleTimeout: FC<IdleTimeoutProps> = ({ promptTimeout, timeout }) => {
         {
           onClick: () => handleOnIdle(),
           style: 'primary',
-          text: t('modal.idle-end-session'),
+          text: t('modal-idle-timeout.end-session'),
         },
         {
           onClick: handleOnIdleContinueSession,
           style: 'default',
-          text: t('modal.idle-continue-session'),
+          text: t('modal-idle-timeout.continue-session'),
         },
       ]}
-      header={t('modal.idle-header')}
+      header={t('modal-idle-timeout.header')}
     >
-      <p>{t('modal.idle-description', { timeRemaining })}</p>
+      <p>{t('modal-idle-timeout.description', { timeRemaining })}</p>
     </Modal>
   )
 }

--- a/components/IdleTimeout.tsx
+++ b/components/IdleTimeout.tsx
@@ -48,12 +48,12 @@ const IdleTimeout: FC<IdleTimeoutProps> = ({ promptTimeout, timeout }) => {
     onIdle: handleOnIdle,
     onPrompt: handleOnPrompt,
     promptTimeout: promptTimeout ?? 5 * 60 * 1000, //5 minutes
-    timeout: timeout ?? 10 * 60 * 1000, //10 minutes
+    timeout: timeout ?? 10, //10 minutes
   })
 
   const tick = useCallback(() => {
-    var minutes = Math.floor(getRemainingTime() / 60000)
-    var seconds = Math.floor((getRemainingTime() / 1000) % 60).toFixed(0)
+    const minutes = Math.floor(getRemainingTime() / 60000)
+    const seconds = Math.floor((getRemainingTime() / 1000) % 60).toFixed(0)
     setTimeRemaining(
       minutes + ':' + (parseInt(seconds) < 10 ? '0' : '') + seconds
     )
@@ -63,9 +63,9 @@ const IdleTimeout: FC<IdleTimeoutProps> = ({ promptTimeout, timeout }) => {
     setInterval(tick, 1000)
   }, [tick])
 
-  return timeRemaining ? (
+  return (
     <Modal
-      open={modalOpen}
+      open={modalOpen && timeRemaining.length > 0}
       actionButtons={[
         {
           onClick: () => handleOnIdle(),
@@ -79,9 +79,10 @@ const IdleTimeout: FC<IdleTimeoutProps> = ({ promptTimeout, timeout }) => {
         },
       ]}
       header={t('modal.idle-header')}
-      description={t('modal.idle-description', { timeRemaining })}
-    />
-  ) : null
+    >
+      <p>{t('modal.idle-description', { timeRemaining })}</p>
+    </Modal>
+  )
 }
 
 export default IdleTimeout

--- a/components/Modal.tsx
+++ b/components/Modal.tsx
@@ -1,14 +1,20 @@
-import { FC, ReactNode, useId } from 'react'
+import { FC, useId } from 'react'
 import ActionButton, { ActionButtonProps } from './ActionButton'
 import { FocusOn } from 'react-focus-on'
 
 export interface ModalProps {
   actionButtons: ActionButtonProps[]
-  children: ReactNode
   open: boolean
+  header: string
+  description: string
 }
 
-const Modal: FC<ModalProps> = ({ actionButtons, children, open }) => {
+const Modal: FC<ModalProps> = ({
+  actionButtons,
+  header,
+  description,
+  open,
+}) => {
   const id = useId()
   if (!open) return <></>
   return (
@@ -19,13 +25,19 @@ const Modal: FC<ModalProps> = ({ actionButtons, children, open }) => {
       >
         <div
           role="dialog"
-          aria-describedby={`${id}-modal-desc`}
-          className="mx-4 p-4 bg-white border-2 border-black md:w-2/3 lg:w-2/5"
+          aria-describedby={`${id}-modal-header`}
+          className="bg-white ring-2 ring-[#999] md:w-2/3 lg:w-2/5 rounded"
         >
-          <div id={`${id}-modal-desc`} className="mb-4">
-            {children}
+          <header
+            id={`${id}-modal-header`}
+            className="bg-blue-deep text-white p-3 border-b border-black rounded-t"
+          >
+            <h2>{header}</h2>
+          </header>
+          <div id={`${id}-modal-desc`} className="p-3">
+            {description}
           </div>
-          <div className="flex gap-2 justify-center">
+          <div className="flex gap-2 justify-end p-2 border-t border-[#999]">
             {actionButtons.map((actionButtonProps) => (
               <ActionButton
                 key={actionButtonProps.text}

--- a/components/Modal.tsx
+++ b/components/Modal.tsx
@@ -1,4 +1,4 @@
-import { FC, useId } from 'react'
+import { FC, ReactNode, useId } from 'react'
 import ActionButton, { ActionButtonProps } from './ActionButton'
 import { FocusOn } from 'react-focus-on'
 
@@ -6,15 +6,10 @@ export interface ModalProps {
   actionButtons: ActionButtonProps[]
   open: boolean
   header: string
-  description: string
+  children: ReactNode
 }
 
-const Modal: FC<ModalProps> = ({
-  actionButtons,
-  header,
-  description,
-  open,
-}) => {
+const Modal: FC<ModalProps> = ({ actionButtons, header, open, children }) => {
   const id = useId()
   if (!open) return <></>
   return (
@@ -26,7 +21,7 @@ const Modal: FC<ModalProps> = ({
         <div
           role="dialog"
           aria-describedby={`${id}-modal-header`}
-          className="bg-white ring-2 ring-gray-modal md:w-2/3 lg:w-2/5 rounded"
+          className="mx-4 bg-white ring-2 ring-gray-modal md:w-2/3 lg:w-2/5 rounded"
         >
           <header
             id={`${id}-modal-header`}
@@ -35,7 +30,7 @@ const Modal: FC<ModalProps> = ({
             <h2>{header}</h2>
           </header>
           <div id={`${id}-modal-desc`} className="p-3">
-            {description}
+            {children}
           </div>
           <div className="flex gap-2 justify-end p-2 border-t border-gray-modal">
             {actionButtons.map((actionButtonProps) => (

--- a/components/Modal.tsx
+++ b/components/Modal.tsx
@@ -26,7 +26,7 @@ const Modal: FC<ModalProps> = ({
         <div
           role="dialog"
           aria-describedby={`${id}-modal-header`}
-          className="bg-white ring-2 ring-[#999] md:w-2/3 lg:w-2/5 rounded"
+          className="bg-white ring-2 ring-gray-modal md:w-2/3 lg:w-2/5 rounded"
         >
           <header
             id={`${id}-modal-header`}
@@ -37,7 +37,7 @@ const Modal: FC<ModalProps> = ({
           <div id={`${id}-modal-desc`} className="p-3">
             {description}
           </div>
-          <div className="flex gap-2 justify-end p-2 border-t border-[#999]">
+          <div className="flex gap-2 justify-end p-2 border-t border-gray-modal">
             {actionButtons.map((actionButtonProps) => (
               <ActionButton
                 key={actionButtonProps.text}

--- a/pages/contact.tsx
+++ b/pages/contact.tsx
@@ -36,18 +36,18 @@ const Contact: FC = () => {
         open={modalOpen}
         actionButtons={[
           {
-            text: t('common:modal.yes-button'),
+            text: t('common:modal-go-back.yes-button'),
             onClick: () => router.push('/landing'),
             style: 'primary',
           },
           {
-            text: t('common:modal.no-button'),
+            text: t('common:modal-go-back.no-button'),
             onClick: () => setModalOpen(false),
           },
         ]}
-        header={t('common:modal.header')}
+        header={t('common:modal-go-back.header')}
       >
-        <p>{t('common:modal.description')}</p>
+        <p>{t('common:modal-go-back.description')}</p>
       </Modal>
     </Layout>
   )

--- a/pages/contact.tsx
+++ b/pages/contact.tsx
@@ -46,8 +46,9 @@ const Contact: FC = () => {
           },
         ]}
         header={t('common:modal.header')}
-        description={t('common:modal.description')}
-      />
+      >
+        <p>{t('common:modal.description')}</p>
+      </Modal>
     </Layout>
   )
 }

--- a/pages/contact.tsx
+++ b/pages/contact.tsx
@@ -45,9 +45,9 @@ const Contact: FC = () => {
             onClick: () => setModalOpen(false),
           },
         ]}
-      >
-        {t('common:modal.description')}
-      </Modal>
+        header={t('common:modal.header')}
+        description={t('common:modal.description')}
+      />
     </Layout>
   )
 }

--- a/pages/email.tsx
+++ b/pages/email.tsx
@@ -192,8 +192,9 @@ export default function Email() {
           },
         ]}
         header={t('common:modal.header')}
-        description={t('common:modal.description')}
-      />
+      >
+        <p>{t('common:modal.description')}</p>
+      </Modal>
     </Layout>
   )
 }

--- a/pages/email.tsx
+++ b/pages/email.tsx
@@ -172,7 +172,7 @@ export default function Email() {
             <ActionButton
               id="btn-cancel"
               disabled={isEmailEsrfLoading}
-              text={t('common:modal.cancel-button')}
+              text={t('common:modal-go-back.cancel-button')}
               onClick={() => setModalOpen(true)}
             />
           </div>
@@ -182,18 +182,18 @@ export default function Email() {
         open={modalOpen}
         actionButtons={[
           {
-            text: t('common:modal.yes-button'),
+            text: t('common:modal-go-back.yes-button'),
             onClick: () => router.push('/landing'),
             style: 'primary',
           },
           {
-            text: t('common:modal.no-button'),
+            text: t('common:modal-go-back.no-button'),
             onClick: () => setModalOpen(false),
           },
         ]}
-        header={t('common:modal.header')}
+        header={t('common:modal-go-back.header')}
       >
-        <p>{t('common:modal.description')}</p>
+        <p>{t('common:modal-go-back.description')}</p>
       </Modal>
     </Layout>
   )

--- a/pages/email.tsx
+++ b/pages/email.tsx
@@ -185,18 +185,15 @@ export default function Email() {
             text: t('common:modal.yes-button'),
             onClick: () => router.push('/landing'),
             style: 'primary',
-            type: 'button',
           },
           {
             text: t('common:modal.no-button'),
             onClick: () => setModalOpen(false),
-            style: 'default',
-            type: 'button',
           },
         ]}
-      >
-        {t('common:modal.description')}
-      </Modal>
+        header={t('common:modal.header')}
+        description={t('common:modal.description')}
+      />
     </Layout>
   )
 }

--- a/pages/status.tsx
+++ b/pages/status.tsx
@@ -247,9 +247,9 @@ const Status: FC = () => {
             onClick: () => setModalOpen(false),
           },
         ]}
-      >
-        {t('common:modal.description')}
-      </Modal>
+        header={t('common:modal.header')}
+        description={t('common:modal.description')}
+      />
     </Layout>
   )
 }

--- a/pages/status.tsx
+++ b/pages/status.tsx
@@ -248,8 +248,9 @@ const Status: FC = () => {
           },
         ]}
         header={t('common:modal.header')}
-        description={t('common:modal.description')}
-      />
+      >
+        <p>{t('common:modal.description')}</p>
+      </Modal>
     </Layout>
   )
 }

--- a/pages/status.tsx
+++ b/pages/status.tsx
@@ -227,7 +227,7 @@ const Status: FC = () => {
               <ActionButton
                 id="btn-cancel"
                 disabled={isCheckStatusLoading}
-                text={t('common:modal.cancel-button')}
+                text={t('common:modal-go-back.cancel-button')}
                 onClick={() => setModalOpen(true)}
               />
             </div>
@@ -238,18 +238,18 @@ const Status: FC = () => {
         open={modalOpen}
         actionButtons={[
           {
-            text: t('common:modal.yes-button'),
+            text: t('common:modal-go-back.yes-button'),
             onClick: () => router.push('/landing'),
             style: 'primary',
           },
           {
-            text: t('common:modal.no-button'),
+            text: t('common:modal-go-back.no-button'),
             onClick: () => setModalOpen(false),
           },
         ]}
-        header={t('common:modal.header')}
+        header={t('common:modal-go-back.header')}
       >
-        <p>{t('common:modal.description')}</p>
+        <p>{t('common:modal-go-back.description')}</p>
       </Modal>
     </Layout>
   )

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -57,16 +57,18 @@
       "external": true
     }
   ],
-  "modal": {
+  "modal-go-back": {
     "cancel-button": "Cancel",
     "yes-button": "Yes",
     "no-button": "No",
     "header": "Return to the home page",
-    "description": "Are you sure you want to go back?",
-    "idle-header": "Session timeout warning",
-    "idle-description": "You have been inactive for 10 minutes and your session is set to expire in {{timeRemaining}}. Select \"Continue Session\" to continue your session.",
-    "idle-continue-session": "Continue session",
-    "idle-end-session": "End session"
+    "description": "Are you sure you want to go back?"
+  },
+  "modal-idle-timeout": {
+    "header": "Session timeout warning",
+    "description": "You have been inactive for 10 minutes and your session is set to expire in {{timeRemaining}}. Select \"Continue Session\" to continue your session.",
+    "continue-session": "Continue session",
+    "end-session": "End session"
   },
   "phone-number": "1-800-567-6868"
 }

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -61,8 +61,10 @@
     "cancel-button": "Cancel",
     "yes-button": "Yes",
     "no-button": "No",
+    "header": "Return to the home page",
     "description": "Are you sure you want to go back?",
-    "idle": "You have been inactive for 10 minutes and your session is set to expire in 5 minutes. Select \"Continue Session\" to continue your session.",
+    "idle-header": "Session timeout warning",
+    "idle-description": "You have been inactive for 10 minutes and your session is set to expire in {{timeRemaining}}. Select \"Continue Session\" to continue your session.",
     "idle-continue-session": "Continue session",
     "idle-end-session": "End session"
   },

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -57,16 +57,18 @@
       "external": true
     }
   ],
-  "modal": {
+  "modal-go-back": {
     "cancel-button": "Annuler",
     "yes-button": "Oui",
     "no-button": "Non",
     "header": "Retournez à la page d'accueil",
-    "description": "Êtes-vous sûr de vouloir revenir en arrière?",
-    "idle-header": "Avertissement d'expiration de la session",
-    "idle-description": "Vous avez été inactif pendant 10 minutes et votre session doit expirer dans {{timeRemaining}}. Sélectionnez \"Continuer la session\" pour continuer votre session.",
-    "idle-continue-session": "Continuer la session",
-    "idle-end-session": "Terminer la session"
+    "description": "Êtes-vous sûr de vouloir revenir en arrière?"
+  },
+  "modal-idle-timeout": {
+    "header": "Avertissement d'expiration de la session",
+    "description": "Vous avez été inactif pendant 10 minutes et votre session doit expirer dans {{timeRemaining}}. Sélectionnez \"Continuer la session\" pour continuer votre session.",
+    "continue-session": "Continuer la session",
+    "end-session": "Terminer la session"
   },
   "phone-number": "1-800-567-6868"
 }

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -61,8 +61,10 @@
     "cancel-button": "Annuler",
     "yes-button": "Oui",
     "no-button": "Non",
+    "header": "Retournez à la page d'accueil",
     "description": "Êtes-vous sûr de vouloir revenir en arrière?",
-    "idle": "Vous avez été inactif pendant 10 minutes et votre session doit expirer dans 5 minutes. Sélectionnez \"Continuer la session\" pour continuer votre session.",
+    "idle-header": "Avertissement d'expiration de la session",
+    "idle-description": "Vous avez été inactif pendant 10 minutes et votre session doit expirer dans {{timeRemaining}}. Sélectionnez \"Continuer la session\" pour continuer votre session.",
     "idle-continue-session": "Continuer la session",
     "idle-end-session": "Terminer la session"
   },

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -51,6 +51,7 @@ module.exports = {
           dark: '#cfd1d5',
           deep: '#bbbfc5',
           helpText: '#6c757d',
+          modal: '#999999',
         },
         orange: {
           dark: '#e59700',

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -40,7 +40,7 @@ module.exports = {
           normal: '#1c578a',
           default: '#091c2d',
           dark: '#26374a',
-          deep: '#26374a',
+          deep: '#2e5274',
           active: '#16446c',
         },
         gray: {


### PR DESCRIPTION
## [ADO-1585](https://dev.azure.com/DTS-STN/passport-status/_workitems/edit/1585)

### Description

This PR updates the modal styling to be more in line with other Canada.ca design patterns for modals and also updates the idle description to include a countdown timer to let the user know how much time they have before they are redirected.

### What to test for/How to test
1. Pull in branch
2. Type `npm run dev`
3. Change the value for `timeout` to something small
4. The modal should pop up warning of a session timeout, with a timer counting down from 5 minutes (or whatever you set `promptTimeout` to)
