### PR TITLE
Temporarily update titles for each page to pass a11y

### DIFF
--- a/pages/email.tsx
+++ b/pages/email.tsx
@@ -21,6 +21,7 @@ import ExternalLink from '../components/ExternalLink'
 import DateSelectField, {
   DateSelectFieldOnChangeEvent,
 } from '../components/DateSelectField'
+import { NextSeo } from 'next-seo'
 
 const initialValues: EmailEsrfApiRequestBody = {
   dateOfBirth: '',
@@ -102,6 +103,10 @@ const Email: FC = () => {
 
   return (
     <Layout>
+      <NextSeo
+        title="Get my passport application file number | Obtenir le numéro de dossier de ma demande de passeport"
+        titleTemplate={'%s \u2010 Canada.ca'}
+      />
       <IdleTimeout />
       <h1 ref={headingRef} className="h1" tabIndex={-1}>
         {t('header')}

--- a/pages/email.tsx
+++ b/pages/email.tsx
@@ -103,7 +103,7 @@ const Email: FC = () => {
 
   return (
     <Layout>
-      <NextSeo title={t('header')} />
+      <NextSeo title={t('page-title')} />
       <IdleTimeout />
       <h1 ref={headingRef} className="h1" tabIndex={-1}>
         {t('header')}

--- a/pages/email.tsx
+++ b/pages/email.tsx
@@ -103,10 +103,7 @@ const Email: FC = () => {
 
   return (
     <Layout>
-      <NextSeo
-        title="Get my passport application file number | Obtenir le numéro de dossier de ma demande de passeport"
-        titleTemplate={'%s \u2010 Canada.ca'}
-      />
+      <NextSeo title={t('header')} />
       <IdleTimeout />
       <h1 ref={headingRef} className="h1" tabIndex={-1}>
         {t('header')}

--- a/pages/expectations.tsx
+++ b/pages/expectations.tsx
@@ -22,11 +22,7 @@ const Expectations: FC = () => {
 
   return (
     <Layout>
-      <NextSeo
-        title="Expectations and privacy | 
-        Attentes et confidentialité"
-        titleTemplate={'%s \u2010 Canada.ca'}
-      />
+      <NextSeo title={t('page-title')} />
       <h1 className="h1">{t('header-purpose')}</h1>
       <h2 className="h2">{t('header-avoid-waiting')}</h2>
       <p>{t('available-after.description')}</p>

--- a/pages/expectations.tsx
+++ b/pages/expectations.tsx
@@ -6,6 +6,7 @@ import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import Layout from '../components/Layout'
 import ActionButton from '../components/ActionButton'
 import { setCookie } from 'cookies-next'
+import { NextSeo } from 'next-seo'
 
 const Expectations: FC = () => {
   const { t } = useTranslation('expectations')
@@ -21,6 +22,11 @@ const Expectations: FC = () => {
 
   return (
     <Layout>
+      <NextSeo
+        title="Expectations and privacy | 
+        Attentes et confidentialité"
+        titleTemplate={'%s \u2010 Canada.ca'}
+      />
       <h1 className="h1">{t('header-purpose')}</h1>
       <h2 className="h2">{t('header-avoid-waiting')}</h2>
       <p>{t('available-after.description')}</p>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -6,7 +6,11 @@ import LinkButton from '../components/LinkButton'
 const Index = () => {
   return (
     <>
-      <NextSeo noindex />
+      <NextSeo
+        noindex
+        title="Passport Application Status Checker (PASC) | Vérificateur du Statut de mon application pour un passport (VSAP)"
+        titleTemplate={'%s \u2010 Canada.ca'}
+      />
       <main
         role="main"
         className="flex bg-splash-page bg-cover bg-center h-screen"

--- a/pages/landing.tsx
+++ b/pages/landing.tsx
@@ -6,12 +6,17 @@ import Layout from '../components/Layout'
 import LinkButton from '../components/LinkButton'
 import Collapse from '../components/Collapse'
 import ExampleImage from '../components/ExampleImage'
+import { NextSeo } from 'next-seo'
 
 const Landing: FC = () => {
   const { t } = useTranslation('landing')
 
   return (
     <Layout>
+      <NextSeo
+        title="Landing page | Page d'accueil"
+        titleTemplate={'%s \u2010 Canada.ca'}
+      />
       <h1 className="h1">{t('header')}</h1>
       <p>{t('description')}</p>
       <div className="flex flex-wrap md:flex-nowrap gap-4 mb-4">

--- a/pages/landing.tsx
+++ b/pages/landing.tsx
@@ -13,7 +13,7 @@ const Landing: FC = () => {
 
   return (
     <Layout>
-      <NextSeo title="Landing page | Page d'accueil" />
+      <NextSeo title={t('page-title')} />
       <h1 className="h1">{t('header')}</h1>
       <p>{t('description')}</p>
       <div className="flex flex-wrap md:flex-nowrap gap-4 mb-4">

--- a/pages/landing.tsx
+++ b/pages/landing.tsx
@@ -13,10 +13,7 @@ const Landing: FC = () => {
 
   return (
     <Layout>
-      <NextSeo
-        title="Landing page | Page d'accueil"
-        titleTemplate={'%s \u2010 Canada.ca'}
-      />
+      <NextSeo title="Landing page | Page d'accueil" />
       <h1 className="h1">{t('header')}</h1>
       <p>{t('description')}</p>
       <div className="flex flex-wrap md:flex-nowrap gap-4 mb-4">

--- a/pages/status.tsx
+++ b/pages/status.tsx
@@ -32,6 +32,7 @@ import ExternalLink from '../components/ExternalLink'
 import DateSelectField, {
   DateSelectFieldOnChangeEvent,
 } from '../components/DateSelectField'
+import { NextSeo } from 'next-seo'
 
 const initialValues: CheckStatusApiRequestQuery = {
   dateOfBirth: '',
@@ -146,6 +147,10 @@ const Status: FC = () => {
 
   return (
     <Layout>
+      <NextSeo
+        title="Check the status of your passport application | Vérifiez l'état de votre demande de passeport"
+        titleTemplate={'%s \u2010 Canada.ca'}
+      />
       <IdleTimeout />
       <h1 ref={headingRef} className="h1" tabIndex={-1}>
         {t('header')}

--- a/pages/status.tsx
+++ b/pages/status.tsx
@@ -147,10 +147,7 @@ const Status: FC = () => {
 
   return (
     <Layout>
-      <NextSeo
-        title="Check the status of your passport application | Vérifiez l'état de votre demande de passeport"
-        titleTemplate={'%s \u2010 Canada.ca'}
-      />
+      <NextSeo title={t('page-title')} />
       <IdleTimeout />
       <h1 ref={headingRef} className="h1" tabIndex={-1}>
         {t('header')}

--- a/public/locales/en/email.json
+++ b/public/locales/en/email.json
@@ -1,4 +1,5 @@
 {
+  "page-title": "Get my passport application file number",
   "header": "Get my passport application file number",
   "description": "Fill in the fields below to get your file number. Make sure your information matches your passport application form. We'll then email the file number to the email address on file.",
   "email": {

--- a/public/locales/en/expectations.json
+++ b/public/locales/en/expectations.json
@@ -3,6 +3,7 @@
   "header-avoid-waiting": "Avoid waiting on the phone and request the status of your application online",
   "header-who-can-check": "Who can check their status online",
   "header-privacy": "Privacy",
+  "page-title": "Expectations and privacy",
   "can-check": {
     "description": "You can get the status of your passport application online if you submitted your passport application either",
     "list": {

--- a/public/locales/en/landing.json
+++ b/public/locales/en/landing.json
@@ -1,5 +1,6 @@
 {
   "header": "Passport application status checker",
+  "page-title": "Landing page",
   "description": "Do you have your passport application file number?",
   "with-esrf": "I have my file number",
   "without-esrf": "I don't have my file number"

--- a/public/locales/en/status.json
+++ b/public/locales/en/status.json
@@ -1,4 +1,5 @@
 {
+  "page-title": "Check my status",
   "date-of-birth": {
     "error": {
       "current": "The applicant date of birth must be in the past.",

--- a/public/locales/fr/email.json
+++ b/public/locales/fr/email.json
@@ -1,4 +1,5 @@
 {
+  "page-title": "Obtenir le numéro de dossier de ma demande de passeport",
   "header": "Obtenir le numéro de dossier de ma demande de passeport",
   "description": "Remplissez les champs ci-dessous pour obtenir votre numéro de dossier. Assurez-vous que vos informations correspondent à votre formulaire de demande de passeport. Nous enverrons ensuite le numéro de dossier par courriel à l'adresse courriel enregistrée.",
   "email": {

--- a/public/locales/fr/expectations.json
+++ b/public/locales/fr/expectations.json
@@ -3,6 +3,7 @@
   "header-avoid-waiting": "Évitez d'attendre au téléphone et demandez l'état de votre demande en ligne",
   "header-who-can-check": "Qui peut vérifier l'état de sa demande en ligne",
   "header-privacy": "Confidentialité",
+  "page-title": "Attentes et confidentialité",
   "can-check": {
     "description": "Vous pouvez obtenir l'état de votre demande de passeport en ligne si vous avez présenté votre demande de passeport soit",
     "list": {

--- a/public/locales/fr/landing.json
+++ b/public/locales/fr/landing.json
@@ -1,5 +1,6 @@
 {
   "header": "Vérificateur de statut de demande de passeport",
+  "page-title": "Page d'accueil",
   "description": "Avez-vous votre numéro de dossier de demande de passeport?",
   "with-esrf": "J'ai mon numéro de dossier",
   "without-esrf": "Je n'ai pas mon numéro de dossier"

--- a/public/locales/fr/status.json
+++ b/public/locales/fr/status.json
@@ -1,4 +1,5 @@
 {
+  "page-title": "Vérifier mon statut",
   "date-of-birth": {
     "error": {
       "current": "La date de naissance du requérant doit être dans le passé.",


### PR DESCRIPTION
## [ADO-1969](https://dev.azure.com/DTS-STN/passport-status/_workitems/edit/1969)

### Description
The only remaining item from our a11y audit (that is a failure, there are two suggestions) is that all of our pages have the same title. Given that we are waiting for comms to provide us with the metadata, this is a temporary fix. I've hardcoded the text rather than using translations to switch between `en | fr` and `fr | en` given the fact that this is all likely to change in the next few days. The only purpose of this PR is to get the app to pass the a11y audit. A more permanent solution (ie. actually editing the Next SEO config) will be done when we get the content from comms

### What to test for/How to test
1. Pull in branch
2. Type `npm run dev`
3. Navigate through each page and confirm that the page title is unique