### PR TITLE
Add style to expections page content

### DIFF
--- a/next-i18next.config.js
+++ b/next-i18next.config.js
@@ -15,4 +15,7 @@ module.exports = {
       ? path.resolve('./public/locales')
       : '/public/locales',
   returnNull: false,
+  react: {
+    transKeepBasicHtmlNodesFor: ['br', 'strong', 'i', 'p', 'b', 'em'],
+  },
 }

--- a/pages/expectations.tsx
+++ b/pages/expectations.tsx
@@ -27,7 +27,7 @@ const Expectations: FC = () => {
       <p>{t('available-after.description')}</p>
       <ul className="list-disc space-y-2 pl-10 mb-5">
         <li>
-          {t('available-after.list.item-1')} <b>{t('common:or')}</b>
+          <Trans i18nKey={'available-after.list.item-1'} ns="expectations" />
         </li>
         <li>{t('available-after.list.item-2')}</li>
       </ul>
@@ -36,15 +36,14 @@ const Expectations: FC = () => {
       <p>{t('can-check.description')}</p>
       <ul className="list-disc space-y-2 pl-10 mb-5">
         <li>
-          {t('can-check.list.item-1.in-person')} <b>{t('common:or')} </b>
-          {t('can-check.list.item-1.by-mail')} <b>{t('common:or')} </b>
+          <Trans i18nKey={'can-check.list.item-1'} ns="expectations" />
         </li>
         <li>{t('can-check.list.item-2')}</li>
       </ul>
       <p>{t('cannot-check.description')}</p>
       <ul className="list-disc space-y-2 pl-10 mb-5">
         <li>
-          {t('cannot-check.list.item-1')} <b>{t('common:or')}</b>
+          <Trans i18nKey={'cannot-check.list.item-1'} ns="expectations" />
         </li>
         <li>{t('cannot-check.list.item-2')}</li>
       </ul>
@@ -52,12 +51,15 @@ const Expectations: FC = () => {
         <p className="m-0">{t('do-not-travel')}</p>
       </blockquote>
       <h2 className="h2">{t('header-privacy')}</h2>
-      <p>{t('expectations:description-privacy.1')}</p>
-      <p>{t('expectations:description-privacy.2')}</p>
-      <p>{t('expectations:description-privacy.3')}</p>
+      <p>
+        <Trans i18nKey={'description-privacy.1'} ns="expectations" />
+      </p>
+      <p>{t('description-privacy.2')}</p>
+      <p>{t('description-privacy.3')}</p>
       <p>
         <Trans
-          i18nKey={'expectations:description-privacy.4'}
+          i18nKey={'description-privacy.4'}
+          ns="expectations"
           components={{
             Link: <ExternalLink href={t('description-privacy.4-link')} />,
           }}
@@ -65,7 +67,8 @@ const Expectations: FC = () => {
       </p>
       <p>
         <Trans
-          i18nKey={'expectations:description-privacy.5'}
+          i18nKey={'description-privacy.5'}
+          ns="expectations"
           components={{
             Link: <ExternalLink href={t('description-privacy.5-link')} />,
           }}
@@ -73,7 +76,8 @@ const Expectations: FC = () => {
       </p>
       <p>
         <Trans
-          i18nKey={'expectations:description-privacy.6'}
+          i18nKey={'description-privacy.6'}
+          ns="expectations"
           components={{
             Link: <ExternalLink href={t('description-privacy.6-link')} />,
           }}

--- a/public/locales/en/expectations.json
+++ b/public/locales/en/expectations.json
@@ -6,10 +6,7 @@
   "can-check": {
     "description": "You can get the status of your passport application online if you submitted your passport application either",
     "list": {
-      "item-1": {
-        "in-person": "in person",
-        "by-mail": "by mail within Canada"
-      },
+      "item-1": "in person <b>or</b> by mail within Canada <b>or</b>",
       "item-2": "by mail from the United States."
     }
   },
@@ -17,24 +14,24 @@
     "description": "The status of your application is available after",
     "updated-status": "We update the status of applications daily.",
     "list": {
-      "item-1": "5 days if you applied in person",
+      "item-1": "5 days if you applied in person <b>or</b>",
       "item-2": "10 days if you applied by mail"
     }
   },
   "cannot-check": {
     "description": "You can't look up the status of a passport application online if you applied for a passport",
     "list": {
-      "item-1": "at a consulate or embassy abroad",
+      "item-1": "at a consulate or embassy abroad <b>or</b>",
       "item-2": "for official government business (special or diplomatic passports)"
     }
   },
   "description-privacy": {
-    "1": "The information provided is collected under section 5.1(1)(a)(i) of the Department of Employment and Social Development Act and/or section 12(e) of the Canadian Passport Order for the purpose of providing you with the status of your passport application. Refusing to provide information will result in not being able to view the status of your passport application.",
+    "1": "The information provided is collected under section 5.1(1)(a)(i) of the <em>Department of Employment and Social Development Act</em> and/or section 12(e) of the <em>Canadian Passport Order</em> for the purpose of providing you with the status of your passport application. Refusing to provide information will result in not being able to view the status of your passport application.",
     "2": "In addition, we collect your email address only if you require Employment and Social Development Canada (ESDC) to send your passport application file number by email. Without your email address, ESDC cannot send your passport application number electronically.",
     "3": "Your personal information may be shared within Service Canada and with Immigration, Refugees and Citizenship Canada to improve services through evaluations, reports and research. This will never result in an administrative decision being made about you.",
     "4": "ESDC carries out this status checker application using services from third-party provider Microsoft Corporation, which may be subject to foreign laws. For more information, see <Link>Microsoft Data Privacy Policy & Privacy Principles</Link>.",
     "4-link": "https://www.microsoft.com/en-ca/trust-center/privacy",
-    "5": "Your personal information is administered in accordance with the Department of Employment and Social Development Act, Privacy Act and other applicable laws. You have the right of access to and protection of your personal information, which is described in Personal Information Bank - Passport Program (ESDC PPU 708). Instructions for obtaining this information are outlined in the government publication titled, <Link>Information about Programs and Information Holdings</Link>.",
+    "5": "Your personal information is administered in accordance with the <em>Department of Employment and Social Development Act</em>, <em>Privacy Act</em> and other applicable laws. You have the right of access to and protection of your personal information, which is described in Personal Information Bank - Passport Program (ESDC PPU 708). Instructions for obtaining this information are outlined in the government publication titled, <Link>Information about Programs and Information Holdings</Link>.",
     "5-link": "https://www.canada.ca/en/employment-social-development/corporate/transparency/access-information/reports/infosource.html",
     "6": "You have the right to file a complaint with the Privacy Commissioner of Canada regarding how ESDC handles your personal information at: <Link>https://www.priv.gc.ca/en/report-a-concern</Link>.",
     "6-link": "https://www.priv.gc.ca/en/report-a-concern"

--- a/public/locales/fr/expectations.json
+++ b/public/locales/fr/expectations.json
@@ -6,10 +6,7 @@
   "can-check": {
     "description": "Vous pouvez obtenir l'état de votre demande de passeport en ligne si vous avez présenté votre demande de passeport soit",
     "list": {
-      "item-1": {
-        "in-person": "En personne",
-        "by-mail": " par la poste au Canada"
-      },
+      "item-1": "En personne  <b>ou</b> par la poste au Canada <b>ou</b>",
       "item-2": "Par la poste des États-Unis"
     }
   },
@@ -17,24 +14,24 @@
     "description": "L'état de votre demande est disponible après",
     "updated-status": "Nous actualisons quotidiennement l'état des demandes.",
     "list": {
-      "item-1": "5 jours si vous avez présenté votre demande en personne",
+      "item-1": "5 jours si vous avez présenté votre demande en personne <b>ou</b>",
       "item-2": "10 jours si vous avez envoyé votre demande par la poste"
     }
   },
   "cannot-check": {
     "description": "Vous ne pouvez pas vérifier l'état de votre demande de passeport en ligne si vous en avez fait la demande",
     "list": {
-      "item-1": "dans un consulat ou une ambassade à l'étranger",
+      "item-1": "dans un consulat ou une ambassade à l'étranger <b>ou</b>",
       "item-2": "pour les affaires officielles du gouvernement (passeports spéciaux ou diplomatiques)"
     }
   },
   "description-privacy": {
-    "1": "Les renseignements fournis sont recueillis en vertu de l'article 5.1(1)(a)(i) de la Loi sur le ministère de l'Emploi et du Développement social et/ou de l'article 12(e) du Décret sur les passeports canadiens dans le but de vous fournir l'état de votre demande de passeport. Si vous refusez de fournir des renseignements, vous ne serez pas en mesure de consulter l'état de votre demande de passeport.",
+    "1": "Les renseignements fournis sont recueillis en vertu de l'article 5.1(1)(a)(i) de la <em>Loi sur le ministère de l'Emploi et du Développement social</em> et/ou de l'article 12(e) du <em>Décret sur les passeports canadiens</em> dans le but de vous fournir l'état de votre demande de passeport. Si vous refusez de fournir des renseignements, vous ne serez pas en mesure de consulter l'état de votre demande de passeport.",
     "2": "De plus, nous ne recueillons votre adresse courriel que si vous demandez à Emploi et Développement social Canada (EDSC)C d'envoyer votre numéro de dossier de demande de passeport par courriel. Sans votre adresse courriel, EDSC ne peut pas envoyer votre numéro de demande de passeport par voie électronique.",
     "3": "Vos renseignements personnels peuvent être partagés au sein de Service Canada et avec Immigration, Réfugiés et Citoyenneté Canada pour améliorer les services au moyen d'évaluations, de rapports et de recherches. Cela n'entraînera jamais de décision administrative à votre sujet.",
     "4": "EDSC exécute cette application de vérification d'état en utilisant les services du fournisseur tiers Microsoft Corporation, qui peuvent être assujettis à des lois étrangères. Pour plus d'information, consultez la <Link>Politique de confidentialité de Microsoft</Link>.",
     "4-link": "https://www.microsoft.com/fr-ca/trust-center/privacy",
-    "5": "Vos renseignements personnels sont administrés conformément à la Loi sur le ministère de l'Emploi et du Développement social, la Loi sur la protection des renseignements personnels et les autres lois applicables. Vous avez le droit d'accéder à vos renseignements personnels et de les protéger, tel que décrit dans le fichier de renseignements personnels - Programme de passeport (EDSC PPU 708). Les instructions pour obtenir ces informations sont décrites dans la publication gouvernementale intitulée <Link>Renseignements sur les programmes et les fonds de renseignements</Link>.",
+    "5": "Vos renseignements personnels sont administrés conformément à la <em>Loi sur le ministère de l'Emploi et du Développement social</em>, la <em>Loi sur la protection des renseignements personnels</em> et les autres lois applicables. Vous avez le droit d'accéder à vos renseignements personnels et de les protéger, tel que décrit dans le fichier de renseignements personnels - Programme de passeport (EDSC PPU 708). Les instructions pour obtenir ces informations sont décrites dans la publication gouvernementale intitulée <Link>Renseignements sur les programmes et les fonds de renseignements</Link>.",
     "5-link": "https://www.canada.ca/fr/emploi-developpement-social/ministere/transparence/aai/rapports/infosource.html",
     "6": "Vous avez le droit de déposer une plainte auprès du Commissariat à la protection de la vie privée du Canada au sujet du traitement de vos renseignements personnels par EDSC\u00a0: <Link>https://www.priv.gc.ca/fr/signaler-un-probleme</Link>.",
     "6-link": "https://www.priv.gc.ca/fr/signaler-un-probleme"


### PR DESCRIPTION
## [ADO-2043](https://dev.azure.com/DTS-STN/passport-status/_workitems/edit/2043)

### Description

List of proposed changes:

- Add style to expections page content.

### What to test for/How to test

Load the application's expections page and ensure the workitems highlighted content is in italic.

### Additional Notes

https://react.i18next.com/latest/trans-component#usage-with-simple-html-elements-like-less-than-br-greater-than-and-others-v10.4.0