### PR TITLE
Moved localePath into i18n block to match github issue suggestion

### DIFF
--- a/next-i18next.config.js
+++ b/next-i18next.config.js
@@ -8,9 +8,9 @@ module.exports = {
   i18n: {
     locales: ['default', 'en', 'fr'],
     defaultLocale: 'default',
+    localePath: path.resolve('./public/locales'),
   },
   appendNamespaceToMissingKey: true,
-  localePath: path.resolve('./public/locales'),
   returnNull: false,
   react: {
     transKeepBasicHtmlNodesFor: ['br', 'strong', 'i', 'p', 'b', 'em'],


### PR DESCRIPTION
Updated where in the config the localePath goes to match the suggested solution from this issue:
https://github.com/i18next/next-i18next/issues/462

Just want to be 100% sure we tried everything.
