### PR TITLE
Update status fields error message

### DIFF
--- a/public/locales/en/status.json
+++ b/public/locales/en/status.json
@@ -1,9 +1,9 @@
 {
   "date-of-birth": {
     "error": {
-      "current": "The date of birth must be in the past.",
-      "invalid": "The date of birth must be valid in the following format: YYYY-MM-DD (Year-Month-Day).",
-      "required": "The date of birth is required."
+      "current": "The applicant date of birth must be in the past.",
+      "invalid": "The applicant date of birth must be valid in the following format: YYYY-MM-DD (Year-Month-Day).",
+      "required": "The applicant date of birth is required."
     },
     "label": "Applicant date of birth"
   },
@@ -18,7 +18,7 @@
   },
   "given-name": {
     "error": {
-      "required": "Given name(s) required."
+      "required": "The given name(s) of applicant is required."
     },
     "label": "Given name(s) of applicant"
   },
@@ -56,7 +56,7 @@
   "status-is": "The latest status of your application according to our records is:",
   "surname": {
     "error": {
-      "required": "The surname is required."
+      "required": "The surname of applicant is required."
     },
     "label": "Surname of applicant"
   },

--- a/public/locales/fr/status.json
+++ b/public/locales/fr/status.json
@@ -1,9 +1,9 @@
 {
   "date-of-birth": {
     "error": {
-      "current": "La date de naissance doit être dans le passé.",
-      "invalid": "La date de naissance doit être valide selon le format suivant\u00a0: aaaa-MM-jj (Année-Mois-Jour).",
-      "required": "La date de naissance obligatoire."
+      "current": "La date de naissance du requérant doit être dans le passé.",
+      "invalid": "La date de naissance du requérant doit être valide selon le format suivant\u00a0: aaaa-MM-jj (Année-Mois-Jour).",
+      "required": "La date de naissance du requérant est obligatoire."
     },
     "label": "Date de naissance du requérant"
   },
@@ -18,7 +18,7 @@
   },
   "given-name": {
     "error": {
-      "required": "Prénom(s) obligatoire(s)."
+      "required": "Le(s) prénom(s) du requérant est(sont) obligatoire(s)."
     },
     "label": "Prénom(s) du requérant"
   },
@@ -56,7 +56,7 @@
   "status-is": "Le dernier statut de votre demande selon nos dossiers est\u00a0:",
   "surname": {
     "error": {
-      "required": "Le nom de famille est obligatoire."
+      "required": "Le nom de famille du requérant est obligatoire."
     },
     "label": "Nom de famille du requérant"
   },


### PR DESCRIPTION
## [ADO-1928](https://dev.azure.com/DTS-STN/passport-status/_workitems/edit/1928)

### Description

List of proposed changes:

- Update fields error message to match new field's name

### What to test for/How to test

Load the `status` page and rendre the error messages. The field name in them should match the field's name.

### Additional Notes
