### PR TITLE
Made ingress and helfmile changes for dev-sced deployment

### DIFF
--- a/helmfile/helmfile.yaml
+++ b/helmfile/helmfile.yaml
@@ -3,6 +3,9 @@ environments:
   prod-blue:
   prod-green:
 
+helmDefaults:
+  createNamespace: false
+
 releases:
 # Single Tier Website
   - name: {{ requiredEnv "PROJECT" }}-{{ requiredEnv "BRANCH" | lower }}

--- a/helmfile/overrides/passport-status/passport-status.yaml.gotmpl
+++ b/helmfile/overrides/passport-status/passport-status.yaml.gotmpl
@@ -44,14 +44,7 @@ service:
     prometheus.io/port: "3000"
 ingress:
     enabled: true
-    annotations: 
-      cert-manager.io/cluster-issuer: letsencrypt-prod
-      appgw.ingress.kubernetes.io/ssl-redirect: "true"
-      kubernetes.io/ingress.class: azure/application-gateway
-    tls:
-      - hosts:
-          - {{ requiredEnv "PROJECT" }}-{{ requiredEnv "BRANCH" | lower }}.{{ requiredEnv "BASE_DOMAIN" }}
-        secretName: ingress-tls-{{ requiredEnv "BRANCH" | lower }}
+    className: nginx
     hosts:
     - host: {{ requiredEnv "PROJECT" }}-{{ requiredEnv "BRANCH" | lower }}.{{ requiredEnv "BASE_DOMAIN" }}
       paths:

--- a/helmfile/sampleContext.sh
+++ b/helmfile/sampleContext.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+export APP_LABEL_CLASSIFICATION=protectedB
+export APP_LABEL_CSD_ID=233240
+export APP_LABEL_DEPARTMENT=ESDC
+export APP_LABEL_DIRECTORATE=EDS
+export APP_LABEL_DIVISION=dsajfdas
+export APP_LABEL_IMMUTABLE=true
+export APP_LABEL_PRODUCT_OWNER=gfdafdas
+export APP_LABEL_PROJECT_ID=16700
+export APP_LABEL_SECTION=fdasfda
+export APP_LABEL_BRANCH=IITB
+export DOCKER_TAG=latest
+export BRANCH=main
+export PROJECT=passport-status
+export CLOUD_ACR_DOMAIN=dtsrhpdevscedacr.azurecr.io
+export BASE_DOMAIN=dev-dp.dts-stn.com


### PR DESCRIPTION
I've made the necessary changes to have the passport status frontend deploy to the new RHP SCED Dev environment. The ingress class is now nginx, TLS config is removed as it's currently terminating at the app gateway (Work in progress to restore e2e TLS). I also added a stub context script that will allow you to quickly set all necessary environment variables for local debugging of helmfile deployments.