### PR TITLE
Updated Fedex/Canada Post results pages

### DIFF
--- a/components/CheckStatusInfo.tsx
+++ b/components/CheckStatusInfo.tsx
@@ -57,11 +57,13 @@ export const CheckStatusInfo: FC<CheckStatusInfoProps> = ({
   return (
     <div id={id}>
       {statusComponent}
-      <ActionButton
-        onClick={onGoBackClick}
-        text={goBackText}
-        style={goBackStyle}
-      />
+      <div className="pt-5">
+        <ActionButton
+          onClick={onGoBackClick}
+          text={goBackText}
+          style={goBackStyle}
+        />
+      </div>
     </div>
   )
 }

--- a/components/CheckStatusResponses/CheckStatusReadyForPickup.tsx
+++ b/components/CheckStatusResponses/CheckStatusReadyForPickup.tsx
@@ -2,7 +2,7 @@ import { FC } from 'react'
 import { useTranslation } from 'next-i18next'
 
 export const CheckStatusReadyForPickup: FC<{}> = () => {
-  const { t } = useTranslation(['status'])
+  const { t } = useTranslation('status')
   return (
     <>
       <h2 data-testid="ready-for-pickup" className="h2">

--- a/components/CheckStatusResponses/CheckStatusShippingCanadaPost.tsx
+++ b/components/CheckStatusResponses/CheckStatusShippingCanadaPost.tsx
@@ -25,18 +25,18 @@ export const CheckStatusShippingCanadaPost: FC<
               i18nKey="status-check-tracking.number"
               ns="status"
               tOptions={{ trackingNumber }}
-              components={{
-                Link: (
-                  <ExternalLink
-                    href={t('status-check-tracking.link.canada-post', {
-                      trackingNumber,
-                    })}
-                  />
-                ),
-              }}
             />
           </>
         )}
+      </p>
+      <p>
+        <ExternalLink
+          href={t('status-check-tracking.link.canada-post', {
+            trackingNumber,
+          })}
+        >
+          {t('status-check-tracking.can-track')}
+        </ExternalLink>
       </p>
       <p className="mt-6">{t('shipped-canada-post.supporting-documents')}</p>
       <p>

--- a/components/CheckStatusResponses/CheckStatusShippingFedex.tsx
+++ b/components/CheckStatusResponses/CheckStatusShippingFedex.tsx
@@ -9,7 +9,7 @@ export interface CheckStatusShippingFedexProps {
 export const CheckStatusShippingFedex: FC<CheckStatusShippingFedexProps> = ({
   trackingNumber,
 }) => {
-  const { t } = useTranslation(['status', 'common'])
+  const { t } = useTranslation('status')
   return (
     <>
       <h2 data-testid="shipped-fedex" className="h2">
@@ -24,18 +24,18 @@ export const CheckStatusShippingFedex: FC<CheckStatusShippingFedexProps> = ({
               i18nKey="status-check-tracking.number"
               ns="status"
               tOptions={{ trackingNumber }}
-              components={{
-                Link: (
-                  <ExternalLink
-                    href={t('status-check-tracking.link.fedex', {
-                      trackingNumber,
-                    })}
-                  />
-                ),
-              }}
             />
           </>
         )}
+      </p>
+      <p>
+        <ExternalLink
+          href={t('status-check-tracking.link.fedex', {
+            trackingNumber,
+          })}
+        >
+          {t('status-check-tracking.can-track')}
+        </ExternalLink>
       </p>
       <p className="mt-6">{t('shipped-fedex.supporting-documents')}</p>
     </>

--- a/public/locales/en/status.json
+++ b/public/locales/en/status.json
@@ -127,7 +127,8 @@
     "express-services-href": "https://www.canada.ca/en/immigration-refugees-citizenship/services/canadian-passports/urgent-emergency-passport.html"
   },
   "status-check-tracking": {
-    "number": "Your tracking number is <strong>{{trackingNumber}}</strong>.<br /><Link>You can track the package online</Link>",
+    "number": "Your tracking number is <strong>{{trackingNumber}}</strong>.",
+    "can-track": "You can track the package online",
     "link": {
       "canada-post": "https://www.canadapost-postescanada.ca/track-reperage/en?referenceNumber={{trackingNumber}}#/details/{{trackingNumber}}",
       "fedex": "https://www.fedex.com/fedextrack/?action=track&cntry_code=ca&locale=en_ca&trackingnumber={{trackingNumber}}"

--- a/public/locales/fr/status.json
+++ b/public/locales/fr/status.json
@@ -127,13 +127,14 @@
     "express-services-href": "https://www.canada.ca/fr/immigration-refugies-citoyennete/services/passeports-canadiens/passeport-urgent-express.html"
   },
   "status-check-tracking": {
-    "number": "Votre numéro de repérage est <strong>{{trackingNumber}}</strong>.<br /><Link>Vous pouvez faire le suivi de l'envoi en ligne</Link>",
+    "number": "Votre numéro de repérage est <strong>{{trackingNumber}}</strong>.",
+    "can-track": "Vous pouvez faire le suivi de l'envoi en ligne",
     "link": {
       "canada-post": "https://www.canadapost-postescanada.ca/track-reperage/fr?referenceNumber={{trackingNumber}}#/details/{{trackingNumber}}",
       "fedex": "https://www.fedex.com/fedextrack/?action=track&cntry_code=ca&locale=fr_ca&trackingnumber={{trackingNumber}}"
     }
   },
-  "status-check-call": "Appelez-nous sans frais au <strong>{{phoneNumber}}</strong>, si vous ne recevez pas vos documents dans les 4 semaines suivant la réception du passeport.",
+  "status-check-call": "Appelez-nous sans frais au <strong>{{phoneNumber}}</strong> si vous ne recevez pas vos documents dans les 4 semaines suivant la réception du passeport.",
   "header-messages": {
     "matches": "<strong>Assurez-vous que vos informations correspondent à votre preuve de citoyenneté et à votre pièce d'identité.</strong> Votre preuve de citoyenneté pourrait être l'une des suivantes\u00a0:",
     "list": {


### PR DESCRIPTION
## [ADO-1999](https://dev.azure.com/DTS-STN/passport-status/_workitems/edit/1999) [ADO-2000](https://dev.azure.com/DTS-STN/passport-status/_workitems/edit/2000)

### Description
This PR addresses the comments on the ADO task from Mario. As per the comments, I've split the `ExternalLink` into it's own paragraph instead of using a `<br />` in the translation, wrapped the restart/reset button in a div and gave it top padding, and removed a stray comma in one of the French translations.

### What to test for/How to test
1. Pull in branch
2. Type `npm run dev`
3. Navigate to `/status`
4. Enter information that has status codes `3` and `4`, and ensure the text shows up as it does in the ADO task
