### PR TITLE
Fix a11y err

### DIFF
--- a/public/locales/en/expectations.json
+++ b/public/locales/en/expectations.json
@@ -11,7 +11,7 @@
         "in-person": "in person",
         "by-mail": "by mail within Canada"
       },
-      "item-2": "by mail from the U.S."
+      "item-2": "by mail from the United States."
     }
   },
   "available-after": {


### PR DESCRIPTION
## [ADO-XXX](https://dev.azure.com/DTS-STN/passport-status/_workitems/edit/xxx)

### Description

List of proposed changes:

Changed text from referencing "U.S" to United States for accessibility.

### What to test for/How to test

notice on the expectations page the references to united states.
### Additional Notes
