### PR TITLE
Update expectations page content

### DIFF
--- a/pages/expectations.tsx
+++ b/pages/expectations.tsx
@@ -30,7 +30,7 @@ const Expectations: FC = () => {
       <h1 className="h1">{t('header-purpose')}</h1>
       <h2 className="h2">{t('header-avoid-waiting')}</h2>
       <p>{t('available-after.description')}</p>
-      <ul className="space-y-2 pl-4 mb-3 list-disc list-inside">
+      <ul className="list-disc space-y-2 pl-10 mb-3">
         <li>
           {t('available-after.list.item-1')} <b>{t('or')}</b>
         </li>
@@ -39,7 +39,7 @@ const Expectations: FC = () => {
       <b>{t('available-after.updated-status')}</b>
       <h2 className="h2">{t('header-who-can-check')}</h2>
       <p>{t('can-check.description')}</p>
-      <ul className="space-y-2 pl-4 mb-3 list-disc list-inside">
+      <ul className="list-disc space-y-2 pl-10 mb-3">
         <li>
           {t('can-check.list.item-1.in-person')} <b>{t('or')} </b>
           {t('can-check.list.item-1.by-mail')}
@@ -47,15 +47,15 @@ const Expectations: FC = () => {
         <li>{t('can-check.list.item-2')}</li>
       </ul>
       <p>{t('cannot-check.description')}</p>
-      <ul className="space-y-2 pl-4 list-disc list-inside">
+      <ul className="list-disc space-y-2 pl-10 mb-3">
         <li>
           {t('cannot-check.list.item-1')} <b>{t('or')}</b>
         </li>
         <li>{t('cannot-check.list.item-2')}</li>
       </ul>
-      <p className="my-8">
-        <strong>{t('do-not-travel')}</strong>
-      </p>
+      <blockquote className="py-3 px-6 mb-3 border-l-6 border-gray-200">
+        <p className="m-0">{t('do-not-travel')}</p>
+      </blockquote>
       <h2 className="h2">{t('header-privacy')}</h2>
       <p>{t('description-privacy')}</p>
       <ActionButton

--- a/pages/expectations.tsx
+++ b/pages/expectations.tsx
@@ -28,26 +28,30 @@ const Expectations: FC = () => {
       }}
     >
       <h1 className="h1">{t('header-purpose')}</h1>
-      <p>{t('can-check.description')}</p>
-      <ul className="space-y-2 pl-4 mb-3">
-        <IconListItem icon="check-mark" text={t('can-check.list.item-1')} />
-        <IconListItem icon="check-mark" text={t('can-check.list.item-2')} />
-      </ul>
+      <h2 className="h2">{t('header-avoid-waiting')}</h2>
       <p>{t('available-after.description')}</p>
-      <ul className="space-y-2 pl-4 mb-3">
-        <IconListItem
-          icon="check-mark"
-          text={t('available-after.list.item-1')}
-        />
-        <IconListItem
-          icon="check-mark"
-          text={t('available-after.list.item-2')}
-        />
+      <ul className="space-y-2 pl-4 mb-3 list-disc list-inside">
+        <li>
+          {t('available-after.list.item-1')} <b>{t('or')}</b>
+        </li>
+        <li>{t('available-after.list.item-2')}</li>
+      </ul>
+      <b>{t('available-after.updated-status')}</b>
+      <h2 className="h2">{t('header-who-can-check')}</h2>
+      <p>{t('can-check.description')}</p>
+      <ul className="space-y-2 pl-4 mb-3 list-disc list-inside">
+        <li>
+          {t('can-check.list.item-1.in-person')} <b>{t('or')} </b>
+          {t('can-check.list.item-1.by-mail')}
+        </li>
+        <li>{t('can-check.list.item-2')}</li>
       </ul>
       <p>{t('cannot-check.description')}</p>
-      <ul className="space-y-2 pl-4">
-        <IconListItem icon="cross" text={t('cannot-check.list.item-1')} />
-        <IconListItem icon="cross" text={t('cannot-check.list.item-2')} />
+      <ul className="space-y-2 pl-4 list-disc list-inside">
+        <li>
+          {t('cannot-check.list.item-1')} <b>{t('or')}</b>
+        </li>
+        <li>{t('cannot-check.list.item-2')}</li>
       </ul>
       <p className="my-8">
         <strong>{t('do-not-travel')}</strong>
@@ -61,22 +65,6 @@ const Expectations: FC = () => {
         onClick={handleOnAgreeClick}
       />
     </Layout>
-  )
-}
-
-interface IconListItemProps {
-  icon: 'check-mark' | 'cross'
-  text: string
-}
-
-const IconListItem: FC<IconListItemProps> = ({ icon, text }) => {
-  return (
-    <li className="flex flex-nowrap gap-2">
-      <div className="font-bold">
-        {icon === 'check-mark' ? <>&#10003;</> : <>&#10007;</>}
-      </div>
-      <div>{text}</div>
-    </li>
   )
 }
 

--- a/public/locales/en/expectations.json
+++ b/public/locales/en/expectations.json
@@ -1,28 +1,35 @@
 {
   "header-purpose": "Check the status of your passport application",
+  "header-avoid-waiting": "Avoid waiting on the phone and request the status of your application online",
+  "header-who-can-check": "Who can check their status online",
   "header-privacy": "Privacy",
   "can-check": {
-    "description": "You can get the status of your passport application online if you submitted your passport application either:",
+    "description": "You can get the status of your passport application online if you submitted your passport application either",
     "list": {
-      "item-1": "in person or by mail within Canada or",
+      "item-1": {
+        "in-person": "in person",
+        "by-mail": "by mail within Canada"
+      },
       "item-2": "by mail from the U.S."
     }
   },
   "available-after": {
-    "description": "We update the status of applications daily. The status of your application is available after:",
+    "description": "The status of your application is available after",
+    "updated-status": "We update the status of applications daily.",
     "list": {
-      "item-1": "5 days if you applied in person or",
+      "item-1": "5 days if you applied in person",
       "item-2": "10 days if you applied by mail"
     }
   },
   "cannot-check": {
-    "description": "You can't look up the status of a passport application online if you:",
+    "description": "You can't look up the status of a passport application online if you applied for a passport",
     "list": {
-      "item-1": "applied for a passport outside of Canada and the United States or",
-      "item-2": "applied for a special or diplomatic passport"
+      "item-1": "at a consulate or embassy abroad",
+      "item-2": "for official government business (special or diplomatic passports)"
     }
   },
   "description-privacy": "Have you read and agree to the privacy and terms of service?",
   "button-agree": "I have read and understand",
-  "do-not-travel": "You should not finalize any travel plans until you have the passport. We are not liable for any losses if you do not receive it in time for your travel."
+  "do-not-travel": "You should not finalize any travel plans until you have the passport. We are not liable for any losses if you do not receive it in time for your travel.",
+  "or": "or"
 }

--- a/public/locales/fr/expectations.json
+++ b/public/locales/fr/expectations.json
@@ -1,28 +1,35 @@
 {
   "header-purpose": "Vérifiez l'état de votre demande de passeport",
+  "header-avoid-waiting": "Évitez d'attendre au téléphone et demandez l'état de votre demande en ligne",
+  "header-who-can-check": "Qui peut vérifier l'état de sa demande en ligne",
   "header-privacy": "Confidentialité",
   "can-check": {
-    "description": "Vous pouvez obtenir le statut de votre demande de passeport en ligne si vous avez soumis votre demande de passeport soit\u00a0:",
+    "description": "Vous pouvez obtenir l'état de votre demande de passeport en ligne si vous avez présenté votre demande de passeport soit",
     "list": {
-      "item-1": "en personne ou par la poste au Canada ou",
-      "item-2": "par courrier depuis les États-Unis"
+      "item-1": {
+        "in-person": "En personne",
+        "by-mail": " par la poste au Canada"
+      },
+      "item-2": "Par la poste des États-Unis"
     }
   },
   "available-after": {
-    "description": "Nous mettons à jour quotidiennement l'état des candidatures. Le statut de votre candidature est disponible après\u00a0:",
+    "description": "L'état de votre demande est disponible après",
+    "updated-status": "Nous actualisons quotidiennement l'état des demandes.",
     "list": {
-      "item-1": "5 jours si vous avez postulé en personne ou",
-      "item-2": "10 jours si vous avez postulé par courrier"
+      "item-1": "5 jours si vous avez présenté votre demande en personne",
+      "item-2": "10 jours si vous avez envoyé votre demande par la poste"
     }
   },
   "cannot-check": {
-    "description": "Vous ne pouvez pas consulter l'état d'une demande de passeport en ligne si vous\u00a0:",
+    "description": "Vous ne pouvez pas vérifier l'état de votre demande de passeport en ligne si vous en avez fait la demande",
     "list": {
-      "item-1": "demandé un passeport à l'extérieur du Canada et des États-Unis ou",
-      "item-2": "demandé un passeport spécial ou diplomatique"
+      "item-1": "dans un consulat ou une ambassade à l'étranger",
+      "item-2": "pour les affaires officielles du gouvernement (passeports spéciaux ou diplomatiques)"
     }
   },
   "description-privacy": "Avez-vous lu et accepté les conditions d'utilisation et de confidentialité?",
   "button-agree": "J'ai lu et j'accept",
-  "do-not-travel": "Vous ne devez finaliser aucun projet de voyage tant que vous n'avez pas le passeport. Nous ne sommes pas responsables des pertes si vous ne le recevez pas à temps pour votre voyage."
+  "do-not-travel": "Vous ne devez pas finaliser vos plans de voyage avant d'avoir le passeport. Nous ne sommes pas responsables des pertes si vous ne le recevez pas à temps pour votre voyage.",
+  "or": "ou"
 }


### PR DESCRIPTION
## [ADO-1924](https://dev.azure.com/DTS-STN/passport-status/_workitems/edit/1924)

### Description
This PR updates the content on the expectations page to match the latest provided text from the above task. This removes the use of `IconListItem` since the newest content uses vanilla bullets.

### What to test for/How to test
1. Pull in branch
2. Type `npm run dev`
3. Navigate to `/expectations`
4. Ensure the text matches what is in the ADO task