### PR TITLE
Add missing units tests and cypress tests for expectation page

### DIFF
--- a/__tests__/components/Collapse.test.tsx
+++ b/__tests__/components/Collapse.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom/extend-expect'
+import { axe, toHaveNoViolations } from 'jest-axe'
+import Collapse from '../../components/Collapse'
+
+expect.extend(toHaveNoViolations)
+
+describe('Collapse', () => {
+  const sut = (
+    <Collapse title="title">
+      <p>content</p>
+    </Collapse>
+  )
+
+  it('renders', () => {
+    render(sut)
+    const screenText = screen.getByText('content')
+    expect(screenText).toBeInTheDocument()
+  })
+
+  it('meets a11y', async () => {
+    const { container } = render(sut)
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
+  })
+})

--- a/__tests__/components/DateSelect.test.tsx
+++ b/__tests__/components/DateSelect.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom/extend-expect'
+import { axe, toHaveNoViolations } from 'jest-axe'
+import DateSelect from '../../components/DateSelect'
+
+expect.extend(toHaveNoViolations)
+
+describe('DateSelect', () => {
+  const sut = (
+    <DateSelect
+      dateSelectLabelId="date-select-label"
+      id="date-select"
+      label="Year"
+      onChange={jest.fn()}
+      type="year"
+      options={[{ value: '1900', label: '1900' }]}
+      value="1900"
+    />
+  )
+
+  it('renders', () => {
+    render(sut)
+    const screenText = screen.getByText('Year')
+    expect(screenText).toBeInTheDocument()
+  })
+
+  it('meets a11y', async () => {
+    const { container } = render(sut)
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
+  })
+})

--- a/__tests__/components/DateSelectField.test.tsx
+++ b/__tests__/components/DateSelectField.test.tsx
@@ -1,0 +1,37 @@
+import { FC } from 'react'
+import { render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom/extend-expect'
+import { axe, toHaveNoViolations } from 'jest-axe'
+import DateSelectField from '../../components/DateSelectField'
+import { DateSelectProps } from '../../components/DateSelect'
+
+expect.extend(toHaveNoViolations)
+
+const DateSelectMock: FC<DateSelectProps> = ({ label }: DateSelectProps) => {
+  return <div data-testid="date-selector">{label}</div>
+}
+
+jest.mock('../../components/DateSelect', () => DateSelectMock)
+
+describe('DateSelectField', () => {
+  const sut = (
+    <DateSelectField
+      id="date-picker"
+      label="Date Picker"
+      onChange={jest.fn()}
+      value="Some value"
+    />
+  )
+
+  it('renders', () => {
+    render(sut)
+    const screenText = screen.getByText('Date Picker')
+    expect(screenText).toBeInTheDocument()
+  })
+
+  it('meets a11y', async () => {
+    const { container } = render(sut)
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
+  })
+})

--- a/__tests__/components/ExampleImage.test.tsx
+++ b/__tests__/components/ExampleImage.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import '@testing-library/jest-dom/extend-expect'
+import { axe, toHaveNoViolations } from 'jest-axe'
+import ExampleImage from '../../components/ExampleImage'
+
+expect.extend(toHaveNoViolations)
+
+describe('ExampleImage', () => {
+  const sut = (
+    <ExampleImage
+      title="title"
+      description="content"
+      imageProps={{
+        src: '/Receipt1_EN.png',
+        alt: 'This is an image',
+        width: 350,
+        height: 350,
+      }}
+    />
+  )
+
+  it('renders', async () => {
+    render(sut)
+    const screenText = screen.getByText('content')
+    expect(screenText).toBeInTheDocument()
+    await waitFor(() => {
+      const img = screen.getByAltText('This is an image')
+      expect(img.getAttribute('src')).toContain('Receipt1_EN.png')
+    })
+  })
+
+  it('meets a11y', async () => {
+    const { container } = render(sut)
+    const results = await axe(container)
+    expect(results).toHaveNoViolations()
+  })
+})

--- a/__tests__/components/IdleTimeout.test.tsx
+++ b/__tests__/components/IdleTimeout.test.tsx
@@ -1,0 +1,28 @@
+import { FC } from 'react'
+import { render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom/extend-expect'
+import IdleTimeout from '../../components/IdleTimeout'
+import { ModalProps } from '../../components/Modal'
+
+const ModalMock: FC<ModalProps> = ({ open }: ModalProps) => {
+  return <div data-testid="modal">{open ? 'modal-opened' : 'modal-closed'}</div>
+}
+
+jest.mock('../../components/Modal', () => ModalMock)
+
+describe('IdleTimeout', () => {
+  let modal: HTMLElement
+
+  it('renders with modal closed', () => {
+    render(<IdleTimeout timeout={1000} />)
+    modal = screen.getByTestId('modal')
+    expect(modal).toBeInTheDocument()
+    expect(modal.textContent).toMatch('modal-closed')
+  })
+
+  it('renders with modal opened after 1 second timeout', () => {
+    setTimeout(function () {
+      expect(modal.textContent).toMatch('modal-opened')
+    }, 2000)
+  })
+})

--- a/cypress/e2e/expectations.cy.js
+++ b/cypress/e2e/expectations.cy.js
@@ -1,0 +1,29 @@
+describe('expectations page loads', () => {
+    beforeEach(() => {
+        cy.visit('/expectations')
+      })
+
+    it('displays the expectations page', () => {
+        cy.location('pathname').should("equal", "/en/expectations");
+    })
+
+    it('should display the button to accept terms', () => {
+        cy.get('#btn-agree').should('be.visible')
+    })
+
+    it('should redirect to the expectations page if terms have not been accepted yet', () => {
+        cy.visit('/landing')
+        cy.location('pathname').should("equal", "/en/expectations");
+    })
+
+    it('should redirect to the landing page once terms have been accepted', () => {
+        cy.get('#btn-agree').first().click()
+        cy.location('pathname').should("equal", "/en/landing");
+    })
+
+    it('has no detectable a11y violations on load', () => {
+        cy.injectAxe();
+        cy.wait(500);
+        cy.checkA11y()
+      })
+})


### PR DESCRIPTION
## [ADO-1919](https://dev.azure.com/DTS-STN/passport-status/_workitems/edit/1919)

### Description
This PR adds unit tests for components that were previously missing, as well as cypress tests for the expectations page.

### What to test for/How to test
1. Pull in branch
2. Type `npm run test:unit` and ensure all tests pass
3. Type `npm run e2e` and ensure all tests pass
