### PR TITLE
Use node:18.13-bullseye-slim with docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
 # Install dependencies only when needed
-FROM node:18.12-alpine3.17 AS deps
-# Check https://github.com/nodejs/docker-node/tree/b4117f9333da4138b03a546ec926ef50a31506c3#nodealpine to understand why libc6-compat might be needed.
-RUN apk add --no-cache libc6-compat
+FROM node:18.13-bullseye-slim AS deps
 WORKDIR /app
 
 
@@ -11,7 +9,7 @@ RUN npm ci
 
 
 # Rebuild the source code only when needed
-FROM node:18.12-alpine3.17 AS builder
+FROM node:18.13-bullseye-slim AS builder
 WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
@@ -31,7 +29,7 @@ ENV NEXT_TELEMETRY_DISABLED 1
 RUN npm run build
 
 # Production image, copy all the files and run next
-FROM node:18.12-alpine3.17 AS runner
+FROM node:18.13-bullseye-slim AS runner
 WORKDIR /app
 
 ENV NODE_ENV production


### PR DESCRIPTION
### Description

List of proposed changes:

- Use node:18.13-bullseye-slim with docker

### What to test for/How to test

### Additional Notes
