### PR TITLE
Use publicRuntimeConfig instead of NEXT_PUBLIC_

### DIFF
--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link'
 import { useRouter } from 'next/router'
 import Banner from './Banner'
 import { useTranslation } from 'next-i18next'
+import getConfig from 'next/config'
 
 export interface HeaderProps {
   gocLink: string
@@ -10,12 +11,14 @@ export interface HeaderProps {
 }
 
 const Header: FC<HeaderProps> = ({ gocLink, skipToMainText }) => {
+  const config = getConfig()
   const { locale, asPath } = useRouter()
   const { t } = useTranslation('common')
 
   const langSelectorLocale = locale === 'en' ? 'fr' : 'en'
   const langSelectorAbbreviation = langSelectorLocale === 'fr' ? 'FR' : 'EN'
   const langSelectorText = langSelectorLocale === 'fr' ? 'Français' : 'English'
+  const showBanner = config?.publicRuntimeConfig?.environment !== 'prod'
 
   return (
     <>
@@ -35,7 +38,7 @@ const Header: FC<HeaderProps> = ({ gocLink, skipToMainText }) => {
       </nav>
 
       <header>
-        {process.env.NEXT_PUBLIC_ENVIRONMENT !== 'prod' && (
+        {showBanner && (
           <Banner
             alert={t('banner.alert')}
             description={t('banner.description')}

--- a/next.config.js
+++ b/next.config.js
@@ -54,6 +54,10 @@ const nextConfig = {
     NEXT_PUBLIC_BUILD_DATE: builddate,
     LOGGING_LEVEL: process.env.LOGGING_LEVEL ?? 'info',
   },
+  publicRuntimeConfig: {
+    appBaseUri: process.env.NEXT_PUBLIC_APP_BASE_URI ?? '',
+    environment: process.env.NEXT_PUBLIC_ENVIRONMENT ?? '',
+  },
   generateBuildId: async () => {
     return process.env.BUILD_ID ?? 'local'
   },

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -4,6 +4,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { DefaultSeo } from 'next-seo'
 import { getNextSEOConfig } from '../next-seo.config'
 import Head from 'next/head'
+import getConfig from 'next/config'
 
 import '../styles/globals.css'
 
@@ -11,10 +12,9 @@ import '../styles/globals.css'
 const queryClient = new QueryClient()
 
 const MyApp = ({ Component, pageProps, router }: AppProps) => {
-  const nextSEOConfig = getNextSEOConfig(
-    process.env.NEXT_PUBLIC_APP_BASE_URI ?? '',
-    router
-  )
+  const config = getConfig()
+  const appBaseUri = config?.publicRuntimeConfig?.appBaseUri
+  const nextSEOConfig = getNextSEOConfig(appBaseUri, router)
 
   return (
     <>

--- a/pages/email.tsx
+++ b/pages/email.tsx
@@ -1,6 +1,6 @@
 import { useFormik, validateYupSchema, yupToFormErrors } from 'formik'
 import * as Yup from 'yup'
-import { GetStaticProps } from 'next'
+import { GetServerSideProps } from 'next'
 import { useRouter } from 'next/router'
 import { Trans, useTranslation } from 'next-i18next'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
@@ -233,7 +233,7 @@ const Email: FC = () => {
   )
 }
 
-export const getStaticProps: GetStaticProps = async ({ locale }) => ({
+export const getServerSideProps: GetServerSideProps = async ({ locale }) => ({
   props: {
     ...(await serverSideTranslations(locale ?? 'default', ['common', 'email'])),
   },

--- a/pages/expectations.tsx
+++ b/pages/expectations.tsx
@@ -1,5 +1,5 @@
 import { FC, MouseEventHandler, useCallback } from 'react'
-import { GetStaticProps } from 'next'
+import { GetServerSideProps } from 'next'
 import Router from 'next/router'
 import { useTranslation } from 'next-i18next'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
@@ -62,7 +62,7 @@ const Expectations: FC = () => {
   )
 }
 
-export const getStaticProps: GetStaticProps = async ({ locale }) => ({
+export const getServerSideProps: GetServerSideProps = async ({ locale }) => ({
   props: {
     ...(await serverSideTranslations(locale ?? 'default', [
       'common',

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,3 +1,4 @@
+import { GetServerSideProps } from 'next'
 import { NextSeo } from 'next-seo'
 import Image from 'next/image'
 import LinkButton from '../components/LinkButton'
@@ -90,5 +91,9 @@ const Index = () => {
     </>
   )
 }
+
+export const getServerSideProps: GetServerSideProps = async () => ({
+  props: {},
+})
 
 export default Index

--- a/pages/landing.tsx
+++ b/pages/landing.tsx
@@ -1,5 +1,5 @@
 import { FC } from 'react'
-import { GetStaticProps } from 'next'
+import { GetServerSideProps } from 'next'
 import { useTranslation } from 'next-i18next'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import Layout from '../components/Layout'
@@ -62,7 +62,7 @@ const Landing: FC = () => {
   )
 }
 
-export const getStaticProps: GetStaticProps = async ({ locale }) => ({
+export const getServerSideProps: GetServerSideProps = async ({ locale }) => ({
   props: {
     ...(await serverSideTranslations(locale ?? 'default', [
       'common',

--- a/pages/status.tsx
+++ b/pages/status.tsx
@@ -7,7 +7,7 @@ import {
   useState,
   useRef,
 } from 'react'
-import { GetStaticProps } from 'next'
+import { GetServerSideProps } from 'next'
 import { useRouter } from 'next/router'
 import { Trans, useTranslation } from 'next-i18next'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
@@ -308,7 +308,7 @@ const Status: FC = () => {
   )
 }
 
-export const getStaticProps: GetStaticProps = async ({ locale }) => ({
+export const getServerSideProps: GetServerSideProps = async ({ locale }) => ({
   props: {
     ...(await serverSideTranslations(locale ?? 'default', [
       'common',


### PR DESCRIPTION
## [ADO-1963](https://dev.azure.com/DTS-STN/passport-status/_workitems/edit/1963)

### Description

List of proposed changes:

- Use publicRuntimeConfig instead of NEXT_PUBLIC_ environment variables in Pages
- Use server-side rendering in all pages

### What to test for/How to test

Load the branch code locally, run `npm run build` and `npm run start` and load the application. You shouldn't see the following tags in head tag.

```html
<link rel="alternate" hreflang="en" href="http://localhost:3000/en/expectations">
<link rel="alternate" hreflang="fr" href="http://localhost:3000/fr/expectations">
<meta property="og:image" content="http://localhost:3000/ogp.jpg">
<meta property="og:image:width" content="2048">
<meta property="og:image:height" content="1152">
```

Set the following env. variable in your `.env.local` file then stop the process and start the application `npm run start` **WITHOUT** building the application again. At this point you should see the above html tags in head tag.

```yaml
# Base URI for the Application
NEXT_PUBLIC_APP_BASE_URI=http://localhost:3000
```

### Additional Notes

Using `process.en.NEXT_PUBLIC_APP_BASE_URI` directly is not good because the value is baked at build time. Setting the `NEXT_PUBLIC_*` variables value at runtime doesn't applied them. The application needs to leverage on using runtime configuration with `publicRuntimeConfig` and switching all our pages to server-side rendering method.
https://nextjs.org/docs/api-reference/next.config.js/runtime-configuration

How to keep NextJs configurable in Docker
https://www.witodelnat.eu/blog/2021/nextjs-docker
