### PR TITLE
Update text to use interpolation, use strong instead of b

### DIFF
--- a/components/CheckStatusResponses/CheckStatusNoRecord.tsx
+++ b/components/CheckStatusResponses/CheckStatusNoRecord.tsx
@@ -12,8 +12,10 @@ export const CheckStatusNoRecord: FC<{}> = () => {
       <p>{t('no-record.cannot-give-status.because')}</p>
       <ul className="list-disc space-y-2 pl-10 mb-5">
         <li>
-          {t('no-record.cannot-give-status.list.item-1')}{' '}
-          <b>{t('common:or')}</b>
+          <Trans
+            i18nKey={'no-record.cannot-give-status.list.item-1'}
+            ns="status"
+          />
         </li>
         <li>{t('no-record.cannot-give-status.list.item-2')}</li>
       </ul>

--- a/pages/expectations.tsx
+++ b/pages/expectations.tsx
@@ -31,7 +31,9 @@ const Expectations: FC = () => {
         </li>
         <li>{t('available-after.list.item-2')}</li>
       </ul>
-      <b>{t('available-after.updated-status')}</b>
+      <p>
+        <strong>{t('available-after.updated-status')}</strong>
+      </p>
       <h2 className="h2">{t('header-who-can-check')}</h2>
       <p>{t('can-check.description')}</p>
       <ul className="list-disc space-y-2 pl-10 mb-5">

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -74,6 +74,5 @@
     "alt": "An example of an official receipt. The file number is circled in the upper left-hand side of the receipt, above a barcode.",
     "src": "/Receipt2_EN.png",
     "descriptive-text": "Example of a receipt where the file number is circled."
-  },
-  "or": "or"
+  }
 }

--- a/public/locales/en/email.json
+++ b/public/locales/en/email.json
@@ -49,7 +49,7 @@
     "list": {
       "item-1": "birth certificate",
       "item-2": "citizenship certificate",
-      "item-3": "citizenship card <b>or</b>",
+      "item-3": "citizenship card <strong>or</strong>",
       "item-4": "other documents, like a naturalization certificate"
     },
     "for-child-application": "<strong>For child applications,</strong> use the child's given name(s) and surname and date of birth, exactly as provided on their proof of citizenship."

--- a/public/locales/en/expectations.json
+++ b/public/locales/en/expectations.json
@@ -6,7 +6,7 @@
   "can-check": {
     "description": "You can get the status of your passport application online if you submitted your passport application either:",
     "list": {
-      "item-1": "in person <b>or</b> by mail in Canada <b>or</b>",
+      "item-1": "in person <strong>or</strong> by mail in Canada <strong>or</strong>",
       "item-2": "by mail from the United States"
     }
   },
@@ -14,14 +14,14 @@
     "description": "The status of your application is available after:",
     "updated-status": "We update the status of applications daily.",
     "list": {
-      "item-1": "5 business days if you applied in person <b>or</b>",
+      "item-1": "5 business days if you applied in person <strong>or</strong>",
       "item-2": "10 business days if you applied by mail"
     }
   },
   "cannot-check": {
     "description": "You can't look up the status of a passport application online if you applied for a passport:",
     "list": {
-      "item-1": "at a consulate or embassy abroad <b>or</b>",
+      "item-1": "at a consulate or embassy abroad <strong>or</strong>",
       "item-2": "for official government business (special or diplomatic passports)"
     }
   },

--- a/public/locales/en/status.json
+++ b/public/locales/en/status.json
@@ -61,35 +61,24 @@
     },
     "label": "Surname of applicant"
   },
-  "unable-to-find-status": "We are unable to determine the status of your application at this time using this service.",
-  "other-ways-to-status": "Contact us",
-  "no-match-title": "Other ways to get your application status:",
   "cannot-provide-result": {
     "title": "We cannot provide a result at this time because:",
     "reason1": "the information you provided does not match the information in our system;",
     "reason2": "we have not yet received your application; or",
     "reason3": "we have received your application but have not yet started processing it."
   },
-  "please-verify": "Please verify the information entered and try again.",
-  "please-wait": "If you have not waited at least (insert amount of time/full service standard), please try again at a later date/time.",
-  "still-unable": {
-    "if-still-unable": "If you are still unable to retrieve your application status, you may:",
-    "contact-call-center": "Contact the Passport Call Centre (insert phone #).",
-    "visit-in-person": "Visit an in-person Service Canada Centre nearest you (link to FSCO)"
-  },
   "no-record": {
     "cannot-give-status": {
       "description": "We can't give you your application status right now",
       "because": "This is because:",
       "list": {
-        "item-1": "the information you gave us doesn't match the information in our system",
+        "item-1": "the information you gave us doesn't match the information in our system <strong>or</strong>",
         "item-2": "we received your application, but haven't started processing it yet"
       }
     },
     "contact-us": "If you can't get your application status using this tool, or if your application is taking longer than the <Link>service standard</Link>, please call us toll free at <strong>{{phoneNumber}}</strong>.",
     "service-standard-link": "https://www.canada.ca/en/immigration-refugees-citizenship/services/canadian-passports/processing-times.html",
-    "double-check": "Double-check your information and try again. If we still can't find your file, you can try again tomorrow. We update our records daily.",
-    "if": "if"
+    "double-check": "Double-check your information and try again. If we still can't find your file, you can try again tomorrow. We update our records daily."
   },
   "being-processed": {
     "received": "We have received your application and are now processing it",
@@ -116,10 +105,6 @@
     "call-us": "For more information, call us toll free at <strong>{{phoneNumber}}</strong>."
   },
   "status-check-contact": {
-    "description-no-record": {
-      "item-1": "after several attempts you still can't get your application status, ",
-      "item-2": "your application is taking longer than the "
-    },
     "call-us": "Call us toll free at <strong>{{phoneNumber}}</strong> if your application is taking longer than the <Link>service standard</Link>",
     "service-standard-href": "https://www.canada.ca/en/immigration-refugees-citizenship/services/canadian-passports/processing-times.html"
   },
@@ -141,7 +126,7 @@
     "list": {
       "item-1": "birth certificate",
       "item-2": "citizenship certificate",
-      "item-3": "citizenship card <b>or</b>",
+      "item-3": "citizenship card <strong>or</strong>",
       "item-4": "other documents, like a naturalization certificate"
     },
     "for-child-application": "<strong>For child applications,</strong> use the child's given name(s) and surname and date of birth, exactly as provided on their proof of citizenship."

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -74,6 +74,5 @@
     "alt": "Exemple de reçu officiel. Le numéro de dossier est entouré dans la partie supérieure gauche du reçu, au-dessus d'un code-barres.",
     "src": "/Receipt2_FR.png",
     "descriptive-text": "Exemple d'un reçu où le numéro de dossier est entouré."
-  },
-  "or": "ou"
+  }
 }

--- a/public/locales/fr/email.json
+++ b/public/locales/fr/email.json
@@ -49,7 +49,7 @@
     "list": {
       "item-1": "un certificat de naissance",
       "item-2": "un certificat de citoyenneté",
-      "item-3": "une carte de citoyenneté <b>ou</b>",
+      "item-3": "une carte de citoyenneté <strong>ou</strong>",
       "item-4": "d'autres documents, comme un certificat de naturalisation"
     },
     "for-child-application": "<strong>Pour les demandes de passeport pour enfants,</strong> utilisez le(s) prénom(s), nom de famille et date de naissance de l'enfant, exactement tels qu'ils figurent sur sa preuve de citoyenneté."

--- a/public/locales/fr/expectations.json
+++ b/public/locales/fr/expectations.json
@@ -6,7 +6,7 @@
   "can-check": {
     "description": "Vous pouvez obtenir l'état de votre demande de passeport en ligne si vous avez présenté votre demande de passeport soit\u00a0:",
     "list": {
-      "item-1": "en personne <b>ou</b> par la poste au Canada <b>ou</b>",
+      "item-1": "en personne <strong>ou</strong> par la poste au Canada <strong>ou</strong>",
       "item-2": "par la poste des États-Unis"
     }
   },
@@ -14,20 +14,20 @@
     "description": "L'état de votre demande est disponible après\u00a0:",
     "updated-status": "Nous actualisons quotidiennement l'état des demandes.",
     "list": {
-      "item-1": "5 jours ouvrables si vous avez présenté votre demande en personne <b>ou</b>",
+      "item-1": "5 jours ouvrables si vous avez présenté votre demande en personne <strong>ou</strong>",
       "item-2": "10 jours ouvrables si vous avez envoyé votre demande par la poste"
     }
   },
   "cannot-check": {
     "description": "Vous ne pouvez pas vérifier l'état de votre demande de passeport en ligne si vous en avez fait la demande\u00a0:",
     "list": {
-      "item-1": "dans un consulat ou une ambassade à l'étranger <b>ou</b>",
+      "item-1": "dans un consulat ou une ambassade à l'étranger <strong>ou</strong>",
       "item-2": "pour les affaires officielles du gouvernement (passeports spéciaux ou diplomatiques)"
     }
   },
   "description-privacy": {
     "1": "Les renseignements fournis sont recueillis en vertu de l'article 5.1(1)(a)(i) de la <em>Loi sur le ministère de l'Emploi et du Développement social</em> et/ou de l'article 12(e) du <em>Décret sur les passeports canadiens</em> dans le but de vous fournir l'état de votre demande de passeport. Si vous refusez de fournir des renseignements, vous ne serez pas en mesure de consulter l'état de votre demande de passeport.",
-    "2": "De plus, nous ne recueillons votre adresse courriel que si vous demandez à Emploi et Développement social Canada (EDSC)C d'envoyer votre numéro de dossier de demande de passeport par courriel. Sans votre adresse courriel, EDSC ne peut pas envoyer votre numéro de demande de passeport par voie électronique.",
+    "2": "De plus, nous ne recueillons votre adresse courriel que si vous demandez à Emploi et Développement social Canada (EDSC) d'envoyer votre numéro de dossier de demande de passeport par courriel. Sans votre adresse courriel, EDSC ne peut pas envoyer votre numéro de demande de passeport par voie électronique.",
     "3": "Vos renseignements personnels peuvent être partagés au sein de Service Canada et avec Immigration, Réfugiés et Citoyenneté Canada pour améliorer les services au moyen d'évaluations, de rapports et de recherches. Cela n'entraînera jamais de décision administrative à votre sujet.",
     "4": "EDSC exécute cette application de vérification d'état en utilisant les services du fournisseur tiers Microsoft Corporation, qui peuvent être assujettis à des lois étrangères. Pour plus d'information, consultez la <Link>Politique de confidentialité de Microsoft</Link>.",
     "4-link": "https://www.microsoft.com/fr-ca/trust-center/privacy",

--- a/public/locales/fr/status.json
+++ b/public/locales/fr/status.json
@@ -61,35 +61,24 @@
     },
     "label": "Nom de famille du requérant"
   },
-  "unable-to-find-status": "Nous ne sommes pas en mesure de déterminer l'état de votre demande pour le moment en utilisant ce service.",
-  "other-ways-to-status": "Contactez-nous",
-  "no-match-title": "D'autres façons d'obtenir l'état de votre demande\u00a0:",
   "cannot-provide-result": {
     "title": "Nous ne pouvons pas fournir de résultat pour le moment car:",
     "reason1": "les informations que vous avez fournies ne correspondent pas à celles qui se trouvent dans notre système;",
     "reason2": "nous n'avons pas encore reçu votre demande; ",
     "reason3": "nous avons reçu votre demande mais n'avons pas encore commencé à la traiter."
   },
-  "please-verify": "Veuillez vérifier les informations saisies et réessayer.",
-  "please-wait": "Si vous n'avez pas attendu au moins (insérer le délai/la norme de service complet), veuillez réessayer à une date/heure ultérieure.",
-  "still-unable": {
-    "if-still-unable": "Si vous ne parvenez toujours pas à récupérer l'état de votre demande, vous pouvez le faire:",
-    "contact-call-center": "Contactez le centre d'appels pour les passeports (insérez le numéro de téléphone).",
-    "visit-in-person": "Rendez-vous dans un Centre Service Canada en personne le plus proche de chez vous (lien vers la CSFO)"
-  },
   "no-record": {
     "cannot-give-status": {
       "description": "Nous ne pouvons pas vous donner l'état de votre demande pour le moment",
       "because": "Ceci est dû au fait que\u00a0:",
       "list": {
-        "item-1": "les renseignements que vous nous avez fournis ne correspondent pas à ceux de notre système ",
+        "item-1": "les renseignements que vous nous avez fournis ne correspondent pas à ceux de notre système <strong>ou</strong>",
         "item-2": "nous avons reçu votre demande, mais n'avons pas encore commencé à la traiter"
       }
     },
     "contact-us": "Si vous ne pouvez pas obtenir l'état de votre demande à l'aide de cet outil, ou si votre demande prend plus de temps que la <Link>norme de service</Link>, appelez-nous sans frais au <strong>{{phoneNumber}}</strong>.",
     "service-standard-link": "https://www.canada.ca/fr/immigration-refugies-citoyennete/services/passeports-canadiens/delais-traitement.html",
-    "double-check": "Revérifiez vos renseignements et essayez à nouveau. Si nous ne trouvons pas votre dossier, vous pouvez réessayer demain. Nous mettons à jour nos dossiers chaque jour.",
-    "if": "si"
+    "double-check": "Revérifiez vos renseignements et essayez à nouveau. Si nous ne trouvons pas votre dossier, vous pouvez réessayer demain. Nous mettons à jour nos dossiers chaque jour."
   },
   "being-processed": {
     "received": "Nous avons reçu votre demande et nous sommes en train de la traiter",
@@ -116,10 +105,6 @@
     "call-us": "Pour plus d'informations, appelez-nous sans frais au <strong>{{phoneNumber}}</strong>."
   },
   "status-check-contact": {
-    "description-no-record": {
-      "item-1": "après plusieurs tentatives, vous ne pouvez toujours pas à obtenir l'état de votre demande, ",
-      "item-2": "votre demande prend plus de temps que la "
-    },
     "call-us": "Appelez-nous sans frais au <strong>{{phoneNumber}}</strong> si votre demande prend plus de temps que la <Link>norme de service</Link>",
     "service-standard-href": "https://www.canada.ca/fr/immigration-refugies-citoyennete/services/passeports-canadiens/delais-traitement.html"
   },
@@ -141,7 +126,7 @@
     "list": {
       "item-1": "un certificat de naissance",
       "item-2": "un certificat de citoyenneté",
-      "item-3": "une carte de citoyenneté <b>ou</b>",
+      "item-3": "une carte de citoyenneté <strong>ou</strong>",
       "item-4": "d'autres documents, comme un certificat de naturalisation"
     },
     "for-child-application": "<strong>Pour les demandes de passeport pour enfants,</strong> utilisez le(s) prénom(s), nom de famille et date de naissance de l'enfant, exactement tels qu'ils figurent sur sa preuve de citoyenneté."


### PR DESCRIPTION
## [ADO-2015](https://dev.azure.com/DTS-STN/passport-status/_workitems/edit/2015) [ADO-2060](https://dev.azure.com/DTS-STN/passport-status/_workitems/edit/2060)

### Description
This PR accomplishes a few things. I've updated `CheckStatusNoRecord` to use interpolation instead of using the `or` key (and have removed that key since this was the last instance of it being used). I've switched all instances where the `<b>` tag was being used to `<strong>` as per the a11y audit (excluding the banner since that won't be on prod anyway). I placed the `We update the status of applications daily` text inside a `<p>` tag as per the a11y audit.

Aside from the above, I've also done some general clean-up on our translation files to get rid of keys that were no longer being used.

### What to test for/How to test
1. Pull in branch
2. Type `npm run dev`
3. Navigate to `/expectations`, inspect page and ensure that the text indicated above is in a `<p>` tag, and that there are no `<b>` tags remaining (confirming this second condition on other pages as well)

