### PR TITLE
Refactor Layout component

### DIFF
--- a/__tests__/components/Layout.test.tsx
+++ b/__tests__/components/Layout.test.tsx
@@ -1,21 +1,8 @@
+import React from 'react'
 import { render, screen } from '@testing-library/react'
 import '@testing-library/jest-dom/extend-expect'
 import { axe, toHaveNoViolations } from 'jest-axe'
 import Layout from '../../components/Layout'
-
-// mocks useRouter to be able to use component' router.asPath
-jest.mock('next/router', () => ({
-  useRouter: jest.fn(),
-}))
-
-// the code below is to avoid the following error:
-//    "An update to Link inside a test was not wrapped in act(...)"
-jest.mock('next/link', () => ({
-  __esModule: true,
-  default: ({ children, href }) => (
-    <children.type {...children.props} href={href} />
-  ),
-}))
 
 //mock custom components
 jest.mock('../../components/MetaData')
@@ -25,7 +12,11 @@ jest.mock('../../components/Footer')
 expect.extend(toHaveNoViolations)
 
 describe('Layout with default text', () => {
-  const sut = <Layout meta={{}} header={{}} footer={{ links: {} }} />
+  const sut = (
+    <Layout meta={{ author: 'author', desc: 'desc', title: 'title' }}>
+      Content
+    </Layout>
+  )
 
   it('Layout contains a Main tag', () => {
     render(sut)

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -1,20 +1,23 @@
-import { FC } from 'react'
+import { FC, ReactNode } from 'react'
 import Header from './Header'
 import Footer from './Footer'
-import MetaData from './MetaData'
+import MetaData, { MetaDataProps } from './MetaData'
+import { useTranslation } from 'next-i18next'
 
 export interface LayoutProps {
-  children: React.ReactNode
-  meta: any
-  header: any
-  footer: any
+  children: ReactNode
+  meta: MetaDataProps
 }
 
-const Layout: FC<LayoutProps> = ({ children, meta, header, footer }) => {
+const Layout: FC<LayoutProps> = ({ children, meta }) => {
+  const { t } = useTranslation('common')
   return (
     <div className="flex flex-col min-h-screen">
-      <MetaData author={meta.author} desc={meta.desc} title={meta.title} />
-      <Header skipToMainText={header.skipToMain} gocLink={header.gocLink} />
+      <MetaData {...meta} />
+      <Header
+        skipToMainText={t('header.skip-to-main')}
+        gocLink={t('header.goc-link')}
+      />
       <main
         role="main"
         id="mainContent"
@@ -24,23 +27,23 @@ const Layout: FC<LayoutProps> = ({ children, meta, header, footer }) => {
       </main>
 
       <Footer
-        dateModifiedText={footer.dateModifiedText}
+        dateModifiedText={t('footer.date-modified-text')}
         footerLogoAltText="symbol2"
         footerLogoImage="/wmms-blk.svg"
         footerNav1="aboutGovernment"
         footerNav2="aboutThisSite"
         links={[
           {
-            link: footer.links.contactUsURL,
-            linkText: footer.links.contactUs,
+            link: t('footer.links.contact-us-url'),
+            linkText: t('footer.links.contact-us'),
           },
           {
-            link: footer.links.termsAndConditionURL,
-            linkText: footer.links.termsAndCondition,
+            link: t('footer.links.terms-and-condition-url'),
+            linkText: t('footer.links.terms-and-condition'),
           },
           {
-            link: footer.links.privacyURL,
-            linkText: footer.links.privacy,
+            link: t('footer.links.privacy-url'),
+            linkText: t('footer.links.privacy'),
           },
         ]}
       />

--- a/pages/email.tsx
+++ b/pages/email.tsx
@@ -84,9 +84,11 @@ export default function Email() {
 
   return (
     <Layout
-      meta={t('common:meta', { returnObjects: true })}
-      header={t('common:header', { returnObjects: true })}
-      footer={t('common:footer', { returnObjects: true })}
+      meta={{
+        author: t('common:meta.author'),
+        desc: t('common:meta.desc'),
+        title: t('common:meta.title'),
+      }}
     >
       <IdleTimeout />
       <h1 className="h1">{t('header')}</h1>

--- a/pages/expectations.tsx
+++ b/pages/expectations.tsx
@@ -21,9 +21,11 @@ const Expectations: FC = () => {
 
   return (
     <Layout
-      meta={t('common:meta', { returnObjects: true })}
-      header={t('common:header', { returnObjects: true })}
-      footer={t('common:footer', { returnObjects: true })}
+      meta={{
+        author: t('common:meta.author'),
+        desc: t('common:meta.desc'),
+        title: t('common:meta.title'),
+      }}
     >
       <h1 className="h1">{t('header-purpose')}</h1>
       <p>{t('can-check.description')}</p>

--- a/pages/landing.tsx
+++ b/pages/landing.tsx
@@ -12,9 +12,11 @@ const Landing: FC = () => {
 
   return (
     <Layout
-      meta={t('common:meta', { returnObjects: true })}
-      header={t('common:header', { returnObjects: true })}
-      footer={t('common:footer', { returnObjects: true })}
+      meta={{
+        author: t('common:meta.author'),
+        desc: t('common:meta.desc'),
+        title: t('common:meta.title'),
+      }}
     >
       <h1 className="h1">{t('header')}</h1>
       <p>{t('description')}</p>

--- a/pages/status.tsx
+++ b/pages/status.tsx
@@ -123,9 +123,11 @@ const Status: FC = () => {
 
   return (
     <Layout
-      meta={t('common:meta', { returnObjects: true })}
-      header={t('common:header', { returnObjects: true })}
-      footer={t('common:footer', { returnObjects: true })}
+      meta={{
+        author: t('common:meta.author'),
+        desc: t('common:meta.desc'),
+        title: t('common:meta.title'),
+      }}
     >
       <IdleTimeout />
       <h1 className="h1">{t('header')}</h1>

--- a/public/locales/defaultTranslations.json
+++ b/public/locales/defaultTranslations.json
@@ -1,7 +1,7 @@
 {
   "meta": {
     "author": "Service Canada",
-    "desc": "Index page - Page d'index",
-    "title": "Passport Application Status Checker (PASC) - Vérificateur du Statut de mon application pour un passport (VSAP)"
+    "desc": "Index page | Page d'index",
+    "title": "Check the status of your passport application - Canada.ca | Vérifiez l'état de votre demande de passeport - Canada.ca"
   }
 }

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -2,16 +2,16 @@
   "contact-us": "Contact us",
   "english": "English",
   "footer": {
-    "dateModifiedText": "Date Modified: ",
+    "date-modified-text": "Date Modified: ",
     "about-this-site": "About this Site",
     "canada-ca-alt-text": "Symbol of the Government of Canada",
     "links": {
-      "contactUs": "Contact information",
-      "contactUsURL": "https://www.canada.ca/en/contact.html",
+      "contact-us": "Contact information",
+      "contact-us-url": "https://www.canada.ca/en/contact.html",
       "privacy": "Privacy",
-      "privacyURL": "https://www.canada.ca/en/transparency/privacy.html",
-      "termsAndCondition": "Terms and conditions",
-      "termsAndConditionURL": "https://www.canada.ca/en/transparency/terms.html"
+      "privacy-url": "https://www.canada.ca/en/transparency/privacy.html",
+      "terms-and-condition": "Terms and conditions",
+      "terms-and-condition-url": "https://www.canada.ca/en/transparency/terms.html"
     }
   },
   "found-errors_one": "The following error was found in the form:",
@@ -19,8 +19,8 @@
   "francais": "Français",
   "goc": "Government of Canada",
   "header": {
-    "gocLink": "https://www.canada.ca/en.html",
-    "skipToMain": "Skip to main content"
+    "goc-link": "https://www.canada.ca/en.html",
+    "skip-to-main": "Skip to main content"
   },
   "header-canada-ca-alt-text": "Symbol of the Government of Canada",
   "language-selection": "Language selection",
@@ -28,7 +28,7 @@
   "meta": {
     "author": "Service Canada",
     "desc": "English",
-    "title": "Passport Application Status Checker (PASC)"
+    "title": "Check the status of your passport application - Canada.ca"
   },
   "required": "(required)",
   "service-and-benefits": "Service and Benefits",

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -2,16 +2,16 @@
   "contact-us": "Nous contacter",
   "english": "English",
   "footer": {
-    "dateModifiedText": "Date de modification\u00A0: ",
+    "date-modified-text": "Date de modification\u00A0: ",
     "about-this-site": "À propos de ce site",
     "canada-ca-alt-text": "Symbole du gouvernement du Canada",
     "links": {
-      "contactUs": "Contactez-nous",
-      "contactUsURL": "https://www.canada.ca/fr/contact.html",
+      "contact-us": "Contactez-nous",
+      "contact-us-url": "https://www.canada.ca/fr/contact.html",
       "privacy": "Confidentialité",
-      "privacyURL": "https://www.canada.ca/en/transparency/privacy.html",
-      "termsAndCondition": "Avis",
-      "termsAndConditionURL": "https://www.canada.ca/en/transparency/terms.html"
+      "privacy-url": "https://www.canada.ca/fr/transparence/confidentialite.html",
+      "terms-and-condition": "Avis",
+      "terms-and-condition-url": "https://www.canada.ca/fr/transparence/avis.html"
     }
   },
   "found-errors_one": "L'erreur suivante a été trouvée dans le formulaire\u00A0: ",
@@ -19,8 +19,8 @@
   "francais": "Français",
   "goc": "Governement du Canada",
   "header": {
-    "gocLink": "https://www.canada.ca/fr.html",
-    "skipToMain": "Passer au contenu principal"
+    "goc-link": "https://www.canada.ca/fr.html",
+    "skip-to-main": "Passer au contenu principal"
   },
   "header-canada-ca-alt-text": "Symbole du gouvernement du Canada",
   "language-selection": "Sélection de la langue",
@@ -28,7 +28,7 @@
   "meta": {
     "author": "Service Canada",
     "desc": "Français",
-    "title": "Vérificateur du Statut de mon application pour un passport (VSAP)"
+    "title": "Vérifiez l'état de votre demande de passeport - Canada.ca"
   },
   "required": "(obligatoire)",
   "service-and-benefits": "Service et avantages",


### PR DESCRIPTION
## [ADO-XXX](https://dev.azure.com/DTS-STN/passport-status/_workitems/edit/xxx)

### Description

List of proposed changes:

- Refactor Layout component and use `useTranslation` hook within the component.
- Move away of using `returnObjects: true` with `useTranslation` hook because error can only be detected at runtime.
- Change page meta title to `Check the status of your passport application - Canada.ca` in English and `Vérifiez l'état de votre demande de passeport - Canada.ca` in French. Official page meta title and description will be provided.
- Fix footer privacy-url and terms-and-condition-url in french local.

### What to test for/How to test

Load the application and ensure the layout locales are correct.

### Additional Notes
