### PR TITLE
Added feedback link to /status and /email pages using i18next Trans c…

### DIFF
--- a/pages/email.tsx
+++ b/pages/email.tsx
@@ -98,8 +98,8 @@ export default function Email() {
             <b>{t('common:phone-number')}</b>.
           </p>
           <div className="mt-10">
-            <Trans i18nKey={'feedback-link'}>
-              Insert feedback <a href="">Link</a>
+            <Trans i18nKey={'common:feedback-link'}>
+              Insert feedback <a href="https://example.com">Link</a>
             </Trans>
           </div>
         </>

--- a/pages/email.tsx
+++ b/pages/email.tsx
@@ -2,7 +2,7 @@ import { useFormik, validateYupSchema, yupToFormErrors } from 'formik'
 import * as Yup from 'yup'
 import { GetStaticProps } from 'next'
 import { useRouter } from 'next/router'
-import { useTranslation } from 'next-i18next'
+import { Trans, useTranslation } from 'next-i18next'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import Layout from '../components/Layout'
 import { useMemo, useState, useCallback } from 'react'
@@ -97,6 +97,11 @@ export default function Email() {
             {t('email-confirmation-msg.please-contact')}{' '}
             <b>{t('common:phone-number')}</b>.
           </p>
+          <div className="mt-10">
+            <Trans i18nKey={'feedback-link'}>
+              Insert feedback <a href="">Link</a>
+            </Trans>
+          </div>
         </>
       ) : (
         <form onSubmit={handleFormikSubmit} id="form-email-esrf">

--- a/pages/status.tsx
+++ b/pages/status.tsx
@@ -148,8 +148,8 @@ const Status: FC = () => {
                 checkStatusResponse={checkStatusResponse}
               />
               <div className="mt-10">
-                <Trans i18nKey={'feedback-link'}>
-                  Insert feedback <a href="">Link</a>
+                <Trans i18nKey={'common:feedback-link'}>
+                  Insert feedback <a href="https://example.com">Link</a>
                 </Trans>
               </div>
             </>

--- a/pages/status.tsx
+++ b/pages/status.tsx
@@ -8,7 +8,7 @@ import {
 } from 'react'
 import { GetStaticProps } from 'next'
 import { useRouter } from 'next/router'
-import { useTranslation } from 'next-i18next'
+import { Trans, useTranslation } from 'next-i18next'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import { useFormik, validateYupSchema, yupToFormErrors } from 'formik'
 import * as Yup from 'yup'
@@ -27,6 +27,7 @@ import Modal from '../components/Modal'
 import IdleTimeout from '../components/IdleTimeout'
 import Collapse from '../components/Collapse'
 import ExampleImage from '../components/ExampleImage'
+import Link from 'next/link'
 
 const initialValues: CheckStatusApiRequestQuery = {
   dateOfBirth: '',
@@ -146,6 +147,11 @@ const Status: FC = () => {
                 checkAgainText={t('check-again')}
                 checkStatusResponse={checkStatusResponse}
               />
+              <div className="mt-10">
+                <Trans i18nKey={'feedback-link'}>
+                  Insert feedback <a href="">Link</a>
+                </Trans>
+              </div>
             </>
           )
         }

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -52,5 +52,6 @@
     "continue-session": "Continue session",
     "end-session": "End session"
   },
-  "phone-number": "1-800-567-6868"
+  "phone-number": "1-800-567-6868",
+  "feedback-link": "Did you find what you were looking for? <1>Give your feedback</1> on the passport status check tool."
 }

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -52,5 +52,6 @@
     "continue-session": "Continuer la session",
     "end-session": "Terminer la session"
   },
-  "phone-number": "1-800-567-6868"
+  "phone-number": "1-800-567-6868",
+  "feedback-link": "Avez-vous trouvé ce que vous cherchiez ? <1>Donnez votre avis</1> sur l'outil de vérification du statut des passeports"
 }


### PR DESCRIPTION
…omponent.

## [ADO-XXX](https://dev.azure.com/DTS-STN/passport-status/_workitems/edit/xxx)

### Description

List of proposed changes:

- Added feedback link text and placeholder link to /email and /status result pages
- easier way to add full translated sentences with translated links in the middle of them to page. We should probably implement where we can

### What to test for/How to test

- go to /email
- enter dummy valid data everywhere
- notice text under button
- repeat for /status


### Additional Notes

Link url to come
