### PR TITLE
Update ExampleImage to use figure, update content

### DIFF
--- a/components/ExampleImage.tsx
+++ b/components/ExampleImage.tsx
@@ -1,5 +1,5 @@
 import { FC } from 'react'
-import Image from 'next/image'
+import Image from 'next/future/image'
 
 export interface ImageProps {
   src: string
@@ -23,13 +23,18 @@ const ExampleImage: FC<ExampleImageProps> = ({
       <p>
         <strong>{title}</strong>
       </p>
-      <Image
-        src={imageProps.src}
-        alt={imageProps.alt}
-        width={imageProps.width}
-        height={imageProps.height}
-      />
-      <p>{description}</p>
+      <figure className="md:w-3/5 bg-white rounded-lg drop-shadow-lg border mb-6 p-1">
+        <Image
+          src={imageProps.src}
+          alt={imageProps.alt}
+          width={imageProps.width}
+          height={imageProps.height}
+          className="w-full"
+        />
+        <figcaption className="px-5 py-3 text-lg">
+          <strong>{description}</strong>
+        </figcaption>
+      </figure>
     </>
   )
 }

--- a/pages/landing.tsx
+++ b/pages/landing.tsx
@@ -39,24 +39,25 @@ const Landing: FC = () => {
           />
         </div>
       </div>
-      <Collapse title={t('collapse-file-number-title')}>
-        <div className="border-t mt-3 p-3 max-w">
+      <Collapse title={t('common:collapse-file-number-title')}>
+        <div className="border-t mt-3 p-3 max-w-prose">
+          <p>{t('common:receipt-explanation')}</p>
           <ExampleImage
-            title={t('receipt-image-1.title')}
-            description={t('receipt-image-1.description-alt')}
+            title={t('common:receipt-image-1.title')}
+            description={t('common:receipt-image-1.descriptive-text')}
             imageProps={{
-              src: t('receipt-image-1.src'),
-              alt: t('receipt-image-1.description-alt'),
+              src: t('common:receipt-image-1.src'),
+              alt: t('common:receipt-image-1.alt'),
               width: 350,
               height: 550,
             }}
           />
           <ExampleImage
-            title={t('receipt-image-2.title')}
-            description={t('receipt-image-2.description-alt')}
+            title={t('common:receipt-image-2.title')}
+            description={t('common:receipt-image-2.descriptive-text')}
             imageProps={{
-              src: t('receipt-image-2.src'),
-              alt: t('receipt-image-2.description-alt'),
+              src: t('common:receipt-image-2.src'),
+              alt: t('common:receipt-image-2.alt'),
               width: 350,
               height: 550,
             }}

--- a/pages/status.tsx
+++ b/pages/status.tsx
@@ -211,7 +211,7 @@ const Status: FC = () => {
               <p>{t('common:receipt-explanation')}</p>
               <ExampleImage
                 title={t('common:receipt-image-1.title')}
-                description={t('common:receipt-image-1.description-alt')}
+                description={t('common:receipt-image-1.descriptive-text')}
                 imageProps={{
                   src: t('common:receipt-image-1.src'),
                   alt: t('common:receipt-image-1.alt'),
@@ -221,7 +221,7 @@ const Status: FC = () => {
               />
               <ExampleImage
                 title={t('common:receipt-image-2.title')}
-                description={t('common:receipt-image-2.description-alt')}
+                description={t('common:receipt-image-2.descriptive-text')}
                 imageProps={{
                   src: t('common:receipt-image-2.src'),
                   alt: t('common:receipt-image-2.alt'),

--- a/pages/status.tsx
+++ b/pages/status.tsx
@@ -206,24 +206,25 @@ const Status: FC = () => {
             textRequired={t('common:required')}
             required
           />
-          <Collapse title={t('collapse-file-number-title')}>
-            <div className="border-t mt-3 p-3 max-w">
+          <Collapse title={t('common:collapse-file-number-title')}>
+            <div className="border-t mt-3 p-3 max-w-prose">
+              <p>{t('common:receipt-explanation')}</p>
               <ExampleImage
-                title={t('receipt-image-1.title')}
-                description={t('receipt-image-1.description-alt')}
+                title={t('common:receipt-image-1.title')}
+                description={t('common:receipt-image-1.description-alt')}
                 imageProps={{
-                  src: t('receipt-image-1.src'),
-                  alt: t('receipt-image-1.description-alt'),
+                  src: t('common:receipt-image-1.src'),
+                  alt: t('common:receipt-image-1.alt'),
                   width: 350,
                   height: 550,
                 }}
               />
               <ExampleImage
-                title={t('receipt-image-2.title')}
-                description={t('receipt-image-2.description-alt')}
+                title={t('common:receipt-image-2.title')}
+                description={t('common:receipt-image-2.description-alt')}
                 imageProps={{
-                  src: t('receipt-image-2.src'),
-                  alt: t('receipt-image-2.description-alt'),
+                  src: t('common:receipt-image-2.src'),
+                  alt: t('common:receipt-image-2.alt'),
                   width: 350,
                   height: 550,
                 }}

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -65,7 +65,7 @@
     "description": "You cannot check the status of your passport application through this test site. Parts of this site may not work and will change."
   },
   "collapse-file-number-title": "Can't find your File Number?",
-  "receipt-explanation": "The file number is used to identify the passport application. The file number can be found on the receipt you were given if you applied for the passport in person. If you applied by mail, or don't have a file number, you can request one below.",
+  "receipt-explanation": "The file number is used to identify the passport application. The file number can be found on the receipt you were given if you applied for the passport in person. If you applied by mail, or don't have a file number, you can select \"I don't have my file number.\"",
   "receipt-image-1": {
     "title": "Example Receipt 1:",
     "alt": "An example of an official receipt. The file number is circled in the centre of the receipt.",

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -63,5 +63,19 @@
   "banner": {
     "alert": "Test site",
     "description": "You cannot check the status of your passport application through this test site. Parts of this site may not work and will change."
+  },
+  "collapse-file-number-title": "Can't find your File Number?",
+  "receipt-explanation": "The file number is used to identify the passport application. The file number can be found on the receipt you were given if you applied for the passport in person. If you applied by mail, or don't have a file number, you can request one below.",
+  "receipt-image-1": {
+    "title": "Example Receipt 1:",
+    "alt": "An example of an official receipt. The file number is circled in the centre of the receipt.",
+    "src": "/Receipt1_EN.png",
+    "descriptive-text": "Example of a receipt where the file number is circled."
+  },
+  "receipt-image-2": {
+    "title": "Example Receipt 2:",
+    "alt": "An example of an official receipt. The file number is circled in the upper left-hand side of the receipt, above a barcode.",
+    "src": "/Receipt2_EN.png",
+    "descriptive-text": "Example of a receipt where the file number is circled."
   }
 }

--- a/public/locales/en/landing.json
+++ b/public/locales/en/landing.json
@@ -2,16 +2,5 @@
   "header": "Passport application status checker",
   "description": "Do you have your passport application file number?",
   "with-esrf": "I have my file number",
-  "without-esrf": "I don't have my file number",
-  "collapse-file-number-title": "Can't find your File Number?",
-  "receipt-image-1": {
-    "title": "Example Receipt 1:",
-    "description-alt": "File Number (circled in red on image) located on centre of an \"Official Receipt\" below date/time",
-    "src": "/Receipt1_EN.png"
-  },
-  "receipt-image-2": {
-    "title": "Example Receipt 2:",
-    "description-alt": "File Number (circled in red on image) located close to the top of an \"Official Receipt and Pick-up Slip\" below the applicant's name",
-    "src": "/Receipt2_EN.png"
-  }
+  "without-esrf": "I don't have my file number"
 }

--- a/public/locales/en/status.json
+++ b/public/locales/en/status.json
@@ -147,16 +147,5 @@
     "matches": "Make sure your information matches your passport application form.",
     "for-child": "For child applications, use the child's given name(s) and surname exactly as provided on their passport application.",
     "passport-officer": "When entering the application into our system, the passport officer may have updated information in the application to match the information provided on the proof of citizenship or supporting identification. This may differ from preferred information for you or your child."
-  },
-  "collapse-file-number-title": "Can't find your File Number?",
-  "receipt-image-1": {
-    "title": "Example Receipt 1:",
-    "description-alt": "File Number (circled in red on image) located on centre of an \"Official Receipt\" below date/time",
-    "src": "/Receipt1_EN.png"
-  },
-  "receipt-image-2": {
-    "title": "Example Receipt 2:",
-    "description-alt": "File Number (circled in red on image) located close to the top of an \"Official Receipt and Pick-up Slip\" below the applicant's name",
-    "src": "/Receipt2_EN.png"
   }
 }

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -63,5 +63,19 @@
   "banner": {
     "alert": "Lieu de test",
     "description": "Vous ne pouvez pas vérifier l'état de votre demande de passeport via ce site de test. Certaines parties de ce site peuvent ne pas fonctionner et seront modifiées."
+  },
+  "collapse-file-number-title": "Vous ne trouvez pas votre numéro de dossier?",
+  "receipt-explanation": "Le numéro de dossier est utilisé pour identifier la demande de passeport. Le numéro de dossier se trouve sur le reçu qui vous a été remis si vous avez fait votre demande de passeport en personne. Si vous avez fait votre demande par courrier, ou si vous n'avez pas de numéro de dossier, vous pouvez en demander un ci-dessous.",
+  "receipt-image-1": {
+    "title": "Exemple de reçu 1\u00a0:",
+    "alt": "Un exemple de reçu officiel. Le numéro de dossier est entouré au centre du reçu.",
+    "src": "/Receipt1_FR.png",
+    "descriptive-text": "Exemple de reçu où le numéro de dossier est entouré."
+  },
+  "receipt-image-2": {
+    "title": "Exemple de reçu 2\u00a0:",
+    "alt": "Exemple de reçu officiel. Le numéro de dossier est entouré dans la partie supérieure gauche du reçu, au-dessus d'un code-barres.",
+    "src": "/Receipt2_FR.png",
+    "descriptive-text": "Exemple d'un reçu où le numéro de dossier est entouré."
   }
 }

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -65,7 +65,7 @@
     "description": "Vous ne pouvez pas vérifier l'état de votre demande de passeport via ce site de test. Certaines parties de ce site peuvent ne pas fonctionner et seront modifiées."
   },
   "collapse-file-number-title": "Vous ne trouvez pas votre numéro de dossier?",
-  "receipt-explanation": "Le numéro de dossier est utilisé pour identifier la demande de passeport. Le numéro de dossier se trouve sur le reçu qui vous a été remis si vous avez fait votre demande de passeport en personne. Si vous avez fait votre demande par courrier, ou si vous n'avez pas de numéro de dossier, vous pouvez en demander un ci-dessous.",
+  "receipt-explanation": "Le numéro de dossier est utilisé pour identifier la demande de passeport. Le numéro de dossier se trouve sur le reçu qui vous a été remis si vous avez fait votre demande de passeport en personne. Si vous avez fait votre demande par courrier, ou si vous n'avez pas de numéro de dossier, vous pouvez selectioner «\u00a0Je n'ai pas mon numéro de dossier\u00a0».",
   "receipt-image-1": {
     "title": "Exemple de reçu 1\u00a0:",
     "alt": "Un exemple de reçu officiel. Le numéro de dossier est entouré au centre du reçu.",

--- a/public/locales/fr/landing.json
+++ b/public/locales/fr/landing.json
@@ -2,16 +2,5 @@
   "header": "Vérificateur de statut de demande de passeport",
   "description": "Avez-vous votre numéro de dossier de demande de passeport?",
   "with-esrf": "J'ai mon numéro de dossier",
-  "without-esrf": "Je n'ai pas mon numéro de dossier",
-  "collapse-file-number-title": "Vous ne trouvez pas votre numéro de dossier?",
-  "receipt-image-1": {
-    "title": "Exemple de reçu 1\u00a0:",
-    "description-alt": "Numéro de dossier (encerclé en rouge sur l'image) situé au centre d'un « reçu officiel » sous la date et l'heure",
-    "src": "/Receipt1_FR.png"
-  },
-  "receipt-image-2": {
-    "title": "Exemple de reçu 2\u00a0:",
-    "description-alt": "Numéro de dossier (encerclé en rouge sur l'image) situé près du haut d'un « reçu officiel et bordereau de cueillette » sous le nom du requérant.",
-    "src": "/Receipt2_FR.png"
-  }
+  "without-esrf": "Je n'ai pas mon numéro de dossier"
 }

--- a/public/locales/fr/status.json
+++ b/public/locales/fr/status.json
@@ -147,16 +147,5 @@
     "matches": "Assurez-vous que vos informations correspondent à votre formulaire de demande de passeport.",
     "for-child": "Pour les demandes concernant des enfants, utilisez le(s) prénom(s) et le nom de famille de l'enfant exactement comme indiqué sur sa demande de passeport.",
     "passport-officer": "Lors de la saisie de la demande dans notre système, l'agent des passeports peut avoir mis à jour les informations de la demande pour qu'elles correspondent aux informations fournies sur la preuve de citoyenneté ou sur les pièces d'identité justificatives. Ces renseignements peuvent différer des renseignements préférés pour vous ou votre enfant."
-  },
-  "collapse-file-number-title": "Vous ne trouvez pas votre numéro de dossier?",
-  "receipt-image-1": {
-    "title": "Exemple de reçu 1\u00a0:",
-    "description-alt": "Numéro de dossier (encerclé en rouge sur l'image) situé au centre d'un « reçu officiel » sous la date et l'heure",
-    "src": "/Receipt1_FR.png"
-  },
-  "receipt-image-2": {
-    "title": "Exemple de reçu 2\u00a0:",
-    "description-alt": "Numéro de dossier (encerclé en rouge sur l'image) situé près du haut d'un « reçu officiel et bordereau de cueillette » sous le nom du requérant.",
-    "src": "/Receipt2_FR.png"
   }
 }


### PR DESCRIPTION
## [ADO-1890](https://dev.azure.com/DTS-STN/passport-status/_workitems/edit/1890)

### Description
This PR updates the alt text and descriptive text for the receipt images on the landing page and the status page. I've also updated the ExampleImage component to use a figure and figcaption, similar to the image cards on Canada.ca. In doing so, I've updated the import for `next/image` in `ExampleImage` to use `next/future/image` since it is now stable (Next 13 uses it already as the default implementation) and adds a lot of utility such as applying styling on the image directly.

### What to test for/How to test
1. Pull in branch
2. Type `npm run dev`
3. Navigate to `/landing`
4. Expand the `Can't find your file number?` dropdown and ensure it has the new content and scales properly

### Additional Notes
The text that goes directly above the first image in the dropdown has the sentence `If you applied by mail, or don't have a file number, you can request one below.` when there is nothing below the dropdown. Will need to talk to business to get this sorted out as the placement for our Collapse component may be incorrect based on that wording. **UPDATE: Text to be changed, waiting on updated content.**
