### PR TITLE
Go to heading after results or going back

### DIFF
--- a/cypress/e2e/404.cy.js
+++ b/cypress/e2e/404.cy.js
@@ -3,7 +3,7 @@
 describe('not found page loads', () => {
   beforeEach(() => {
     cy.visit('/expectations')
-    cy.get('#confirmBtn button').first().click()
+    cy.get('#btn-agree').first().click()
     cy.request({url: '/404', failOnStatusCode: false}).its('status').should('equal', 404)
     cy.visit('/404', {failOnStatusCode: false})
   })

--- a/cypress/e2e/email.cy.js
+++ b/cypress/e2e/email.cy.js
@@ -3,7 +3,7 @@
 describe('email page loads', () => {
     beforeEach(() => {
       cy.visit('/expectations')
-      cy.get('#confirmBtn button').first().click()
+      cy.get('#btn-agree').first().click()
       cy.visit('/email')
     })
 
@@ -29,10 +29,31 @@ describe('email page loads', () => {
     })
 })
 
+describe('responses', ()=>{
+  it('loads result', ()=>{
+    cy.visit('/expectations')
+    cy.get('#btn-agree').first().click()
+    cy.visit('/email')
+    cy.get('#email').type('yanis.pierre@example.com')
+    cy.get('#givenName').type('Yanis')
+    cy.get('#surname').type('Piérre')
+    cy.get('#dateOfBirth').type('1972-07-29')
+    cy.get('#btn-submit').click()
+    cy.get('#response-result').should('exist')
+    cy.focused().should('have.prop', 'tagName' ).should('eq', 'H1')
+  })
+
+  it('loads result has no detectable a11y violations', ()=>{
+    cy.injectAxe();
+    cy.wait(500);
+    cy.checkA11y()
+  })
+})
+
 describe('cancel email esrf', ()=>{
   it('loads dialog', ()=>{
     cy.visit('/expectations')
-    cy.get('#confirmBtn button').first().click()
+    cy.get('#btn-agree').first().click()
     cy.visit('/email')
     cy.get('#btn-cancel').click()
     cy.get('[role="dialog"]').should('exist')

--- a/cypress/e2e/landing.cy.js
+++ b/cypress/e2e/landing.cy.js
@@ -1,7 +1,7 @@
 describe('landing page loads', () => {
     beforeEach(() => {
       cy.visit('/expectations')
-      cy.get('#confirmBtn button').first().click()
+      cy.get('#btn-agree').first().click()
       cy.visit('/landing')
     })
 
@@ -27,7 +27,7 @@ describe('landing page loads', () => {
 describe('user does not ESRF number',()=>{
     it('should redirect to the email page',()=>{
       cy.visit('/expectations')
-      cy.get('#confirmBtn button').first().click()
+      cy.get('#btn-agree').first().click()
       cy.visit('/landing')
       cy.get('#without-esrf').click()
       cy.location('pathname').should("equal", "/en/email");
@@ -37,7 +37,7 @@ describe('user does not ESRF number',()=>{
 describe('user does have ESRF number',()=>{
   it('should redirect to the form',()=>{
     cy.visit('/expectations')
-    cy.get('#confirmBtn button').first().click()
+    cy.get('#btn-agree').first().click()
     cy.visit('/landing')
     cy.get('#with-esrf').click()
     cy.location('pathname').should("equal", "/en/status");

--- a/cypress/e2e/status.cy.js
+++ b/cypress/e2e/status.cy.js
@@ -3,7 +3,7 @@
 describe('status page loads', () => {
   beforeEach(() => {
     cy.visit('/expectations')
-    cy.get('#confirmBtn button').first().click()
+    cy.get('#btn-agree').first().click()
     cy.visit('/status')
   })
 
@@ -32,7 +32,7 @@ describe('status page loads', () => {
 describe('ESRF field validation', ()=>{
   beforeEach(() => {
     cy.visit('/expectations')
-    cy.get('#confirmBtn button').first().click()
+    cy.get('#btn-agree').first().click()
     cy.visit('/status')
   })
 
@@ -51,7 +51,7 @@ describe('ESRF field validation', ()=>{
 describe('givenName field validation', ()=>{
   beforeEach(() => {
     cy.visit('/expectations')
-    cy.get('#confirmBtn button').first().click()
+    cy.get('#btn-agree').first().click()
     cy.visit('/status')
   })
 
@@ -70,7 +70,7 @@ describe('givenName field validation', ()=>{
 describe('surname field validation', ()=>{
   beforeEach(() => {
     cy.visit('/expectations')
-    cy.get('#confirmBtn button').first().click()
+    cy.get('#btn-agree').first().click()
     cy.visit('/status')
   })
 
@@ -89,7 +89,7 @@ describe('surname field validation', ()=>{
 describe('Date of Birth field validation', ()=>{
   beforeEach(() => {
     cy.visit('/expectations')
-    cy.get('#confirmBtn button').first().click()
+    cy.get('#btn-agree').first().click()
     cy.visit('/status')
   })
 
@@ -116,7 +116,7 @@ describe('Date of Birth field validation', ()=>{
 describe('responses', ()=>{
   it('loads result', ()=>{
     cy.visit('/expectations')
-    cy.get('#confirmBtn button').first().click()
+    cy.get('#btn-agree').first().click()
     cy.visit('/status')
     cy.get('#esrf').type('A02D85ED')
     cy.get('#givenName').type('Yanis')
@@ -124,6 +124,7 @@ describe('responses', ()=>{
     cy.get('#dateOfBirth').type('1972-07-29')
     cy.get('#btn-submit').click()
     cy.get('#response-result').should('exist')
+    cy.focused().should('have.prop', 'tagName' ).should('eq', 'H1')
   })
 
   it('loads result has no detectable a11y violations', ()=>{
@@ -134,7 +135,7 @@ describe('responses', ()=>{
 
   it('loads no result', ()=>{
     cy.visit('/expectations')
-    cy.get('#confirmBtn button').first().click()
+    cy.get('#btn-agree').first().click()
     cy.visit('/status')
     cy.get('#esrf').type('A1234567')
     cy.get('#givenName').type('John')
@@ -142,6 +143,7 @@ describe('responses', ()=>{
     cy.get('#dateOfBirth').type('1990-12-01')
     cy.get('#btn-submit').click()
     cy.get('#response-no-result').should('exist')
+    cy.focused().should('have.prop', 'tagName' ).should('eq', 'H1')
   })
 
   it('no result has no detectable a11y violations', ()=>{
@@ -154,7 +156,7 @@ describe('responses', ()=>{
 describe('cancel check status', ()=>{
   it('loads dialog', ()=>{
     cy.visit('/expectations')
-    cy.get('#confirmBtn button').first().click()
+    cy.get('#btn-agree').first().click()
     cy.visit('/status')
     cy.get('#btn-cancel').click()
     cy.get('[role="dialog"]').should('exist')

--- a/pages/email.tsx
+++ b/pages/email.tsx
@@ -5,7 +5,7 @@ import { useRouter } from 'next/router'
 import { Trans, useTranslation } from 'next-i18next'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import Layout from '../components/Layout'
-import { FC, useMemo, useState } from 'react'
+import { FC, useCallback, useMemo, useRef, useState } from 'react'
 import ErrorSummary, {
   ErrorSummaryItem,
   getErrorSummaryItems,
@@ -41,14 +41,20 @@ const validationSchema = Yup.object({
 const Email: FC = () => {
   const { t } = useTranslation('email')
   const router = useRouter()
+  const headingRef = useRef<HTMLHeadingElement>(null)
   const [modalOpen, setModalOpen] = useState(false)
+
+  const scrollToHeading = useCallback(() => {
+    headingRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center' })
+    headingRef.current?.focus()
+  }, [headingRef])
 
   const {
     error: emailEsrfError,
     isLoading: isEmailEsrfLoading,
     isSuccess: isEmailEsrfSuccess,
     mutate: emailEsrf,
-  } = useEmailEsrf()
+  } = useEmailEsrf({ onSuccess: () => scrollToHeading() })
 
   const {
     errors: formikErrors,
@@ -92,10 +98,12 @@ const Email: FC = () => {
       }}
     >
       <IdleTimeout />
-      <h1 className="h1">{t('header')}</h1>
+      <h1 ref={headingRef} className="h1" tabIndex={-1}>
+        {t('header')}
+      </h1>
 
       {isEmailEsrfSuccess ? (
-        <>
+        <div id="response-result">
           <h2 className="h2">{t('email-confirmation-msg.request-received')}</h2>
           <p>{t('email-confirmation-msg.if-exists')}</p>
           <p>
@@ -108,7 +116,7 @@ const Email: FC = () => {
               <ExternalLink href="https://example.com">Link</ExternalLink>
             </Trans>
           </div>
-        </>
+        </div>
       ) : (
         <form onSubmit={handleFormikSubmit} id="form-email-esrf">
           <p>{t('header-messages.fill-in-field')}</p>

--- a/pages/expectations.tsx
+++ b/pages/expectations.tsx
@@ -54,13 +54,12 @@ const Expectations: FC = () => {
       </p>
       <h2 className="h2">{t('header-privacy')}</h2>
       <p>{t('description-privacy')}</p>
-      <div id="confirmBtn">
-        <ActionButton
-          style="primary"
-          text={t('button-agree')}
-          onClick={handleOnAgreeClick}
-        />
-      </div>
+      <ActionButton
+        id="btn-agree"
+        style="primary"
+        text={t('button-agree')}
+        onClick={handleOnAgreeClick}
+      />
     </Layout>
   )
 }

--- a/pages/status.tsx
+++ b/pages/status.tsx
@@ -5,6 +5,7 @@ import {
   useCallback,
   useMemo,
   useState,
+  useRef,
 } from 'react'
 import { GetStaticProps } from 'next'
 import { useRouter } from 'next/router'
@@ -48,7 +49,13 @@ const validationSchema = Yup.object({
 const Status: FC = () => {
   const { t } = useTranslation('status')
   const router = useRouter()
+  const headingRef = useRef<HTMLHeadingElement>(null)
   const [modalOpen, setModalOpen] = useState(false)
+
+  const scrollToHeading = useCallback(() => {
+    headingRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center' })
+    headingRef.current?.focus()
+  }, [headingRef])
 
   const {
     errors: formikErrors,
@@ -88,7 +95,7 @@ const Status: FC = () => {
     formikStatus === 'submitted' ? formikValues : initialValues,
     {
       enabled: formikStatus === 'submitted',
-      onSuccess: () => window.scrollTo(0, 0),
+      onSuccess: () => scrollToHeading(),
     }
   )
 
@@ -106,9 +113,15 @@ const Status: FC = () => {
       }
       setFormikStatus(undefined)
       removeCheckStatusResponse()
-      window.scrollTo(0, 0)
+      scrollToHeading()
     },
-    [checkStatusResponse, setFormikStatus, removeCheckStatusResponse, router]
+    [
+      checkStatusResponse,
+      setFormikStatus,
+      removeCheckStatusResponse,
+      scrollToHeading,
+      router,
+    ]
   )
 
   const handleOnESRFChange: ChangeEventHandler<HTMLInputElement> = useCallback(
@@ -130,138 +143,134 @@ const Status: FC = () => {
       }}
     >
       <IdleTimeout />
-      <h1 className="h1">{t('header')}</h1>
-      {(() => {
-        if (checkStatusResponse !== undefined) {
-          return (
-            <>
-              <CheckStatusInfo
-                id={
-                  checkStatusResponse === null
-                    ? 'response-no-result'
-                    : 'response-result'
-                }
-                onGoBackClick={handleOnGoBackClick}
-                goBackText={
-                  checkStatusResponse === null ? t('previous') : t('reset')
-                }
-                goBackStyle="primary"
-                checkAgainText={t('check-again')}
-                checkStatusResponse={checkStatusResponse}
+      <h1 ref={headingRef} className="h1" tabIndex={-1}>
+        {t('header')}
+      </h1>
+      {checkStatusResponse !== undefined ? (
+        <>
+          <CheckStatusInfo
+            id={
+              checkStatusResponse === null
+                ? 'response-no-result'
+                : 'response-result'
+            }
+            onGoBackClick={handleOnGoBackClick}
+            goBackText={
+              checkStatusResponse === null ? t('previous') : t('reset')
+            }
+            goBackStyle="primary"
+            checkAgainText={t('check-again')}
+            checkStatusResponse={checkStatusResponse}
+          />
+          <div className="mt-10">
+            <Trans i18nKey={'common:feedback-link'}>
+              Insert feedback{' '}
+              <ExternalLink href="https://example.com">Link</ExternalLink>
+            </Trans>
+          </div>
+        </>
+      ) : (
+        <form onSubmit={handleFormikSubmit} id="form-get-status">
+          <p>{t('header-messages.fill-in-field')}</p>
+          <p>
+            <strong>{t('header-messages.matches')}</strong>
+          </p>
+          <p>{t('header-messages.for-child')}</p>
+          <p>{t('header-messages.passport-officer')}</p>
+          {errorSummaryItems.length > 0 && (
+            <ErrorSummary
+              id="error-summary-get-status"
+              summary={t('common:found-errors', {
+                count: errorSummaryItems.length,
+              })}
+              errors={errorSummaryItems}
+            />
+          )}
+          <InputField
+            id="esrf"
+            name="esrf"
+            label={t('esrf.label')}
+            onChange={handleOnESRFChange}
+            value={formikValues.esrf}
+            errorMessage={formikErrors.esrf && t(formikErrors.esrf)}
+            textRequired={t('common:required')}
+            required
+          />
+          <Collapse title={t('collapse-file-number-title')}>
+            <div className="border-t mt-3 p-3 max-w">
+              <ExampleImage
+                title={t('receipt-image-1.title')}
+                description={t('receipt-image-1.description-alt')}
+                imageProps={{
+                  src: t('receipt-image-1.src'),
+                  alt: t('receipt-image-1.description-alt'),
+                  width: 350,
+                  height: 550,
+                }}
               />
-              <div className="mt-10">
-                <Trans i18nKey={'common:feedback-link'}>
-                  Insert feedback{' '}
-                  <ExternalLink href="https://example.com">Link</ExternalLink>
-                </Trans>
-              </div>
-            </>
-          )
-        }
-
-        return (
-          <form onSubmit={handleFormikSubmit} id="form-get-status">
-            <p>{t('header-messages.fill-in-field')}</p>
-            <p>
-              <strong>{t('header-messages.matches')}</strong>
-            </p>
-            <p>{t('header-messages.for-child')}</p>
-            <p>{t('header-messages.passport-officer')}</p>
-            {errorSummaryItems.length > 0 && (
-              <ErrorSummary
-                id="error-summary-get-status"
-                summary={t('common:found-errors', {
-                  count: errorSummaryItems.length,
-                })}
-                errors={errorSummaryItems}
-              />
-            )}
-            <InputField
-              id="esrf"
-              name="esrf"
-              label={t('esrf.label')}
-              onChange={handleOnESRFChange}
-              value={formikValues.esrf}
-              errorMessage={formikErrors.esrf && t(formikErrors.esrf)}
-              textRequired={t('common:required')}
-              required
-            />
-            <Collapse title={t('collapse-file-number-title')}>
-              <div className="border-t mt-3 p-3 max-w">
-                <ExampleImage
-                  title={t('receipt-image-1.title')}
-                  description={t('receipt-image-1.description-alt')}
-                  imageProps={{
-                    src: t('receipt-image-1.src'),
-                    alt: t('receipt-image-1.description-alt'),
-                    width: 350,
-                    height: 550,
-                  }}
-                />
-                <ExampleImage
-                  title={t('receipt-image-2.title')}
-                  description={t('receipt-image-2.description-alt')}
-                  imageProps={{
-                    src: t('receipt-image-2.src'),
-                    alt: t('receipt-image-2.description-alt'),
-                    width: 350,
-                    height: 550,
-                  }}
-                />
-              </div>
-            </Collapse>
-            <InputField
-              id="givenName"
-              name="givenName"
-              label={t('given-name.label')}
-              onChange={handleFormikChange}
-              value={formikValues.givenName}
-              errorMessage={formikErrors.givenName && t(formikErrors.givenName)}
-              textRequired={t('common:required')}
-              required
-            />
-            <InputField
-              id="surname"
-              name="surname"
-              label={t('surname.label')}
-              onChange={handleFormikChange}
-              value={formikValues.surname}
-              errorMessage={formikErrors.surname && t(formikErrors.surname)}
-              textRequired={t('common:required')}
-              required
-            />
-            <InputField
-              id="dateOfBirth"
-              name="dateOfBirth"
-              type="date"
-              label={t('date-of-birth.label')}
-              onChange={handleFormikChange}
-              value={formikValues.dateOfBirth}
-              errorMessage={
-                formikErrors.dateOfBirth && t(formikErrors.dateOfBirth)
-              }
-              textRequired={t('common:required')}
-              max={'9999-12-31'}
-              required
-            />
-            <div className="flex gap-2 flex-wrap">
-              <ActionButton
-                id="btn-submit"
-                disabled={isCheckStatusLoading}
-                type="submit"
-                text={t('check-status')}
-                style="primary"
-              />
-              <ActionButton
-                id="btn-cancel"
-                disabled={isCheckStatusLoading}
-                text={t('common:modal-go-back.cancel-button')}
-                onClick={() => setModalOpen(true)}
+              <ExampleImage
+                title={t('receipt-image-2.title')}
+                description={t('receipt-image-2.description-alt')}
+                imageProps={{
+                  src: t('receipt-image-2.src'),
+                  alt: t('receipt-image-2.description-alt'),
+                  width: 350,
+                  height: 550,
+                }}
               />
             </div>
-          </form>
-        )
-      })()}
+          </Collapse>
+          <InputField
+            id="givenName"
+            name="givenName"
+            label={t('given-name.label')}
+            onChange={handleFormikChange}
+            value={formikValues.givenName}
+            errorMessage={formikErrors.givenName && t(formikErrors.givenName)}
+            textRequired={t('common:required')}
+            required
+          />
+          <InputField
+            id="surname"
+            name="surname"
+            label={t('surname.label')}
+            onChange={handleFormikChange}
+            value={formikValues.surname}
+            errorMessage={formikErrors.surname && t(formikErrors.surname)}
+            textRequired={t('common:required')}
+            required
+          />
+          <InputField
+            id="dateOfBirth"
+            name="dateOfBirth"
+            type="date"
+            label={t('date-of-birth.label')}
+            onChange={handleFormikChange}
+            value={formikValues.dateOfBirth}
+            errorMessage={
+              formikErrors.dateOfBirth && t(formikErrors.dateOfBirth)
+            }
+            textRequired={t('common:required')}
+            max={'9999-12-31'}
+            required
+          />
+          <div className="flex gap-2 flex-wrap">
+            <ActionButton
+              id="btn-submit"
+              disabled={isCheckStatusLoading}
+              type="submit"
+              text={t('check-status')}
+              style="primary"
+            />
+            <ActionButton
+              id="btn-cancel"
+              disabled={isCheckStatusLoading}
+              text={t('common:modal-go-back.cancel-button')}
+              onClick={() => setModalOpen(true)}
+            />
+          </div>
+        </form>
+      )}
       <Modal
         open={modalOpen}
         actionButtons={[


### PR DESCRIPTION
## [ADO-1891](https://dev.azure.com/DTS-STN/passport-status/_workitems/edit/1891) Accessibility - information is missed by screen reader

### Description

List of proposed changes:

- Scroll and focus on heading `H1` after results or going back to the form

### What to test for/How to test

Run the application and navigate withing the form `/status` and `/email` with your keyboard. The page should scroll and focus on heading `H1` after a results is displayed or you are going back to the form.

### Additional Notes

Focus Styles on Non-Interactive Elements?
https://css-tricks.com/focus-styles-non-interactive-elements/#:~:text=Headers%20aren't%20focusable%20elements,'t%20%E2%80%9Cinteractive%E2%80%9D%20elements.

React useRef hook
https://www.w3schools.com/react/react_useref.asp