### PR TITLE
Add background color to DOB field for Firefox a11y

### DIFF
--- a/components/DateSelect.tsx
+++ b/components/DateSelect.tsx
@@ -60,7 +60,7 @@ const DateSelect: FC<DateSelectProps> = ({
         aria-required={required ? true : undefined}
         className={`py-1 px-3 border rounded w-40 ${
           error ? 'border-accent-error' : 'border-neutral-400'
-        } focus:outline-none focus:border-sky-500 focus:ring-sky-500`}
+        } focus:outline-none focus:border-sky-500 focus:ring-sky-500 bg-white`}
       >
         <option value="" disabled></option>
         {options.map(({ label, value }) => (


### PR DESCRIPTION
### Description
One of the suggestions brought up in our a11y audit, and also something that was talked about previously. This PR adds the `bg-white` class to the `DateSelect` component which makes the DOB dropdowns have a white background in all browsers. This fix is really only for Firefox since the inputs had a grey background, making them appear disabled. Other browsers won't show a difference.

### What to test for/How to test
1. Pull in branch
2. Type `npm run dev` and open in Firefox
3. Navigate to `/status`
4. Ensure the DOB dropdowns have a white background and function as expected
