### PR TITLE
Add hyperlink that goes to Get ESRF

### DIFF
--- a/pages/landing.tsx
+++ b/pages/landing.tsx
@@ -1,12 +1,13 @@
 import { FC } from 'react'
 import { GetServerSideProps } from 'next'
-import { useTranslation } from 'next-i18next'
+import { Trans, useTranslation } from 'next-i18next'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import { NextSeo } from 'next-seo'
 import Layout from '../components/Layout'
 import LinkButton from '../components/LinkButton'
 import Collapse from '../components/Collapse'
 import ExampleImage from '../components/ExampleImage'
+import LinkText from '../components/LinkText'
 
 const Landing: FC = () => {
   const { t } = useTranslation('landing')
@@ -35,25 +36,31 @@ const Landing: FC = () => {
           />
         </div>
       </div>
-      <Collapse title={t('common:collapse-file-number-title')}>
+      <Collapse title={t('collapse-file-number-title')}>
         <div className="border-t mt-3 p-3 max-w-prose">
-          <p>{t('common:receipt-explanation')}</p>
+          <p>
+            <Trans
+              i18nKey="receipt-explanation"
+              ns="landing"
+              components={{ Link: <LinkText href="/email" /> }}
+            />
+          </p>
           <ExampleImage
-            title={t('common:receipt-image-1.title')}
-            description={t('common:receipt-image-1.descriptive-text')}
+            title={t('receipt-image-1.title')}
+            description={t('receipt-image-1.descriptive-text')}
             imageProps={{
-              src: t('common:receipt-image-1.src'),
-              alt: t('common:receipt-image-1.alt'),
+              src: t('receipt-image-1.src'),
+              alt: t('receipt-image-1.alt'),
               width: 350,
               height: 550,
             }}
           />
           <ExampleImage
-            title={t('common:receipt-image-2.title')}
-            description={t('common:receipt-image-2.descriptive-text')}
+            title={t('receipt-image-2.title')}
+            description={t('receipt-image-2.descriptive-text')}
             imageProps={{
-              src: t('common:receipt-image-2.src'),
-              alt: t('common:receipt-image-2.alt'),
+              src: t('receipt-image-2.src'),
+              alt: t('receipt-image-2.alt'),
               width: 350,
               height: 550,
             }}

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -60,19 +60,5 @@
   "banner": {
     "alert": "Test site",
     "description": "You cannot check the status of your passport application through this test site. Parts of this site may not work and will change."
-  },
-  "collapse-file-number-title": "Can't find your file number?",
-  "receipt-explanation": "The file number is used to identify the passport application. The file number can be found on the receipt you were given if you applied for the passport in person. If you applied by mail, or don't have a file number, request to receive it.",
-  "receipt-image-1": {
-    "title": "Example Receipt 1:",
-    "alt": "An example of an official receipt. The file number is circled in the centre of the receipt.",
-    "src": "/Receipt1_EN.png",
-    "descriptive-text": "Example of a receipt where the file number is circled."
-  },
-  "receipt-image-2": {
-    "title": "Example Receipt 2:",
-    "alt": "An example of an official receipt. The file number is circled in the upper left-hand side of the receipt, above a barcode.",
-    "src": "/Receipt2_EN.png",
-    "descriptive-text": "Example of a receipt where the file number is circled."
   }
 }

--- a/public/locales/en/landing.json
+++ b/public/locales/en/landing.json
@@ -2,5 +2,19 @@
   "header": "Passport application file number",
   "description": "Do you have your passport application file number?",
   "with-esrf": "I have my file number",
-  "without-esrf": "I don't have my file number"
+  "without-esrf": "I don't have my file number",
+  "collapse-file-number-title": "Can't find your file number?",
+  "receipt-explanation": "The file number is used to identify the passport application. The file number can be found on the receipt you were given if you applied for the passport in person. If you applied by mail, or don't have a file number, you can <Link>request to receive it</Link>.",
+  "receipt-image-1": {
+    "title": "Example Receipt 1:",
+    "alt": "An example of an official receipt. The file number is circled in the centre of the receipt.",
+    "src": "/Receipt1_EN.png",
+    "descriptive-text": "Example of a receipt where the file number is circled."
+  },
+  "receipt-image-2": {
+    "title": "Example Receipt 2:",
+    "alt": "An example of an official receipt. The file number is circled in the upper left-hand side of the receipt, above a barcode.",
+    "src": "/Receipt2_EN.png",
+    "descriptive-text": "Example of a receipt where the file number is circled."
+  }
 }

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -60,19 +60,5 @@
   "banner": {
     "alert": "Lieu de test",
     "description": "Vous ne pouvez pas vérifier l'état de votre demande de passeport via ce site de test. Certaines parties de ce site peuvent ne pas fonctionner et seront modifiées."
-  },
-  "collapse-file-number-title": "Vous ne pouvez pas trouver votre numéro de dossier?",
-  "receipt-explanation": "Le numéro de dossier est utilisé pour identifier la demande de passeport. Le numéro de dossier se trouve sur le reçu qui vous a été remis si vous avez fait votre demande de passeport en personne. Si vous avez fait une demande par la poste, ou si vous n'avez pas de numéro de dossier, vous pouvez l'en demander.",
-  "receipt-image-1": {
-    "title": "Exemple de reçu 1\u00a0:",
-    "alt": "Un exemple de reçu officiel. Le numéro de dossier est entouré au centre du reçu.",
-    "src": "/Receipt1_FR.png",
-    "descriptive-text": "Exemple d'un reçu où le numéro de dossier est entouré."
-  },
-  "receipt-image-2": {
-    "title": "Exemple de reçu 2\u00a0:",
-    "alt": "Exemple de reçu officiel. Le numéro de dossier est entouré dans la partie supérieure gauche du reçu, au-dessus d'un code-barres.",
-    "src": "/Receipt2_FR.png",
-    "descriptive-text": "Exemple d'un reçu où le numéro de dossier est entouré."
   }
 }

--- a/public/locales/fr/landing.json
+++ b/public/locales/fr/landing.json
@@ -2,5 +2,19 @@
   "header": "Numéro de dossier de demande de passeport",
   "description": "Avez-vous le numéro de votre dossier de demande de passeport?",
   "with-esrf": "J'ai mon numéro de dossier",
-  "without-esrf": "Je n'ai pas mon numéro de dossier"
+  "without-esrf": "Je n'ai pas mon numéro de dossier",
+  "collapse-file-number-title": "Vous ne pouvez pas trouver votre numéro de dossier?",
+  "receipt-explanation": "Le numéro de dossier est utilisé pour identifier la demande de passeport. Le numéro de dossier se trouve sur le reçu qui vous a été remis si vous avez fait votre demande de passeport en personne. Si vous avez fait une demande par la poste, ou si vous n'avez pas de numéro de dossier, <Link>vous pouvez l'en demander</Link>.",
+  "receipt-image-1": {
+    "title": "Exemple de reçu 1\u00a0:",
+    "alt": "Un exemple de reçu officiel. Le numéro de dossier est entouré au centre du reçu.",
+    "src": "/Receipt1_FR.png",
+    "descriptive-text": "Exemple d'un reçu où le numéro de dossier est entouré."
+  },
+  "receipt-image-2": {
+    "title": "Exemple de reçu 2\u00a0:",
+    "alt": "Exemple de reçu officiel. Le numéro de dossier est entouré dans la partie supérieure gauche du reçu, au-dessus d'un code-barres.",
+    "src": "/Receipt2_FR.png",
+    "descriptive-text": "Exemple d'un reçu où le numéro de dossier est entouré."
+  }
 }


### PR DESCRIPTION
## [ADO-2063](https://dev.azure.com/DTS-STN/passport-status/_workitems/edit/2063)

### Description

List of proposed changes:

- Add hyperlink that goes to Get ESRF in Landing page

### What to test for/How to test

Load the application, navigate to `/landing` page and open the collapsable receipt infor and ensure the explanation text have a link to `/email` and it's using the current UI locale.

### Additional Notes
