### PR TITLE
Updated result messaging for Canada Post and Ready For Pickup

### DIFF
--- a/components/CheckStatusResponses/CheckStatusReadyForPickup.tsx
+++ b/components/CheckStatusResponses/CheckStatusReadyForPickup.tsx
@@ -5,7 +5,7 @@ export const CheckStatusReadyForPickup: FC<{}> = () => {
   const { t } = useTranslation(['status'])
   return (
     <>
-      <h2 data-testid="ready-for-pickup" className="h2 text-blue-normal">
+      <h2 data-testid="ready-for-pickup" className="h2">
         {t('ready-for-pickup.has-been-printed')}
       </h2>
       <ul className="list-disc space-y-2 pl-10 mb-5">

--- a/components/CheckStatusResponses/CheckStatusReadyForPickup.tsx
+++ b/components/CheckStatusResponses/CheckStatusReadyForPickup.tsx
@@ -2,15 +2,15 @@ import { FC } from 'react'
 import { useTranslation } from 'next-i18next'
 
 export const CheckStatusReadyForPickup: FC<{}> = () => {
-  const { t } = useTranslation(['status', 'common'])
+  const { t } = useTranslation(['status'])
   return (
     <>
       <h2 data-testid="ready-for-pickup" className="h2 text-blue-normal">
-        {t('status-check-passport-printed')}
+        {t('ready-for-pickup.has-been-printed')}
       </h2>
       <ul className="list-disc space-y-2 pl-10 mb-5">
         <li>{t('ready-for-pickup.check-receipt')}</li>
-        <li>{t('ready-for-pickup.do-not-visit')}</li>
+        <li>{t('ready-for-pickup.not-available')}</li>
       </ul>
     </>
   )

--- a/components/CheckStatusResponses/CheckStatusShippingCanadaPost.tsx
+++ b/components/CheckStatusResponses/CheckStatusShippingCanadaPost.tsx
@@ -13,7 +13,7 @@ export const CheckStatusShippingCanadaPost: FC<
 
   return (
     <>
-      <h2 data-testid="shipped-canada-post" className="h2 text-blue-normal">
+      <h2 data-testid="shipped-canada-post" className="h2">
         {t('status-check-passport-printed-and-mailed')}
       </h2>
       <p>
@@ -31,9 +31,7 @@ export const CheckStatusShippingCanadaPost: FC<
           </>
         )}
       </p>
-      <p className="mt-6 text-blue-light">
-        {t('shipped-canada-post.supporting-documents')}
-      </p>
+      <p className="mt-6">{t('shipped-canada-post.supporting-documents')}</p>
       <p>
         <Trans
           i18nKey="status-check-call"

--- a/components/CheckStatusResponses/CheckStatusShippingCanadaPost.tsx
+++ b/components/CheckStatusResponses/CheckStatusShippingCanadaPost.tsx
@@ -1,5 +1,5 @@
 import { FC } from 'react'
-import { useTranslation } from 'next-i18next'
+import { Trans, useTranslation } from 'next-i18next'
 import ExternalLink from '../ExternalLink'
 
 export interface CheckStatusShippingCanadaPostProps {
@@ -14,7 +14,7 @@ export const CheckStatusShippingCanadaPost: FC<
   return (
     <>
       <h2 data-testid="shipped-canada-post" className="h2 text-blue-normal">
-        {t('status-check-passport-printed')}
+        {t('status-check-passport-printed-and-mailed')}
       </h2>
       <p>
         {t('shipped-canada-post.mailing')}
@@ -35,8 +35,11 @@ export const CheckStatusShippingCanadaPost: FC<
         {t('shipped-canada-post.supporting-documents')}
       </p>
       <p>
-        {t('status-check-call')} <b>{t('common:phone-number')}</b>{' '}
-        {t('shipped-canada-post.did-not-receive')}
+        <Trans
+          i18nKey="status-check-call"
+          ns="status"
+          tOptions={{ phoneNumber: t('common:phone-number') }}
+        />
       </p>
     </>
   )

--- a/components/CheckStatusResponses/CheckStatusShippingFedex.tsx
+++ b/components/CheckStatusResponses/CheckStatusShippingFedex.tsx
@@ -13,7 +13,7 @@ export const CheckStatusShippingFedex: FC<CheckStatusShippingFedexProps> = ({
   return (
     <>
       <h2 data-testid="shipped-fedex" className="h2 text-blue-normal">
-        {t('status-check-passport-printed')}
+        {t('status-check-passport-printed-and-mailed')}
       </h2>
       <p>
         {t('shipped-fedex.mailing')}

--- a/public/locales/en/status.json
+++ b/public/locales/en/status.json
@@ -100,19 +100,18 @@
   },
   "ready-for-pickup": {
     "has-been-printed": "The passport has been printed",
-    "check-receipt": "Check your receipt to confirm when and where to pick up the passport.",
-    "do-not-visit": "Don't visit the pickup location before the date printed on your receipt."
+    "check-receipt": "The passport is on its way to the pickup location. Check your receipt to confirm the date and location.",
+    "not-available": "The passport will not be available before the pickup date printed on your receipt."
   },
   "shipped-canada-post": {
     "mailing": "We're mailing it to you by Canada Post. ",
-    "supporting-documents": "We may send your supporting documents back separately.",
-    "did-not-receive": ", if you don't receive your documents within 4 weeks of receiving your passport."
+    "supporting-documents": "We may send your supporting documents back separately."
   },
   "shipped-fedex": {
     "mailing": "We're sending it to you by Fedex. ",
     "supporting-documents": "You'll receive the passport and supporting documents in the same envelope."
   },
-  "status-check-passport-printed": "The passport has been printed",
+  "status-check-passport-printed-and-mailed": "The passport has been printed and mailed",
   "not-acceptable": {
     "cannot-process": "We have reviewed your application and can't process it further",
     "explanation": "We're sending you a letter explaining why, and including your supporting documents. You should get these within 4 weeks."
@@ -143,7 +142,7 @@
       "fedex": "https://www.fedex.com/fedextrack/?action=track&cntry_code=ca&locale=en_ca&trackingnumber={{trackingNumber}}"
     }
   },
-  "status-check-call": "Call us at ",
+  "status-check-call": "Call us toll free at <strong>{{phoneNumber}}</strong> if you don't receive your documents within 4 weeks of receiving your passport.",
   "header-messages": {
     "matches": "Make sure your information matches your proof of citizenship and supporting ID. Your proof of citizenship could be",
     "list": {

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -52,7 +52,7 @@
     "continue-session": "Continuer la session",
     "end-session": "Terminer la session"
   },
-  "phone-number": "1 800 567 6868",
+  "phone-number": "1-800-567-6868",
   "feedback-link-header": "Nous voulons améliorer cet outil",
   "feedback-link": "Donnez-nous votre avis sur l'Outil de vérification de l'état de la demande de passeport",
   "feedback-link-url": "https://www.canada.ca/fr/emploi-developpement-social/services/passeport/retroaction-etat-demande.html",

--- a/public/locales/fr/status.json
+++ b/public/locales/fr/status.json
@@ -99,19 +99,19 @@
     "never": "jamais"
   },
   "ready-for-pickup": {
-    "check-receipt": "Vérifiez votre reçu pour confirmer la date et le lieu de retrait du passeport.",
-    "do-not-visit": "Ne vous rendez pas au lieu de retrait avant la date indiquée sur votre reçu."
+    "has-been-printed": "Le passeport a été imprimé",
+    "check-receipt": "Le passeport est en route vers le lieu de retrait. Vérifiez votre reçu pour confirmer la date et le lieu de retrait du passeport.",
+    "not-available": "Le passeport ne sera pas disponible avant la date de retrait imprimée sur votre reçu."
   },
   "shipped-canada-post": {
     "mailing": "Nous vous l'envoyons par Postes Canada. ",
-    "supporting-documents": "Nous pourrions renvoyer vos documents justificatifs séparément",
-    "did-not-receive": "si vous ne recevez pas vos documents dans les 4 semaines suivant la réception du passeport."
+    "supporting-documents": "Nous pourrions renvoyer vos documents justificatifs séparément"
   },
   "shipped-fedex": {
     "mailing": "Nous vous l'envoyons par FedEx. ",
     "supporting-documents": "Vous recevrez le passeport et les documents justificatifs dans la même enveloppe."
   },
-  "status-check-passport-printed": "Le passeport a été imprimé",
+  "status-check-passport-printed-and-mailed": "Le passeport a été imprimé",
   "not-acceptable": {
     "cannot-process": "Nous avons examiné votre demande et ne pouvons pas la traiter davantage",
     "explanation": "Nous vous envoyons une lettre expliquant pourquoi et incluant vos documents justificatifs. Vous devriez les recevoir dans un délai de 4 semaines."
@@ -142,7 +142,7 @@
       "fedex": "https://www.fedex.com/fedextrack/?action=track&cntry_code=ca&locale=fr_ca&trackingnumber={{trackingNumber}}"
     }
   },
-  "status-check-call": "Appelez-nous au ",
+  "status-check-call": "Appelez-nous sans frais au <strong>{{phoneNumber}}</strong>, si vous ne recevez pas vos documents dans les 4 semaines suivant la réception du passeport.",
   "header-messages": {
     "matches": "Assurez-vous que vos informations correspondent à votre preuve de citoyenneté et à votre pièce d'identité. Votre preuve de citoyenneté peut être",
     "list": {


### PR DESCRIPTION
## [ADO-1999](https://dev.azure.com/DTS-STN/passport-status/_workitems/edit/1999) [ADO-2001](https://dev.azure.com/DTS-STN/passport-status/_workitems/edit/2001)
 
### Description
This PR updates the results messaging for the canada post and ready for pickup statuses.

### What to test for/How to test
1. Pull in branch
2. Type `npm run dev`
3. Navigate to `/status`
4. Enter data with status code 2 and 3 and confirm the content matches what is in the ADO task