### PR TITLE
Update CheckStatusNotAcceptable with latest content

### DIFF
--- a/components/CheckStatusResponses/CheckStatusNotAcceptable.tsx
+++ b/components/CheckStatusResponses/CheckStatusNotAcceptable.tsx
@@ -1,5 +1,5 @@
 import { FC } from 'react'
-import { useTranslation } from 'next-i18next'
+import { Trans, useTranslation } from 'next-i18next'
 
 export const CheckStatusNotAcceptable: FC<{}> = () => {
   const { t } = useTranslation(['status', 'common'])
@@ -8,7 +8,13 @@ export const CheckStatusNotAcceptable: FC<{}> = () => {
       <h2 data-testid="not-acceptable" className="h2">
         {t('not-acceptable.cannot-process')}
       </h2>
-      <p>{t('not-acceptable.explanation')}</p>
+      <p>
+        <Trans
+          i18nKey="not-acceptable.explanation"
+          ns="status"
+          tOptions={{ phoneNumber: t('common:phone-number') }}
+        />
+      </p>
     </>
   )
 }

--- a/public/locales/en/status.json
+++ b/public/locales/en/status.json
@@ -116,7 +116,7 @@
   },
   "not-acceptable": {
     "cannot-process": "We have reviewed your application and can't process it further",
-    "explanation": "We're sending you a letter explaining why, and including your supporting documents. You should get these within 4 weeks."
+    "explanation": "We're sending you a letter explaining why and will return your supporting documents at the same time.<br />For more information, call us toll free at <strong>{{phoneNumber}}</strong>."
   },
   "status-check-contact": {
     "description-no-record": {

--- a/public/locales/fr/status.json
+++ b/public/locales/fr/status.json
@@ -116,7 +116,7 @@
   },
   "not-acceptable": {
     "cannot-process": "Nous avons examiné votre demande et ne pouvons pas la traiter davantage",
-    "explanation": "Nous vous envoyons une lettre expliquant pourquoi et incluant vos documents justificatifs. Vous devriez les recevoir dans un délai de 4 semaines."
+    "explanation": "Nous vous envoyons une lettre expliquant pourquoi et nous vous renverrons vos documents justificatifs par la même occasion.<br />Pour plus d'informations, appelez-nous sans frais au <strong>{{phoneNumber}}</strong>."
   },
   "status-check-contact": {
     "description-no-record": {


### PR DESCRIPTION
## [ADO-1998](https://dev.azure.com/DTS-STN/passport-status/_workitems/edit/1998)

### Description
This PR updates the content for `CheckStatusNotAcceptable` to be in line with the latest content provided in the above ADO task.

### What to test for/How to test
1. Pull in branch
2. Type `npm run dev`
3. Navigate to `/status`
4. Enter in information that has status code `5` and confirm the content matches the ADO task