### PR TITLE
Change input help-block text color

### DIFF
--- a/components/InputField.tsx
+++ b/components/InputField.tsx
@@ -70,7 +70,7 @@ const InputField: FC<InputFieldProps> = ({
       />
       {helpMessage && (
         <div
-          className="text-gray-helpText text-base max-w-prose mt-1.5"
+          className="text-gray-600 text-base max-w-prose mt-1.5"
           id={inputHelpMessageId}
         >
           {helpMessage}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -50,7 +50,6 @@ module.exports = {
           default: '#dcdee1',
           dark: '#cfd1d5',
           deep: '#bbbfc5',
-          helpText: '#6c757d',
           modal: '#999999',
         },
         orange: {


### PR DESCRIPTION
## [ADO-1889](https://dev.azure.com/DTS-STN/passport-status/_workitems/edit/1889) Accessibility - Text elements must have sufficient color contrast against the background

### Description

List of proposed changes:

- Change input's help text color to pass a11y color contrast

### What to test for/How to test

Run the application and go to `/email` then check the color of the email address field's information. It should be `text-gray-600` that would be equivalent to `#4b5563`. It's the same as Tailwind CSS form example: https://v1.tailwindcss.com/components/forms#form-grid.

I've checked the `.help-block` class from Canada.ca website css and it doesn't pass AAA constrast ratio.

```css
.help-block{
    display: block;
    margin-top: 5px;
    margin-bottom: 10px;
    color: #737373
}
```

![image](https://user-images.githubusercontent.com/114004123/208453012-34123ea6-b6ff-48d7-9ab9-f1f14023ca9f.png)


### Additional Notes

![image](https://user-images.githubusercontent.com/114004123/208452241-4b40432e-d816-41c2-a83f-2f22f7a53425.png)

