### PR TITLE
Change application name and meta data

### DIFF
--- a/__tests__/next-seo.config.test.ts
+++ b/__tests__/next-seo.config.test.ts
@@ -19,7 +19,7 @@ describe('getNextSEOConfig', () => {
 
     // assert
     expect(act.description).toBe(
-      "Check the status of your passport application. | Vérifiez l'état de votre demande de passeport."
+      "Passport application status checker | Outil de vérification de l'état de la demande de passeport"
     )
   })
 
@@ -32,9 +32,7 @@ describe('getNextSEOConfig', () => {
     const act = getNextSEOConfig(appBaseUri, router)
 
     // assert
-    expect(act.description).toBe(
-      'Check the status of your passport application.'
-    )
+    expect(act.description).toBe('Passport application status checker')
   })
 
   it('should call getFrenchConfig when router.locale is `fr`', () => {
@@ -47,7 +45,7 @@ describe('getNextSEOConfig', () => {
 
     // assert
     expect(act.description).toBe(
-      "Vérifiez l'état de votre demande de passeport."
+      "Outil de vérification de l'état de la demande de passeport"
     )
   })
 })

--- a/next-seo.config.ts
+++ b/next-seo.config.ts
@@ -45,23 +45,32 @@ export type GetNextSEOConfig = (
 ) => DefaultSeoProps
 
 export const getDefaultConfig: GetNextSEOConfig = (appBaseUri, router) => ({
-  titleTemplate:
-    "%s \u2010 Check the status of your passport application | Vérifiez l'état de votre demande de passeport \u2010 Canada.ca",
+  titleTemplate: '%s \u2010 Canada.ca',
   defaultTitle:
-    "Check the status of your passport application | Vérifiez l'état de votre demande de passeport \u2010 Canada.ca",
+    "Passport application status checker | Outil de vérification de l'état de la demande de passeport",
   description:
-    "Check the status of your passport application. | Vérifiez l'état de votre demande de passeport.",
+    "Passport application status checker | Outil de vérification de l'état de la demande de passeport",
   additionalMetaTags: [
     {
       name: 'author',
-      content:
-        'Immigration, Refugees and Citizenship Canada | Immigration, Réfugiés et Citoyenneté Canada',
+      content: 'Immigration, Refugees and Citizenship Canada',
+    },
+    {
+      name: 'author',
+      keyOverride: 'author:fr',
+      lang: 'fr',
+      content: 'Immigration, Réfugiés et Citoyenneté Canada',
     },
     { name: 'dcterms.accessRights', content: '2' },
     {
       name: 'dcterms.creator',
-      content:
-        'Immigration, Refugees and Citizenship Canada | Immigration, Réfugiés et Citoyenneté Canada',
+      content: 'Immigration, Refugees and Citizenship Canada',
+    },
+    {
+      name: 'dcterms.creator',
+      keyOverride: 'dcterms.creator:fr',
+      lang: 'fr',
+      content: 'Immigration, Réfugiés et Citoyenneté Canada',
     },
     { name: 'dcterms.language', content: 'eng' },
     { name: 'dcterms.spatial', content: 'Canada' },
@@ -71,7 +80,7 @@ export const getDefaultConfig: GetNextSEOConfig = (appBaseUri, router) => ({
     images: getOpenGraphImages(appBaseUri),
     locale: 'en_CA',
     siteName:
-      "Check the status of your passport application | Vérifiez l'état de votre demande de passeport \u2010 Canada.ca",
+      "Passport application status checker | Outil de vérification de l'état de la demande de passeport \u2010 Canada.ca",
     type: 'website',
   },
   twitter: {
@@ -82,10 +91,9 @@ export const getDefaultConfig: GetNextSEOConfig = (appBaseUri, router) => ({
 
 export const getEnglishConfig: GetNextSEOConfig = (appBaseUri, router) => ({
   titleTemplate:
-    '%s \u2010 Check the status of your passport application \u2010 Canada.ca',
-  defaultTitle:
-    'Check the status of your passport application \u2010 Canada.ca',
-  description: 'Check the status of your passport application.',
+    '%s \u2010 Passport application status checker \u2010 Canada.ca',
+  defaultTitle: 'Passport application status checker \u2010 Canada.ca',
+  description: 'Passport application status checker',
   additionalMetaTags: [
     {
       name: 'author',
@@ -103,7 +111,7 @@ export const getEnglishConfig: GetNextSEOConfig = (appBaseUri, router) => ({
   openGraph: {
     images: getOpenGraphImages(appBaseUri),
     locale: 'en_CA',
-    siteName: 'Check the status of your passport application \u2010 Canada.ca',
+    siteName: 'Passport application status checker \u2010 Canada.ca',
     type: 'website',
   },
   twitter: {
@@ -114,10 +122,10 @@ export const getEnglishConfig: GetNextSEOConfig = (appBaseUri, router) => ({
 
 export const getFrenchConfig: GetNextSEOConfig = (appBaseUri, router) => ({
   titleTemplate:
-    "%s \u2010 Vérifiez l'état de votre demande de passeport \u2010 Canada.ca",
+    "%s \u2010 Outil de vérification de l'état de la demande de passeport \u2010 Canada.ca",
   defaultTitle:
-    "Vérifiez l'état de votre demande de passeport \u2010 Canada.ca",
-  description: "Vérifiez l'état de votre demande de passeport.",
+    "Outil de vérification de l'état de la demande de passeport \u2010 Canada.ca",
+  description: "Outil de vérification de l'état de la demande de passeport",
   additionalMetaTags: [
     {
       name: 'author',
@@ -135,7 +143,8 @@ export const getFrenchConfig: GetNextSEOConfig = (appBaseUri, router) => ({
   openGraph: {
     images: getOpenGraphImages(appBaseUri),
     locale: 'fr_CA',
-    siteName: "Vérifiez l'état de votre demande de passeport \u2010 Canada.ca",
+    siteName:
+      "Outil de vérification de l'état de la demande de passeport \u2010 Canada.ca",
     type: 'website',
   },
   twitter: {

--- a/pages/email.tsx
+++ b/pages/email.tsx
@@ -112,7 +112,7 @@ const Email: FC = () => {
 
   return (
     <Layout>
-      <NextSeo title={t('page-title')} />
+      <NextSeo title={t('header')} />
       <IdleTimeout />
       <h1 ref={headingRef} className="h1" tabIndex={-1}>
         {t('header')}

--- a/pages/expectations.tsx
+++ b/pages/expectations.tsx
@@ -6,7 +6,6 @@ import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import Layout from '../components/Layout'
 import ActionButton from '../components/ActionButton'
 import { setCookie } from 'cookies-next'
-import { NextSeo } from 'next-seo'
 import ExternalLink from '../components/ExternalLink'
 
 const Expectations: FC = () => {
@@ -23,8 +22,7 @@ const Expectations: FC = () => {
 
   return (
     <Layout>
-      <NextSeo title={t('page-title')} />
-      <h1 className="h1">{t('header-purpose')}</h1>
+      <h1 className="h1">{t('header')}</h1>
       <h2 className="h2">{t('header-avoid-waiting')}</h2>
       <p>{t('available-after.description')}</p>
       <ul className="list-disc space-y-2 pl-10 mb-5">

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -8,7 +8,7 @@ const Index = () => {
     <>
       <NextSeo
         noindex
-        title="Passport Application Status Checker (PASC) | Vérificateur du Statut de mon application pour un passport (VSAP)"
+        title="Passport application status checker | Outil de vérification de l'état de la demande de passeport"
         titleTemplate={'%s \u2010 Canada.ca'}
       />
       <main
@@ -18,7 +18,8 @@ const Index = () => {
         <div className="m-auto w-[300px] md:w-[400px] lg:w-[500px] bg-gray-lighter">
           <div className="p-8">
             <h1 className="sr-only">
-              service.canada.ca-passport-status-checker
+              Passport application status checker | Outil de vérification de
+              l&#39;état de la demande de passeport
             </h1>
             <div className="w-11/12 lg:w-8/12">
               <Image

--- a/pages/landing.tsx
+++ b/pages/landing.tsx
@@ -6,14 +6,12 @@ import Layout from '../components/Layout'
 import LinkButton from '../components/LinkButton'
 import Collapse from '../components/Collapse'
 import ExampleImage from '../components/ExampleImage'
-import { NextSeo } from 'next-seo'
 
 const Landing: FC = () => {
   const { t } = useTranslation('landing')
 
   return (
     <Layout>
-      <NextSeo title={t('page-title')} />
       <h1 className="h1">{t('header')}</h1>
       <p>{t('description')}</p>
       <div className="flex flex-wrap md:flex-nowrap gap-4 mb-4">

--- a/pages/status.tsx
+++ b/pages/status.tsx
@@ -156,7 +156,7 @@ const Status: FC = () => {
 
   return (
     <Layout>
-      <NextSeo title={t('page-title')} />
+      <NextSeo title={t('header')} />
       <IdleTimeout />
       <h1 ref={headingRef} className="h1" tabIndex={-1}>
         {t('header')}

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -54,7 +54,7 @@
   },
   "phone-number": "1-800-567-6868",
   "feedback-link-header": "We want to improve this tool.",
-  "feedback-link": "<2>Give us your feedback</2> on the Check the status of your passport application tool.",
+  "feedback-link": "<2>Give us your feedback</2> on the Passport application status checker tool.",
   "feedback-link-url": "https://www.canada.ca/en/employment-social-development/services/passport/application-status-feedback.html",
   "opens-in-new-tab": "(opens in a new tab)",
   "banner": {

--- a/public/locales/en/email.json
+++ b/public/locales/en/email.json
@@ -1,5 +1,4 @@
 {
-  "page-title": "Get my passport application file number",
   "header": "Get my passport application file number",
   "description": "Fill in the fields below to get your file number. Make sure your information matches your passport application form. We'll then email the file number to the email address on file.",
   "email": {

--- a/public/locales/en/expectations.json
+++ b/public/locales/en/expectations.json
@@ -1,9 +1,8 @@
 {
-  "header-purpose": "Check the status of your passport application",
+  "header": "Passport application status checker",
   "header-avoid-waiting": "Avoid waiting on the phone and request the status of your application online",
   "header-who-can-check": "Who can check their status online",
   "header-privacy": "Privacy notice statement",
-  "page-title": "Expectations and privacy",
   "can-check": {
     "description": "You can get the status of your passport application online if you submitted your passport application either",
     "list": {

--- a/public/locales/en/landing.json
+++ b/public/locales/en/landing.json
@@ -1,6 +1,5 @@
 {
   "header": "Passport application status checker",
-  "page-title": "Landing page",
   "description": "Do you have your passport application file number?",
   "with-esrf": "I have my file number",
   "without-esrf": "I don't have my file number"

--- a/public/locales/en/status.json
+++ b/public/locales/en/status.json
@@ -1,5 +1,4 @@
 {
-  "page-title": "Check my status",
   "date-of-birth": {
     "error": {
       "current": "The applicant date of birth must be in the past.",
@@ -63,7 +62,7 @@
   },
   "unable-to-find-status": "We are unable to determine the status of your application at this time using this service.",
   "other-ways-to-status": "Contact us",
-  "no-match-title": "Other ways to get your status:",
+  "no-match-title": "Other ways to get your application status:",
   "cannot-provide-result": {
     "title": "We cannot provide a result at this time because:",
     "reason1": "the information you provided does not match the information in our system;",
@@ -73,7 +72,7 @@
   "please-verify": "Please verify the information entered and try again.",
   "please-wait": "If you have not waited at least (insert amount of time/full service standard), please try again at a later date/time.",
   "still-unable": {
-    "if-still-unable": "If you are still unable to retrieve your status, you may:",
+    "if-still-unable": "If you are still unable to retrieve your application status, you may:",
     "contact-call-center": "Contact the Passport Call Centre (insert phone #).",
     "visit-in-person": "Visit an in-person Service Canada Centre nearest you (link to FSCO)"
   },

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -54,7 +54,7 @@
   },
   "phone-number": "1 800 567 6868",
   "feedback-link-header": "Nous voulons améliorer cet outil.",
-  "feedback-link": "<2>Faites-nous part de vos commentaires</2> sur l'outil Vérifiez l'état de votre demande de passeport.",
+  "feedback-link": "<2>Faites-nous part de vos commentaires</2> sur l'Outil de vérification de l'état de la demande de passeport.",
   "feedback-link-url": "https://www.canada.ca/fr/emploi-developpement-social/services/passeport/retroaction-etat-demande.html",
   "opens-in-new-tab": "(s'ouvre dans un nouvel onglet)",
   "banner": {

--- a/public/locales/fr/email.json
+++ b/public/locales/fr/email.json
@@ -1,5 +1,4 @@
 {
-  "page-title": "Obtenir le numéro de dossier de ma demande de passeport",
   "header": "Obtenir le numéro de dossier de ma demande de passeport",
   "description": "Remplissez les champs ci-dessous pour obtenir votre numéro de dossier. Assurez-vous que vos informations correspondent à votre formulaire de demande de passeport. Nous enverrons ensuite le numéro de dossier par courriel à l'adresse courriel enregistrée.",
   "email": {

--- a/public/locales/fr/expectations.json
+++ b/public/locales/fr/expectations.json
@@ -1,9 +1,8 @@
 {
-  "header-purpose": "Vérifiez l'état de votre demande de passeport",
+  "header": "Outil de vérification de l'état de la demande de passeport",
   "header-avoid-waiting": "Évitez d'attendre au téléphone et demandez l'état de votre demande en ligne",
   "header-who-can-check": "Qui peut vérifier l'état de sa demande en ligne",
   "header-privacy": "Avis de confidentialité",
-  "page-title": "Attentes et confidentialité",
   "can-check": {
     "description": "Vous pouvez obtenir l'état de votre demande de passeport en ligne si vous avez présenté votre demande de passeport soit",
     "list": {

--- a/public/locales/fr/landing.json
+++ b/public/locales/fr/landing.json
@@ -1,6 +1,5 @@
 {
-  "header": "Vérificateur de statut de demande de passeport",
-  "page-title": "Page d'accueil",
+  "header": "Outil de vérification de l'état de la demande de passeport",
   "description": "Avez-vous votre numéro de dossier de demande de passeport?",
   "with-esrf": "J'ai mon numéro de dossier",
   "without-esrf": "Je n'ai pas mon numéro de dossier"

--- a/public/locales/fr/status.json
+++ b/public/locales/fr/status.json
@@ -1,5 +1,4 @@
 {
-  "page-title": "Vérifier mon statut",
   "date-of-birth": {
     "error": {
       "current": "La date de naissance du requérant doit être dans le passé.",
@@ -54,16 +53,16 @@
       "description": "Si vous voyez cela, c'est que quelque chose s'est mal passé."
     }
   },
-  "status-is": "Le dernier statut de votre demande selon nos dossiers est\u00a0:",
+  "status-is": "L'état le plus récent de votre demande selon nos dossiers est\u00a0:",
   "surname": {
     "error": {
       "required": "Le nom de famille du requérant est obligatoire."
     },
     "label": "Nom de famille du requérant"
   },
-  "unable-to-find-status": "Nous ne sommes pas en mesure de déterminer le statut de votre demande pour le moment en utilisant ce service.",
+  "unable-to-find-status": "Nous ne sommes pas en mesure de déterminer l'état de votre demande pour le moment en utilisant ce service.",
   "other-ways-to-status": "Contactez-nous",
-  "no-match-title": "D'autres façons d'obtenir votre statut\u00a0:",
+  "no-match-title": "D'autres façons d'obtenir l'état de votre demande\u00a0:",
   "cannot-provide-result": {
     "title": "Nous ne pouvons pas fournir de résultat pour le moment car:",
     "reason1": "les informations que vous avez fournies ne correspondent pas à celles qui se trouvent dans notre système;",
@@ -73,7 +72,7 @@
   "please-verify": "Veuillez vérifier les informations saisies et réessayer.",
   "please-wait": "Si vous n'avez pas attendu au moins (insérer le délai/la norme de service complet), veuillez réessayer à une date/heure ultérieure.",
   "still-unable": {
-    "if-still-unable": "Si vous ne parvenez toujours pas à récupérer votre statut, vous pouvez le faire:",
+    "if-still-unable": "Si vous ne parvenez toujours pas à récupérer l'état de votre demande, vous pouvez le faire:",
     "contact-call-center": "Contactez le centre d'appels pour les passeports (insérez le numéro de téléphone).",
     "visit-in-person": "Rendez-vous dans un Centre Service Canada en personne le plus proche de chez vous (lien vers la CSFO)"
   },


### PR DESCRIPTION
## [ADO-2006](https://dev.azure.com/DTS-STN/passport-status/_workitems/edit/2006)

### Description

List of proposed changes:

- Make the page title to reflect of page h1 or application
- Change the application name in English `Passport application status checker` and French `Outil de vérification de l'état de la demande de passeport`
- Change `statut` to `état` in French content

### What to test for/How to test

Ensure the application title is correct in both English and French.

### Additional Notes
