### PR TITLE
Handle HTTP422 responses from API as `not found`

### DIFF
--- a/pages/api/check-status.ts
+++ b/pages/api/check-status.ts
@@ -84,7 +84,10 @@ export const searchPassportStatusApi = async (
 
   if (response.status === 404 || response.status === 422) {
     logger.debug(`error ${response.status}: ${response.body}`)
-    return res.status(response.status).send('Passport Status Not Found')
+
+    // 404 and 422 responses should both be handled as
+    // `not found` results to mitigate data probing attacks
+    return res.status(404).send('Passport Status Not Found')
   }
 
   logger.debug(`Status: ${response.status}: ${response.statusText}`)


### PR DESCRIPTION
### Description

List of changes:

- Fix regression from commit `b0208241` that broke how 422 response codes from the API are handled.

### What to test for/How to test

Perform a status search that will result in multiple search results, expect to see a 404 from the API instead of a 422.