### PR TITLE
Update button on email page to have correct text

### DIFF
--- a/public/locales/en/email.json
+++ b/public/locales/en/email.json
@@ -28,7 +28,7 @@
     },
     "label": "Date of birth"
   },
-  "email-esrf": "Email my file number (ESRF)",
+  "email-esrf": "Email my file number",
   "email-sent-confirmation": "An email has been sent if there was a match in our records with the file number (ESRF).",
   "email-confirmation-msg": {
     "request-received": "Your request to get the file number has been received",

--- a/public/locales/fr/email.json
+++ b/public/locales/fr/email.json
@@ -28,7 +28,7 @@
     },
     "label": "Date de naissance"
   },
-  "email-esrf": "Envoyer mon numéro de dossier (FEDS)",
+  "email-esrf": "Envoyer mon numéro de dossier",
   "email-sent-confirmation": "Un courriel a été envoyé s'il y avait une correspondance dans nos dossiers avec le numéro de dossier (FEDS).",
   "email-confirmation-msg": {
     "request-received": "Votre demande d'obtention du numéro de dossier a été reçue",


### PR DESCRIPTION
## [ADO-1837](https://dev.azure.com/DTS-STN/passport-status/_workitems/edit/1837)

### Description
Very small PR that removes the ESRF/FEDS text from the submit button on the email page.

### What to test for/How to test
1. Pull in branch
2. Type `npm run dev`
3. Navigate to `/email` and confirm that the button text matches the text in the ADO task