### PR TITLE
Update email and status pages content

### DIFF
--- a/components/LinkText.tsx
+++ b/components/LinkText.tsx
@@ -1,0 +1,22 @@
+import { FC } from 'react'
+import Link, { LinkProps } from 'next/link'
+
+type LinkTextProps<T> = React.AnchorHTMLAttributes<HTMLAnchorElement> &
+  React.PropsWithChildren<T>
+
+/**
+ * @see https://github.com/i18next/react-i18next/issues/1090#issuecomment-1215615932
+ */
+const LinkText: FC<LinkTextProps<LinkProps>> = ({
+  children,
+  href,
+  ...restProps
+}) => {
+  return (
+    <Link href={href || ''}>
+      <a {...restProps}>{children}</a>
+    </Link>
+  )
+}
+
+export default LinkText

--- a/pages/email.tsx
+++ b/pages/email.tsx
@@ -144,9 +144,20 @@ const Email: FC = () => {
           <ul className="list-disc space-y-2 pl-10 mb-5">
             <li>{t('header-messages.list.item-1')}</li>
             <li>{t('header-messages.list.item-2')}</li>
-            <li>{t('header-messages.list.item-3')}</li>
+            <li>
+              <Trans i18nKey="header-messages.list.item-3" ns="email" />
+            </li>
             <li>{t('header-messages.list.item-4')}</li>
           </ul>
+          <div className="p-5 mb-5 border border-gray-300 bg-gray-100 rounded">
+            <p className="m-0">
+              <Trans
+                i18nKey="header-messages.for-child-application"
+                ns="email"
+              />
+            </p>
+          </div>
+
           {errorSummaryItems.length > 0 && (
             <ErrorSummary
               id="error-summary-email-esrf"
@@ -156,6 +167,7 @@ const Email: FC = () => {
               errors={errorSummaryItems}
             />
           )}
+
           <InputField
             id="email"
             name="email"

--- a/pages/expectations.tsx
+++ b/pages/expectations.tsx
@@ -47,9 +47,9 @@ const Expectations: FC = () => {
         </li>
         <li>{t('cannot-check.list.item-2')}</li>
       </ul>
-      <blockquote className="py-3 px-6 mb-3 border-l-6 border-gray-200">
+      <div className="p-5 mb-5 border border-gray-300 bg-gray-100 rounded">
         <p className="m-0">{t('do-not-travel')}</p>
-      </blockquote>
+      </div>
       <h2 className="h2">{t('header-privacy')}</h2>
       <p>
         <Trans i18nKey={'description-privacy.1'} ns="expectations" />

--- a/pages/status.tsx
+++ b/pages/status.tsx
@@ -9,7 +9,7 @@ import {
 } from 'react'
 import { GetServerSideProps } from 'next'
 import { useRouter } from 'next/router'
-import { useTranslation } from 'next-i18next'
+import { Trans, useTranslation } from 'next-i18next'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import { useFormik, validateYupSchema, yupToFormErrors } from 'formik'
 import * as Yup from 'yup'
@@ -26,13 +26,12 @@ import ErrorSummary, {
 import CheckStatusInfo from '../components/CheckStatusInfo'
 import Modal from '../components/Modal'
 import IdleTimeout from '../components/IdleTimeout'
-import Collapse from '../components/Collapse'
-import ExampleImage from '../components/ExampleImage'
 import ExternalLink from '../components/ExternalLink'
 import DateSelectField, {
   DateSelectFieldOnChangeEvent,
 } from '../components/DateSelectField'
 import { NextSeo } from 'next-seo'
+import LinkText from '../components/LinkText'
 
 const initialValues: CheckStatusApiRequestQuery = {
   dateOfBirth: '',
@@ -186,20 +185,24 @@ const Status: FC = () => {
       ) : (
         <form onSubmit={handleFormikSubmit} id="form-get-status">
           <p>
-            <strong>{t('header-messages.matches')}</strong>
+            <Trans i18nKey="header-messages.matches" ns="status" />
           </p>
           <ul className="list-disc space-y-2 pl-10 mb-5">
             <li>{t('header-messages.list.item-1')}</li>
             <li>{t('header-messages.list.item-2')}</li>
-            <li>{t('header-messages.list.item-3')}</li>
+            <li>
+              <Trans i18nKey="header-messages.list.item-3" ns="status" />
+            </li>
             <li>{t('header-messages.list.item-4')}</li>
           </ul>
-          <blockquote className="py-3 px-6 mb-3 border-l-6 border-gray-200">
+          <div className="p-5 mb-5 border border-gray-300 bg-gray-100 rounded">
             <p className="m-0">
-              <b>{t('header-messages.for-child.application')}</b>
-              {t('header-messages.for-child.use-exactly')}
+              <Trans
+                i18nKey="header-messages.for-child-application"
+                ns="status"
+              />
             </p>
-          </blockquote>
+          </div>
 
           {errorSummaryItems.length > 0 && (
             <ErrorSummary
@@ -210,6 +213,7 @@ const Status: FC = () => {
               errors={errorSummaryItems}
             />
           )}
+
           <InputField
             id="esrf"
             name="esrf"
@@ -219,32 +223,18 @@ const Status: FC = () => {
             errorMessage={formikErrors.esrf && t(formikErrors.esrf)}
             textRequired={t('common:required')}
             required
+            helpMessage={
+              <p>
+                <Trans
+                  i18nKey="esrf.help"
+                  ns="status"
+                  components={{
+                    Link: <LinkText href="/email" />,
+                  }}
+                />
+              </p>
+            }
           />
-          <Collapse title={t('common:collapse-file-number-title')}>
-            <div className="border-t mt-3 p-3 max-w-prose">
-              <p>{t('common:receipt-explanation')}</p>
-              <ExampleImage
-                title={t('common:receipt-image-1.title')}
-                description={t('common:receipt-image-1.descriptive-text')}
-                imageProps={{
-                  src: t('common:receipt-image-1.src'),
-                  alt: t('common:receipt-image-1.alt'),
-                  width: 350,
-                  height: 550,
-                }}
-              />
-              <ExampleImage
-                title={t('common:receipt-image-2.title')}
-                description={t('common:receipt-image-2.descriptive-text')}
-                imageProps={{
-                  src: t('common:receipt-image-2.src'),
-                  alt: t('common:receipt-image-2.alt'),
-                  width: 350,
-                  height: 550,
-                }}
-              />
-            </div>
-          </Collapse>
           <InputField
             id="givenName"
             name="givenName"

--- a/public/locales/en/email.json
+++ b/public/locales/en/email.json
@@ -42,15 +42,16 @@
   },
   "help-message": {
     "email": "Provide your full email address exactly as provided on the passport application form.",
-    "for-child-application": "<strong>For child applications,</strong> use the child's given name(s) and surname and date of birth, exactly as provided on their proof of citizenship."
+    "for-child-application": "<strong>For child applications,</strong> provide the full email address for the applicant parent or legal guardian exactly as provided on the passport application."
   },
   "header-messages": {
     "matches": "<strong>Make sure your information matches your proof of citizenship and supporting ID.</strong> Your proof of citizenship could be one of the following:",
     "list": {
       "item-1": "birth certificate",
       "item-2": "citizenship certificate",
-      "item-3": "citizenship card or",
+      "item-3": "citizenship card <b>or</b>",
       "item-4": "other documents, like a naturalization certificate"
-    }
+    },
+    "for-child-application": "<strong>For child applications,</strong> use the child's given name(s) and surname and date of birth, exactly as provided on their proof of citizenship."
   }
 }

--- a/public/locales/en/status.json
+++ b/public/locales/en/status.json
@@ -14,6 +14,7 @@
     "error": {
       "required": "The file number is required."
     },
+    "help": "If you can't find your file number, you can <Link>request to receive it</Link>.",
     "label": "File number"
   },
   "given-name": {
@@ -144,27 +145,13 @@
   },
   "status-check-call": "Call us toll free at <strong>{{phoneNumber}}</strong> if you don't receive your documents within 4 weeks of receiving your passport.",
   "header-messages": {
-    "matches": "Make sure your information matches your proof of citizenship and supporting ID. Your proof of citizenship could be",
+    "matches": "<strong>Make sure your information matches your proof of citizenship and supporting ID.</strong> Your proof of citizenship could be one of the following:",
     "list": {
-      "item-1": "birth certificates",
-      "item-2": "citizenship certificates",
-      "item-3": "citizenship cards",
-      "item-4": "other documents, like naturalization certificates"
+      "item-1": "birth certificate",
+      "item-2": "citizenship certificate",
+      "item-3": "citizenship card <b>or</b>",
+      "item-4": "other documents, like a naturalization certificate"
     },
-    "for-child": {
-      "application": "For child applications",
-      "use-exactly": ", use the child's given name(s), surname and date of birth, exactly as provided on their proof of citizenship."
-    }
-  },
-  "collapse-file-number-title": "Can't find your File Number?",
-  "receipt-image-1": {
-    "title": "Example Receipt 1:",
-    "description-alt": "File Number (circled in red on image) located on centre of an \"Official Receipt\" below date/time",
-    "src": "/Receipt1_EN.png"
-  },
-  "receipt-image-2": {
-    "title": "Example Receipt 2:",
-    "description-alt": "File Number (circled in red on image) located close to the top of an \"Official Receipt and Pick-up Slip\" below the applicant's name",
-    "src": "/Receipt2_EN.png"
+    "for-child-application": "<strong>For child applications,</strong> use the child's given name(s) and surname and date of birth, exactly as provided on their proof of citizenship."
   }
 }

--- a/public/locales/fr/email.json
+++ b/public/locales/fr/email.json
@@ -48,9 +48,10 @@
     "matches": "<strong>Assurez-vous que vos informations correspondent à votre preuve de citoyenneté et à votre pièce d'identité.</strong> Votre preuve de citoyenneté pourrait être l'une des suivantes\u00a0:",
     "list": {
       "item-1": "un certificat de naissance",
-      "item-2": "un certificate de citoyenneté",
-      "item-3": "une carte de citoyenneté ou",
+      "item-2": "un certificat de citoyenneté",
+      "item-3": "une carte de citoyenneté <b>ou</b>",
       "item-4": "d'autres documents, comme un certificat de naturalisation"
-    }
+    },
+    "for-child-application": "<strong>Pour les demandes de passeport pour enfants,</strong> utilisez le(s) prénom(s), nom de famille et date de naissance de l'enfant, exactement tels qu'ils figurent sur sa preuve de citoyenneté."
   }
 }

--- a/public/locales/fr/status.json
+++ b/public/locales/fr/status.json
@@ -14,6 +14,7 @@
     "error": {
       "required": "Le numéro de dossier est obligatoire."
     },
+    "help": "Si vous ne pouvez pas trouver votre numéro de dossier, <Link>vous pouvez l'en demander</Link>.",
     "label": "Numéro de dossier"
   },
   "given-name": {
@@ -144,27 +145,13 @@
   },
   "status-check-call": "Appelez-nous sans frais au <strong>{{phoneNumber}}</strong>, si vous ne recevez pas vos documents dans les 4 semaines suivant la réception du passeport.",
   "header-messages": {
-    "matches": "Assurez-vous que vos informations correspondent à votre preuve de citoyenneté et à votre pièce d'identité. Votre preuve de citoyenneté peut être",
+    "matches": "<strong>Assurez-vous que vos informations correspondent à votre preuve de citoyenneté et à votre pièce d'identité.</strong> Votre preuve de citoyenneté pourrait être l'une des suivantes\u00a0:",
     "list": {
-      "item-1": "Certificat de naissance",
-      "item-2": "Certificat de citoyenneté",
-      "item-3": "Carte de citoyenneté",
-      "item-4": "D'autres documents, comme un certificat de naturalisation"
+      "item-1": "un certificat de naissance",
+      "item-2": "un certificat de citoyenneté",
+      "item-3": "une carte de citoyenneté <b>ou</b>",
+      "item-4": "d'autres documents, comme un certificat de naturalisation"
     },
-    "for-child": {
-      "application": "Pour la demande d'un enfant",
-      "use-exactly": ", utilisez le(s) prénom(s), nom de famille et date de naissance de l'enfant, exactement tels qu'ils figurent sur sa preuve de citoyenneté."
-    }
-  },
-  "collapse-file-number-title": "Vous ne trouvez pas votre numéro de dossier?",
-  "receipt-image-1": {
-    "title": "Exemple de reçu 1\u00a0:",
-    "description-alt": "Numéro de dossier (encerclé en rouge sur l'image) situé au centre d'un «\u00a0reçu officiel\u00a0» sous la date et l'heure",
-    "src": "/Receipt1_FR.png"
-  },
-  "receipt-image-2": {
-    "title": "Exemple de reçu 2\u00a0:",
-    "description-alt": "Numéro de dossier (encerclé en rouge sur l'image) situé près du haut d'un «\u00a0reçu officiel et bordereau de cueillette\u00a0» sous le nom du requérant.",
-    "src": "/Receipt2_FR.png"
+    "for-child-application": "<strong>Pour les demandes de passeport pour enfants,</strong> utilisez le(s) prénom(s), nom de famille et date de naissance de l'enfant, exactement tels qu'ils figurent sur sa preuve de citoyenneté."
   }
 }


### PR DESCRIPTION
## [ADO-1996](https://dev.azure.com/DTS-STN/passport-status/_workitems/edit/1996) & [ADO-2004](https://dev.azure.com/DTS-STN/passport-status/_workitems/edit/2004)

### Description

List of proposed changes:

- Update status page content based on workitem 1996
- Update email page header information to match status page content. Also fixed previous PR #260 content.
- Apply `well` component style instead of blockquote as it was mentionned in a UI meeting couple weeks ago.

### What to test for/How to test

Load email and status pages and ensure the content match what's in the workitems.

### Additional Notes

Wells
https://wet-boew.github.io/wet-boew-styleguide/design/wells-en.html?wbdisable=true
