### PR TITLE
Add prettier plugin sort imports

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,6 +1,9 @@
-{ 
+{
   "semi": false,
-  tabWidth: 2,
-  singleQuote: true,
-  quoteProps: "consistent"
+  "tabWidth": 2,
+  "singleQuote": true,
+  "quoteProps": "consistent",
+  "importOrder": ["^react$", "^@testing-library/(.*)$", "<THIRD_PARTY_MODULES>", "^[./]"],
+  "importOrderSeparation": true,
+  "importOrderSortSpecifiers": true
 }

--- a/__tests__/api/check-status.test.ts
+++ b/__tests__/api/check-status.test.ts
@@ -1,7 +1,8 @@
-import handler from '../../pages/api/check-status'
-import { createMocks, createRequest, createResponse } from 'node-mocks-http'
-import { CheckStatusApiRequestQuery } from '../../lib/types'
 import { NextApiRequest, NextApiResponse } from 'next'
+import { createMocks, createRequest, createResponse } from 'node-mocks-http'
+
+import { CheckStatusApiRequestQuery } from '../../lib/types'
+import handler from '../../pages/api/check-status'
 
 /**
  * NextApiRequest, NextApiResponse and node-mocks-http createResponse, createResponse types union

--- a/__tests__/api/email-esrf.ts
+++ b/__tests__/api/email-esrf.ts
@@ -1,8 +1,9 @@
-import handler from '../../pages/api/email-esrf'
-import { createMocks, createRequest, createResponse } from 'node-mocks-http'
-import { NextApiRequest, NextApiResponse } from 'next'
 import { IncomingHttpHeaders } from 'http'
+import { NextApiRequest, NextApiResponse } from 'next'
+import { createMocks, createRequest, createResponse } from 'node-mocks-http'
+
 import { EmailEsrfApiRequestBody } from '../../lib/types'
+import handler from '../../pages/api/email-esrf'
 
 /**
  * NextApiRequest, NextApiResponse and node-mocks-http createResponse, createResponse types union

--- a/__tests__/components/ActionButton.test.tsx
+++ b/__tests__/components/ActionButton.test.tsx
@@ -1,6 +1,8 @@
-import { render, screen } from '@testing-library/react'
 import '@testing-library/jest-dom/extend-expect'
+import { render, screen } from '@testing-library/react'
+
 import { axe, toHaveNoViolations } from 'jest-axe'
+
 import ActionButton from '../../components/ActionButton'
 
 expect.extend(toHaveNoViolations)

--- a/__tests__/components/Banner.test.tsx
+++ b/__tests__/components/Banner.test.tsx
@@ -1,6 +1,8 @@
-import { render, screen } from '@testing-library/react'
 import '@testing-library/jest-dom/extend-expect'
+import { render, screen } from '@testing-library/react'
+
 import { axe, toHaveNoViolations } from 'jest-axe'
+
 import Banner from '../../components/Banner'
 
 expect.extend(toHaveNoViolations)

--- a/__tests__/components/CheckStatusFileBeingProcessed.test.tsx
+++ b/__tests__/components/CheckStatusFileBeingProcessed.test.tsx
@@ -1,6 +1,8 @@
-import { render, screen } from '@testing-library/react'
-import { axe, toHaveNoViolations } from 'jest-axe'
 import '@testing-library/jest-dom/extend-expect'
+import { render, screen } from '@testing-library/react'
+
+import { axe, toHaveNoViolations } from 'jest-axe'
+
 import CheckStatusFileBeingProcessed from '../../components/CheckStatusResponses/CheckStatusFileBeingProcessed'
 
 expect.extend(toHaveNoViolations)

--- a/__tests__/components/CheckStatusInfo.test.tsx
+++ b/__tests__/components/CheckStatusInfo.test.tsx
@@ -1,6 +1,8 @@
-import { render, screen } from '@testing-library/react'
-import { axe, toHaveNoViolations } from 'jest-axe'
 import '@testing-library/jest-dom/extend-expect'
+import { render, screen } from '@testing-library/react'
+
+import { axe, toHaveNoViolations } from 'jest-axe'
+
 import CheckStatusInfo from '../../components/CheckStatusInfo'
 
 expect.extend(toHaveNoViolations)

--- a/__tests__/components/CheckStatusNoRecord.test.tsx
+++ b/__tests__/components/CheckStatusNoRecord.test.tsx
@@ -1,6 +1,8 @@
-import { render, screen } from '@testing-library/react'
-import { axe, toHaveNoViolations } from 'jest-axe'
 import '@testing-library/jest-dom/extend-expect'
+import { render, screen } from '@testing-library/react'
+
+import { axe, toHaveNoViolations } from 'jest-axe'
+
 import CheckStatusNoRecord from '../../components/CheckStatusResponses/CheckStatusNoRecord'
 
 expect.extend(toHaveNoViolations)

--- a/__tests__/components/CheckStatusNotAcceptable.test.tsx
+++ b/__tests__/components/CheckStatusNotAcceptable.test.tsx
@@ -1,6 +1,8 @@
-import { render, screen } from '@testing-library/react'
-import { axe, toHaveNoViolations } from 'jest-axe'
 import '@testing-library/jest-dom/extend-expect'
+import { render, screen } from '@testing-library/react'
+
+import { axe, toHaveNoViolations } from 'jest-axe'
+
 import CheckStatusNotAcceptable from '../../components/CheckStatusResponses/CheckStatusNotAcceptable'
 
 expect.extend(toHaveNoViolations)

--- a/__tests__/components/CheckStatusReadyForPickup.test.tsx
+++ b/__tests__/components/CheckStatusReadyForPickup.test.tsx
@@ -1,6 +1,8 @@
-import { render, screen } from '@testing-library/react'
-import { axe, toHaveNoViolations } from 'jest-axe'
 import '@testing-library/jest-dom/extend-expect'
+import { render, screen } from '@testing-library/react'
+
+import { axe, toHaveNoViolations } from 'jest-axe'
+
 import CheckStatusReadyForPickup from '../../components/CheckStatusResponses/CheckStatusReadyForPickup'
 
 expect.extend(toHaveNoViolations)

--- a/__tests__/components/CheckStatusShippingCanadaPost.test.tsx
+++ b/__tests__/components/CheckStatusShippingCanadaPost.test.tsx
@@ -1,6 +1,8 @@
-import { render, screen } from '@testing-library/react'
-import { axe, toHaveNoViolations } from 'jest-axe'
 import '@testing-library/jest-dom/extend-expect'
+import { render, screen } from '@testing-library/react'
+
+import { axe, toHaveNoViolations } from 'jest-axe'
+
 import CheckStatusShippingFedex from '../../components/CheckStatusResponses/CheckStatusShippingFedex'
 
 expect.extend(toHaveNoViolations)

--- a/__tests__/components/CheckStatusShippingFedex.test.tsx
+++ b/__tests__/components/CheckStatusShippingFedex.test.tsx
@@ -1,6 +1,8 @@
-import { render, screen } from '@testing-library/react'
-import { axe, toHaveNoViolations } from 'jest-axe'
 import '@testing-library/jest-dom/extend-expect'
+import { render, screen } from '@testing-library/react'
+
+import { axe, toHaveNoViolations } from 'jest-axe'
+
 import CheckStatusFileBeingProcessed from '../../components/CheckStatusResponses/CheckStatusFileBeingProcessed'
 
 expect.extend(toHaveNoViolations)

--- a/__tests__/components/Collapse.test.tsx
+++ b/__tests__/components/Collapse.test.tsx
@@ -1,6 +1,8 @@
-import { render, screen } from '@testing-library/react'
 import '@testing-library/jest-dom/extend-expect'
+import { render, screen } from '@testing-library/react'
+
 import { axe, toHaveNoViolations } from 'jest-axe'
+
 import Collapse from '../../components/Collapse'
 
 expect.extend(toHaveNoViolations)

--- a/__tests__/components/DateModified.test.tsx
+++ b/__tests__/components/DateModified.test.tsx
@@ -1,6 +1,8 @@
-import { render } from '@testing-library/react'
 import '@testing-library/jest-dom/extend-expect'
+import { render } from '@testing-library/react'
+
 import { axe, toHaveNoViolations } from 'jest-axe'
+
 import DateModified from '../../components/DateModified'
 
 expect.extend(toHaveNoViolations)

--- a/__tests__/components/DateSelect.test.tsx
+++ b/__tests__/components/DateSelect.test.tsx
@@ -1,6 +1,8 @@
-import { render, screen } from '@testing-library/react'
 import '@testing-library/jest-dom/extend-expect'
+import { render, screen } from '@testing-library/react'
+
 import { axe, toHaveNoViolations } from 'jest-axe'
+
 import DateSelect from '../../components/DateSelect'
 
 expect.extend(toHaveNoViolations)

--- a/__tests__/components/DateSelectField.test.tsx
+++ b/__tests__/components/DateSelectField.test.tsx
@@ -1,9 +1,12 @@
 import { FC } from 'react'
-import { render, screen } from '@testing-library/react'
+
 import '@testing-library/jest-dom/extend-expect'
+import { render, screen } from '@testing-library/react'
+
 import { axe, toHaveNoViolations } from 'jest-axe'
-import DateSelectField from '../../components/DateSelectField'
+
 import { DateSelectProps } from '../../components/DateSelect'
+import DateSelectField from '../../components/DateSelectField'
 
 expect.extend(toHaveNoViolations)
 

--- a/__tests__/components/ErrorLayout.test.tsx
+++ b/__tests__/components/ErrorLayout.test.tsx
@@ -1,9 +1,11 @@
 /**
  * @jest-environment jsdom
  */
-import { render, screen } from '@testing-library/react'
 import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+
 import { axe, toHaveNoViolations } from 'jest-axe'
+
 import ErrorLayout from '../../components/ErrorLayout'
 
 expect.extend(toHaveNoViolations)

--- a/__tests__/components/ErrorSummary.test.tsx
+++ b/__tests__/components/ErrorSummary.test.tsx
@@ -1,6 +1,8 @@
-import { render, screen } from '@testing-library/react'
 import '@testing-library/jest-dom/extend-expect'
+import { render, screen } from '@testing-library/react'
+
 import { axe, toHaveNoViolations } from 'jest-axe'
+
 import ErrorSummary from '../../components/ErrorSummary'
 
 expect.extend(toHaveNoViolations)

--- a/__tests__/components/ExampleImage.test.tsx
+++ b/__tests__/components/ExampleImage.test.tsx
@@ -1,6 +1,8 @@
-import { render, screen, waitFor } from '@testing-library/react'
 import '@testing-library/jest-dom/extend-expect'
+import { render, screen, waitFor } from '@testing-library/react'
+
 import { axe, toHaveNoViolations } from 'jest-axe'
+
 import ExampleImage from '../../components/ExampleImage'
 
 expect.extend(toHaveNoViolations)

--- a/__tests__/components/ExternalLink.test.tsx
+++ b/__tests__/components/ExternalLink.test.tsx
@@ -1,6 +1,8 @@
-import { render, screen } from '@testing-library/react'
-import { axe, toHaveNoViolations } from 'jest-axe'
 import '@testing-library/jest-dom/extend-expect'
+import { render, screen } from '@testing-library/react'
+
+import { axe, toHaveNoViolations } from 'jest-axe'
+
 import ExternalLink from '../../components/ExternalLink'
 
 expect.extend(toHaveNoViolations)

--- a/__tests__/components/Footer.test.tsx
+++ b/__tests__/components/Footer.test.tsx
@@ -1,7 +1,9 @@
-import { render, screen } from '@testing-library/react'
-import '@testing-library/jest-dom/extend-expect'
 import '@testing-library/jest-dom'
+import '@testing-library/jest-dom/extend-expect'
+import { render, screen } from '@testing-library/react'
+
 import { axe, toHaveNoViolations } from 'jest-axe'
+
 import Footer from '../../components/Footer'
 
 expect.extend(toHaveNoViolations)

--- a/__tests__/components/Header.test.tsx
+++ b/__tests__/components/Header.test.tsx
@@ -1,7 +1,9 @@
-import { render, screen } from '@testing-library/react'
 import '@testing-library/jest-dom/extend-expect'
+import { render, screen } from '@testing-library/react'
+
 import { axe, toHaveNoViolations } from 'jest-axe'
 import { useRouter } from 'next/router'
+
 import Header from '../../components/Header'
 
 const defaultRouterObj = {

--- a/__tests__/components/IdleTimeout.test.tsx
+++ b/__tests__/components/IdleTimeout.test.tsx
@@ -1,6 +1,8 @@
 import { FC } from 'react'
-import { render, screen } from '@testing-library/react'
+
 import '@testing-library/jest-dom/extend-expect'
+import { render, screen } from '@testing-library/react'
+
 import IdleTimeout from '../../components/IdleTimeout'
 import { ModalProps } from '../../components/Modal'
 

--- a/__tests__/components/InputErrorMessage.test.tsx
+++ b/__tests__/components/InputErrorMessage.test.tsx
@@ -1,6 +1,8 @@
-import { render, screen } from '@testing-library/react'
 import '@testing-library/jest-dom/extend-expect'
+import { render, screen } from '@testing-library/react'
+
 import { axe, toHaveNoViolations } from 'jest-axe'
+
 import InputErrorMessage from '../../components/InputErrorMessage'
 
 expect.extend(toHaveNoViolations)

--- a/__tests__/components/InputField.test.tsx
+++ b/__tests__/components/InputField.test.tsx
@@ -1,6 +1,8 @@
-import { render, screen } from '@testing-library/react'
 import '@testing-library/jest-dom/extend-expect'
+import { render, screen } from '@testing-library/react'
+
 import { axe, toHaveNoViolations } from 'jest-axe'
+
 import InputField from '../../components/InputField'
 
 expect.extend(toHaveNoViolations)

--- a/__tests__/components/InputLabel.test.tsx
+++ b/__tests__/components/InputLabel.test.tsx
@@ -1,7 +1,9 @@
-import { render, screen } from '@testing-library/react'
 import '@testing-library/jest-dom/extend-expect'
-import InputLabel from '../../components/InputLabel'
+import { render, screen } from '@testing-library/react'
+
 import { axe, toHaveNoViolations } from 'jest-axe'
+
+import InputLabel from '../../components/InputLabel'
 
 expect.extend(toHaveNoViolations)
 

--- a/__tests__/components/Layout.test.tsx
+++ b/__tests__/components/Layout.test.tsx
@@ -1,7 +1,10 @@
 import React from 'react'
-import { render, screen } from '@testing-library/react'
+
 import '@testing-library/jest-dom/extend-expect'
+import { render, screen } from '@testing-library/react'
+
 import { axe, toHaveNoViolations } from 'jest-axe'
+
 import Layout from '../../components/Layout'
 
 //mock custom components

--- a/__tests__/components/LinkButton.test.tsx
+++ b/__tests__/components/LinkButton.test.tsx
@@ -1,6 +1,8 @@
-import { render, screen } from '@testing-library/react'
 import '@testing-library/jest-dom/extend-expect'
+import { render, screen } from '@testing-library/react'
+
 import { axe, toHaveNoViolations } from 'jest-axe'
+
 import LinkButton from '../../components/LinkButton'
 
 expect.extend(toHaveNoViolations)

--- a/__tests__/components/Modal.test.tsx
+++ b/__tests__/components/Modal.test.tsx
@@ -1,6 +1,8 @@
-import { render, screen } from '@testing-library/react'
-import { axe, toHaveNoViolations } from 'jest-axe'
 import '@testing-library/jest-dom/extend-expect'
+import { render, screen } from '@testing-library/react'
+
+import { axe, toHaveNoViolations } from 'jest-axe'
+
 import Modal from '../../components/Modal'
 
 expect.extend(toHaveNoViolations)

--- a/__tests__/next-seo.config.test.ts
+++ b/__tests__/next-seo.config.test.ts
@@ -1,11 +1,13 @@
 import '@testing-library/jest-dom'
+
 import { OpenGraphMedia } from 'next-seo/lib/types'
+
 import {
+  LanguageAlternate,
+  NextSEORouter,
   getLanguageAlternates,
   getNextSEOConfig,
   getOpenGraphImages,
-  LanguageAlternate,
-  NextSEORouter,
 } from '../next-seo.config'
 
 describe('getNextSEOConfig', () => {

--- a/__tests__/pages/404.test.tsx
+++ b/__tests__/pages/404.test.tsx
@@ -1,8 +1,9 @@
 /**
  * @jest-environment jsdom
  */
-import { render, screen } from '@testing-library/react'
 import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+
 import Custom404 from '../../pages/404'
 
 describe('404', () => {

--- a/__tests__/pages/_app.test.tsx
+++ b/__tests__/pages/_app.test.tsx
@@ -1,10 +1,12 @@
 /**
  * @jest-environment jsdom
  */
-import { render, screen } from '@testing-library/react'
 import '@testing-library/jest-dom'
-import App from '../../pages/_app'
+import { render, screen } from '@testing-library/react'
+
 import { Router } from 'next/router'
+
+import App from '../../pages/_app'
 
 const MockComponent = jest
   .fn()

--- a/__tests__/pages/_error.test.tsx
+++ b/__tests__/pages/_error.test.tsx
@@ -1,8 +1,9 @@
 /**
  * @jest-environment jsdom
  */
-import { render, screen } from '@testing-library/react'
 import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+
 import CustomError from '../../pages/_error'
 
 describe('custom error', () => {

--- a/__tests__/pages/email.test.tsx
+++ b/__tests__/pages/email.test.tsx
@@ -1,6 +1,8 @@
-import { render, screen } from '@testing-library/react'
 import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+
 import { axe, toHaveNoViolations } from 'jest-axe'
+
 import Email from '../../pages/email'
 
 expect.extend(toHaveNoViolations)

--- a/__tests__/pages/expectations.test.tsx
+++ b/__tests__/pages/expectations.test.tsx
@@ -1,9 +1,11 @@
 /**
  * @jest-environment jsdom
  */
-import { render, screen } from '@testing-library/react'
 import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+
 import { axe, toHaveNoViolations } from 'jest-axe'
+
 import Expectations from '../../pages/expectations'
 
 expect.extend(toHaveNoViolations)

--- a/__tests__/pages/index.test.tsx
+++ b/__tests__/pages/index.test.tsx
@@ -1,8 +1,9 @@
 /**
  * @jest-environment jsdom
  */
-import { render, screen } from '@testing-library/react'
 import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+
 import Index from '../../pages/index'
 
 // mocks useRouter to be able to use component' router.asPath

--- a/__tests__/pages/landing.test.tsx
+++ b/__tests__/pages/landing.test.tsx
@@ -1,10 +1,12 @@
 /**
  * @jest-environment jsdom
  */
-import { render, screen } from '@testing-library/react'
 import '@testing-library/jest-dom'
-import Landing from '../../pages/landing'
+import { render, screen } from '@testing-library/react'
+
 import { axe, toHaveNoViolations } from 'jest-axe'
+
+import Landing from '../../pages/landing'
 
 expect.extend(toHaveNoViolations)
 

--- a/__tests__/pages/status.test.tsx
+++ b/__tests__/pages/status.test.tsx
@@ -1,6 +1,8 @@
-import { render, screen } from '@testing-library/react'
 import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+
 import { axe, toHaveNoViolations } from 'jest-axe'
+
 import Status from '../../pages/status'
 
 expect.extend(toHaveNoViolations)

--- a/components/CheckStatusInfo.tsx
+++ b/components/CheckStatusInfo.tsx
@@ -1,13 +1,14 @@
 import { FC, MouseEventHandler } from 'react'
+
 import { CheckStatusApiResponse } from '../lib/types'
-import ActionButton, { ActionButtonStyle } from './ActionButton'
 import { StatusCode } from '../lib/types'
+import ActionButton, { ActionButtonStyle } from './ActionButton'
 import CheckStatusFileBeingProcessed from './CheckStatusResponses/CheckStatusFileBeingProcessed'
+import CheckStatusNoRecord from './CheckStatusResponses/CheckStatusNoRecord'
+import CheckStatusNotAcceptable from './CheckStatusResponses/CheckStatusNotAcceptable'
 import CheckStatusReadyForPickup from './CheckStatusResponses/CheckStatusReadyForPickup'
 import CheckStatusShippingCanadaPost from './CheckStatusResponses/CheckStatusShippingCanadaPost'
 import CheckStatusShippingFedex from './CheckStatusResponses/CheckStatusShippingFedex'
-import CheckStatusNotAcceptable from './CheckStatusResponses/CheckStatusNotAcceptable'
-import CheckStatusNoRecord from './CheckStatusResponses/CheckStatusNoRecord'
 
 export interface CheckStatusInfoProps {
   id: string

--- a/components/CheckStatusResponses/CheckStatusFileBeingProcessed.tsx
+++ b/components/CheckStatusResponses/CheckStatusFileBeingProcessed.tsx
@@ -1,5 +1,7 @@
 import { FC } from 'react'
+
 import { Trans, useTranslation } from 'next-i18next'
+
 import ExternalLink from '../ExternalLink'
 
 export const CheckStatusFileBeingProcessed: FC<{}> = () => {

--- a/components/CheckStatusResponses/CheckStatusNoRecord.tsx
+++ b/components/CheckStatusResponses/CheckStatusNoRecord.tsx
@@ -1,5 +1,7 @@
 import { FC } from 'react'
+
 import { Trans, useTranslation } from 'next-i18next'
+
 import ExternalLink from '../ExternalLink'
 
 export const CheckStatusNoRecord: FC<{}> = () => {

--- a/components/CheckStatusResponses/CheckStatusNotAcceptable.tsx
+++ b/components/CheckStatusResponses/CheckStatusNotAcceptable.tsx
@@ -1,4 +1,5 @@
 import { FC } from 'react'
+
 import { Trans, useTranslation } from 'next-i18next'
 
 export const CheckStatusNotAcceptable: FC<{}> = () => {

--- a/components/CheckStatusResponses/CheckStatusReadyForPickup.tsx
+++ b/components/CheckStatusResponses/CheckStatusReadyForPickup.tsx
@@ -1,4 +1,5 @@
 import { FC } from 'react'
+
 import { useTranslation } from 'next-i18next'
 
 export const CheckStatusReadyForPickup: FC<{}> = () => {

--- a/components/CheckStatusResponses/CheckStatusShippingCanadaPost.tsx
+++ b/components/CheckStatusResponses/CheckStatusShippingCanadaPost.tsx
@@ -1,5 +1,7 @@
 import { FC } from 'react'
+
 import { Trans, useTranslation } from 'next-i18next'
+
 import ExternalLink from '../ExternalLink'
 
 export interface CheckStatusShippingCanadaPostProps {

--- a/components/CheckStatusResponses/CheckStatusShippingFedex.tsx
+++ b/components/CheckStatusResponses/CheckStatusShippingFedex.tsx
@@ -1,5 +1,7 @@
 import { FC } from 'react'
+
 import { Trans, useTranslation } from 'next-i18next'
+
 import ExternalLink from '../ExternalLink'
 
 export interface CheckStatusShippingFedexProps {

--- a/components/DateSelectField.tsx
+++ b/components/DateSelectField.tsx
@@ -1,12 +1,14 @@
-import { FC, useEffect, useMemo, useState, useCallback, useRef } from 'react'
-import { useTranslation } from 'next-i18next'
-import InputErrorMessage from './InputErrorMessage'
-import InputLabel from './InputLabel'
+import { FC, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+
 import { getDaysInMonth, isExists } from 'date-fns'
+import { useTranslation } from 'next-i18next'
+
 import DateSelect, {
   DateSelectOnChangeEvent,
   DateSelectOption,
 } from './DateSelect'
+import InputErrorMessage from './InputErrorMessage'
+import InputLabel from './InputLabel'
 
 export type DateSelectFieldOnChangeEvent = (dateString: string) => void
 

--- a/components/ErrorSummary.tsx
+++ b/components/ErrorSummary.tsx
@@ -1,6 +1,7 @@
+import { FC, useEffect } from 'react'
+
 import { FormikErrors } from 'formik'
 import { TFunction } from 'next-i18next'
-import { FC, useEffect } from 'react'
 
 export interface ErrorSummaryItem {
   feildId: string

--- a/components/ExampleImage.tsx
+++ b/components/ExampleImage.tsx
@@ -1,4 +1,5 @@
 import { FC } from 'react'
+
 import Image from 'next/future/image'
 
 export interface ImageProps {

--- a/components/ExternalLink.tsx
+++ b/components/ExternalLink.tsx
@@ -1,4 +1,5 @@
 import { FC, PropsWithChildren } from 'react'
+
 import { useTranslation } from 'next-i18next'
 
 export interface ExternalLinkProps extends PropsWithChildren {

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,4 +1,5 @@
 import { FC } from 'react'
+
 import DateModified from './DateModified'
 
 export interface FooterLink {

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,9 +1,11 @@
 import React, { FC } from 'react'
-import Link from 'next/link'
-import { useRouter } from 'next/router'
-import Banner from './Banner'
+
 import { useTranslation } from 'next-i18next'
 import getConfig from 'next/config'
+import Link from 'next/link'
+import { useRouter } from 'next/router'
+
+import Banner from './Banner'
 
 export interface HeaderProps {
   gocLink: string

--- a/components/IdleTimeout.tsx
+++ b/components/IdleTimeout.tsx
@@ -1,8 +1,10 @@
+import { FC, useCallback, useEffect, useState } from 'react'
+
 import { deleteCookie } from 'cookies-next'
 import { useTranslation } from 'next-i18next'
 import { useRouter } from 'next/router'
-import { FC, useState, useEffect, useCallback } from 'react'
 import { IIdleTimerProps, useIdleTimer } from 'react-idle-timer'
+
 import Modal from './Modal'
 
 export interface IdleTimeoutProps

--- a/components/InputField.tsx
+++ b/components/InputField.tsx
@@ -1,4 +1,5 @@
 import React, { FC } from 'react'
+
 import InputErrorMessage from './InputErrorMessage'
 import InputLabel from './InputLabel'
 

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -1,7 +1,9 @@
 import { FC, ReactNode } from 'react'
-import Header from './Header'
-import Footer from './Footer'
+
 import { useTranslation } from 'next-i18next'
+
+import Footer from './Footer'
+import Header from './Header'
 
 export interface LayoutProps {
   children: ReactNode

--- a/components/LinkButton.tsx
+++ b/components/LinkButton.tsx
@@ -1,4 +1,5 @@
 import { FC } from 'react'
+
 import Link from 'next/link'
 
 export type LinkButtonSize = 'xs' | 'sm' | 'md' | 'lg'

--- a/components/LinkText.tsx
+++ b/components/LinkText.tsx
@@ -1,4 +1,5 @@
 import { FC } from 'react'
+
 import Link, { LinkProps } from 'next/link'
 
 type LinkTextProps<T> = React.AnchorHTMLAttributes<HTMLAnchorElement> &

--- a/components/Modal.tsx
+++ b/components/Modal.tsx
@@ -1,6 +1,8 @@
 import { FC, ReactNode, useEffect, useId, useRef } from 'react'
-import ActionButton, { ActionButtonProps } from './ActionButton'
+
 import { FocusOn } from 'react-focus-on'
+
+import ActionButton, { ActionButtonProps } from './ActionButton'
 
 export interface ModalProps {
   actionButtons: ActionButtonProps[]

--- a/lib/useCheckStatus.ts
+++ b/lib/useCheckStatus.ts
@@ -1,6 +1,7 @@
-import { useQuery, UseQueryOptions } from '@tanstack/react-query'
+import { UseQueryOptions, useQuery } from '@tanstack/react-query'
 import { ApiError } from 'next/dist/server/api-utils'
-import { CheckStatusApiResponse, CheckStatusApiRequestQuery } from './types'
+
+import { CheckStatusApiRequestQuery, CheckStatusApiResponse } from './types'
 
 export const fetchCheckStatus = async (
   checkStatusApiRequestQuery: CheckStatusApiRequestQuery,

--- a/lib/useEmailEsrf.ts
+++ b/lib/useEmailEsrf.ts
@@ -1,5 +1,6 @@
-import { useMutation, UseMutationOptions } from '@tanstack/react-query'
+import { UseMutationOptions, useMutation } from '@tanstack/react-query'
 import { ApiError } from 'next/dist/server/api-utils'
+
 import { EmailEsrfApiRequestBody } from './types'
 
 const useEmailEsrf = (

--- a/load-test.js
+++ b/load-test.js
@@ -1,6 +1,5 @@
 // k6 Documentation: https://k6.io/docs/
-
-import { sleep, group } from 'k6'
+import { group, sleep } from 'k6'
 import http from 'k6/http'
 
 export const options = {

--- a/logging/log-util.tsx
+++ b/logging/log-util.tsx
@@ -1,5 +1,6 @@
-import logLevelData from './log-level'
 import pino, { Logger, stdTimeFunctions } from 'pino'
+
+import logLevelData from './log-level'
 
 const logLevels = new Map<string, string | undefined>(
   Object.entries(logLevelData)

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
+
 import { getLogger } from './logging/log-util'
 
 //regex to check if there's an extension in the path, ie .jpg

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "@testing-library/dom": "^8.20.0",
         "@testing-library/jest-dom": "^5.16.5",
         "@testing-library/react": "^13.4.0",
+        "@trivago/prettier-plugin-sort-imports": "^4.0.0",
         "@types/jest": "^29.4.0",
         "@types/jest-axe": "^3.5.5",
         "@types/node": "^18.11.18",
@@ -2113,6 +2114,124 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@trivago/prettier-plugin-sort-imports": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@trivago/prettier-plugin-sort-imports/-/prettier-plugin-sort-imports-4.0.0.tgz",
+      "integrity": "sha512-Tyuk5ZY4a0e2MNFLdluQO9F6d1awFQYXVVujEPFfvKPPXz8DADNHzz73NMhwCSXGSuGGZcA/rKOyZBrxVNMxaA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "7.17.8",
+        "@babel/generator": "7.17.7",
+        "@babel/parser": "7.18.9",
+        "@babel/traverse": "7.17.3",
+        "@babel/types": "7.17.0",
+        "javascript-natural-sort": "0.7.1",
+        "lodash": "4.17.21"
+      },
+      "peerDependencies": {
+        "@vue/compiler-sfc": "3.x",
+        "prettier": "2.x"
+      }
+    },
+    "node_modules/@trivago/prettier-plugin-sort-imports/node_modules/@babel/core": {
+      "version": "7.17.8",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.17.8.tgz",
+      "integrity": "sha512-OdQDV/7cRBtJHLSOBqqbYNkOcydOgnX59TZx4puf41fzcVtN3e/4yqY8lMQsK+5X2lJtAdmA+6OHqsj1hBJ4IQ==",
+      "dev": true,
+      "dependencies": {
+        "@ampproject/remapping": "^2.1.0",
+        "@babel/code-frame": "^7.16.7",
+        "@babel/generator": "^7.17.7",
+        "@babel/helper-compilation-targets": "^7.17.7",
+        "@babel/helper-module-transforms": "^7.17.7",
+        "@babel/helpers": "^7.17.8",
+        "@babel/parser": "^7.17.8",
+        "@babel/template": "^7.16.7",
+        "@babel/traverse": "^7.17.3",
+        "@babel/types": "^7.17.0",
+        "convert-source-map": "^1.7.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.1.2",
+        "semver": "^6.3.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@trivago/prettier-plugin-sort-imports/node_modules/@babel/generator": {
+      "version": "7.17.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.17.7.tgz",
+      "integrity": "sha512-oLcVCTeIFadUoArDTwpluncplrYBmTCCZZgXCbgNGvOBBiSDDK3eWO4b/+eOTli5tKv1lg+a5/NAXg+nTcei1w==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.17.0",
+        "jsesc": "^2.5.1",
+        "source-map": "^0.5.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@trivago/prettier-plugin-sort-imports/node_modules/@babel/parser": {
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.18.9.tgz",
+      "integrity": "sha512-9uJveS9eY9DJ0t64YbIBZICtJy8a5QrDEVdiLCG97fVLpDTpGX7t8mMSb6OWw6Lrnjqj4O8zwjELX3dhoMgiBg==",
+      "dev": true,
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@trivago/prettier-plugin-sort-imports/node_modules/@babel/traverse": {
+      "version": "7.17.3",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.17.3.tgz",
+      "integrity": "sha512-5irClVky7TxRWIRtxlh2WPUUOLhcPN06AGgaQSB8AEwuyEBgJVuJ5imdHm5zxk8w0QS5T+tDfnDxAlhWjpb7cw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.16.7",
+        "@babel/generator": "^7.17.3",
+        "@babel/helper-environment-visitor": "^7.16.7",
+        "@babel/helper-function-name": "^7.16.7",
+        "@babel/helper-hoist-variables": "^7.16.7",
+        "@babel/helper-split-export-declaration": "^7.16.7",
+        "@babel/parser": "^7.17.3",
+        "@babel/types": "^7.17.0",
+        "debug": "^4.1.0",
+        "globals": "^11.1.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@trivago/prettier-plugin-sort-imports/node_modules/@babel/types": {
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.17.0.tgz",
+      "integrity": "sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.16.7",
+        "to-fast-properties": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@trivago/prettier-plugin-sort-imports/node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
@@ -2528,6 +2647,81 @@
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       }
+    },
+    "node_modules/@vue/compiler-core": {
+      "version": "3.2.45",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.45.tgz",
+      "integrity": "sha512-rcMj7H+PYe5wBV3iYeUgbCglC+pbpN8hBLTJvRiK2eKQiWqu+fG9F+8sW99JdL4LQi7Re178UOxn09puSXvn4A==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@babel/parser": "^7.16.4",
+        "@vue/shared": "3.2.45",
+        "estree-walker": "^2.0.2",
+        "source-map": "^0.6.1"
+      }
+    },
+    "node_modules/@vue/compiler-dom": {
+      "version": "3.2.45",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.2.45.tgz",
+      "integrity": "sha512-tyYeUEuKqqZO137WrZkpwfPCdiiIeXYCcJ8L4gWz9vqaxzIQRccTSwSWZ/Axx5YR2z+LvpUbmPNXxuBU45lyRw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@vue/compiler-core": "3.2.45",
+        "@vue/shared": "3.2.45"
+      }
+    },
+    "node_modules/@vue/compiler-sfc": {
+      "version": "3.2.45",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.2.45.tgz",
+      "integrity": "sha512-1jXDuWah1ggsnSAOGsec8cFjT/K6TMZ0sPL3o3d84Ft2AYZi2jWJgRMjw4iaK0rBfA89L5gw427H4n1RZQBu6Q==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@babel/parser": "^7.16.4",
+        "@vue/compiler-core": "3.2.45",
+        "@vue/compiler-dom": "3.2.45",
+        "@vue/compiler-ssr": "3.2.45",
+        "@vue/reactivity-transform": "3.2.45",
+        "@vue/shared": "3.2.45",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.25.7",
+        "postcss": "^8.1.10",
+        "source-map": "^0.6.1"
+      }
+    },
+    "node_modules/@vue/compiler-ssr": {
+      "version": "3.2.45",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.2.45.tgz",
+      "integrity": "sha512-6BRaggEGqhWht3lt24CrIbQSRD5O07MTmd+LjAn5fJj568+R9eUD2F7wMQJjX859seSlrYog7sUtrZSd7feqrQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@vue/compiler-dom": "3.2.45",
+        "@vue/shared": "3.2.45"
+      }
+    },
+    "node_modules/@vue/reactivity-transform": {
+      "version": "3.2.45",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity-transform/-/reactivity-transform-3.2.45.tgz",
+      "integrity": "sha512-BHVmzYAvM7vcU5WmuYqXpwaBHjsS8T63jlKGWVtHxAHIoMIlmaMyurUSEs1Zcg46M4AYT5MtB1U274/2aNzjJQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "@babel/parser": "^7.16.4",
+        "@vue/compiler-core": "3.2.45",
+        "@vue/shared": "3.2.45",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.25.7"
+      }
+    },
+    "node_modules/@vue/shared": {
+      "version": "3.2.45",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.45.tgz",
+      "integrity": "sha512-Ewzq5Yhimg7pSztDV+RH1UDKBzmtqieXQlpTVm2AwraoRL/Rks96mvd8Vgi7Lj+h+TH8dv7mXD3FRZR3TUvbSg==",
+      "dev": true,
+      "peer": true
     },
     "node_modules/abab": {
       "version": "2.0.6",
@@ -5269,6 +5463,13 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true,
+      "peer": true
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -6944,6 +7145,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/javascript-natural-sort": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/javascript-natural-sort/-/javascript-natural-sort-0.7.1.tgz",
+      "integrity": "sha512-nO6jcEfZWQXDhOiBtG2KvKyEptz7RVbpGP4vTD2hLBdmNQSsCiicO2Ioinv6UI4y9ukqnBpy+XZ9H6uLNgJTlw==",
+      "dev": true
     },
     "node_modules/jest": {
       "version": "29.4.1",
@@ -9721,6 +9928,16 @@
       "dev": true,
       "bin": {
         "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
+      "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "sourcemap-codec": "^1.4.8"
       }
     },
     "node_modules/make-dir": {
@@ -12528,6 +12745,14 @@
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
       }
+    },
+    "node_modules/sourcemap-codec": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+      "deprecated": "Please use @jridgewell/sourcemap-codec instead",
+      "dev": true,
+      "peer": true
     },
     "node_modules/split": {
       "version": "0.3.3",
@@ -15535,6 +15760,97 @@
       "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
       "dev": true
     },
+    "@trivago/prettier-plugin-sort-imports": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@trivago/prettier-plugin-sort-imports/-/prettier-plugin-sort-imports-4.0.0.tgz",
+      "integrity": "sha512-Tyuk5ZY4a0e2MNFLdluQO9F6d1awFQYXVVujEPFfvKPPXz8DADNHzz73NMhwCSXGSuGGZcA/rKOyZBrxVNMxaA==",
+      "dev": true,
+      "requires": {
+        "@babel/core": "7.17.8",
+        "@babel/generator": "7.17.7",
+        "@babel/parser": "7.18.9",
+        "@babel/traverse": "7.17.3",
+        "@babel/types": "7.17.0",
+        "javascript-natural-sort": "0.7.1",
+        "lodash": "4.17.21"
+      },
+      "dependencies": {
+        "@babel/core": {
+          "version": "7.17.8",
+          "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.17.8.tgz",
+          "integrity": "sha512-OdQDV/7cRBtJHLSOBqqbYNkOcydOgnX59TZx4puf41fzcVtN3e/4yqY8lMQsK+5X2lJtAdmA+6OHqsj1hBJ4IQ==",
+          "dev": true,
+          "requires": {
+            "@ampproject/remapping": "^2.1.0",
+            "@babel/code-frame": "^7.16.7",
+            "@babel/generator": "^7.17.7",
+            "@babel/helper-compilation-targets": "^7.17.7",
+            "@babel/helper-module-transforms": "^7.17.7",
+            "@babel/helpers": "^7.17.8",
+            "@babel/parser": "^7.17.8",
+            "@babel/template": "^7.16.7",
+            "@babel/traverse": "^7.17.3",
+            "@babel/types": "^7.17.0",
+            "convert-source-map": "^1.7.0",
+            "debug": "^4.1.0",
+            "gensync": "^1.0.0-beta.2",
+            "json5": "^2.1.2",
+            "semver": "^6.3.0"
+          }
+        },
+        "@babel/generator": {
+          "version": "7.17.7",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.17.7.tgz",
+          "integrity": "sha512-oLcVCTeIFadUoArDTwpluncplrYBmTCCZZgXCbgNGvOBBiSDDK3eWO4b/+eOTli5tKv1lg+a5/NAXg+nTcei1w==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.17.0",
+            "jsesc": "^2.5.1",
+            "source-map": "^0.5.0"
+          }
+        },
+        "@babel/parser": {
+          "version": "7.18.9",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.18.9.tgz",
+          "integrity": "sha512-9uJveS9eY9DJ0t64YbIBZICtJy8a5QrDEVdiLCG97fVLpDTpGX7t8mMSb6OWw6Lrnjqj4O8zwjELX3dhoMgiBg==",
+          "dev": true
+        },
+        "@babel/traverse": {
+          "version": "7.17.3",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.17.3.tgz",
+          "integrity": "sha512-5irClVky7TxRWIRtxlh2WPUUOLhcPN06AGgaQSB8AEwuyEBgJVuJ5imdHm5zxk8w0QS5T+tDfnDxAlhWjpb7cw==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.16.7",
+            "@babel/generator": "^7.17.3",
+            "@babel/helper-environment-visitor": "^7.16.7",
+            "@babel/helper-function-name": "^7.16.7",
+            "@babel/helper-hoist-variables": "^7.16.7",
+            "@babel/helper-split-export-declaration": "^7.16.7",
+            "@babel/parser": "^7.17.3",
+            "@babel/types": "^7.17.0",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0"
+          }
+        },
+        "@babel/types": {
+          "version": "7.17.0",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.17.0.tgz",
+          "integrity": "sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.16.7",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+          "dev": true
+        }
+      }
+    },
     "@tsconfig/node10": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
@@ -15890,6 +16206,81 @@
         "@typescript-eslint/types": "5.48.0",
         "eslint-visitor-keys": "^3.3.0"
       }
+    },
+    "@vue/compiler-core": {
+      "version": "3.2.45",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.45.tgz",
+      "integrity": "sha512-rcMj7H+PYe5wBV3iYeUgbCglC+pbpN8hBLTJvRiK2eKQiWqu+fG9F+8sW99JdL4LQi7Re178UOxn09puSXvn4A==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@babel/parser": "^7.16.4",
+        "@vue/shared": "3.2.45",
+        "estree-walker": "^2.0.2",
+        "source-map": "^0.6.1"
+      }
+    },
+    "@vue/compiler-dom": {
+      "version": "3.2.45",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.2.45.tgz",
+      "integrity": "sha512-tyYeUEuKqqZO137WrZkpwfPCdiiIeXYCcJ8L4gWz9vqaxzIQRccTSwSWZ/Axx5YR2z+LvpUbmPNXxuBU45lyRw==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@vue/compiler-core": "3.2.45",
+        "@vue/shared": "3.2.45"
+      }
+    },
+    "@vue/compiler-sfc": {
+      "version": "3.2.45",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.2.45.tgz",
+      "integrity": "sha512-1jXDuWah1ggsnSAOGsec8cFjT/K6TMZ0sPL3o3d84Ft2AYZi2jWJgRMjw4iaK0rBfA89L5gw427H4n1RZQBu6Q==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@babel/parser": "^7.16.4",
+        "@vue/compiler-core": "3.2.45",
+        "@vue/compiler-dom": "3.2.45",
+        "@vue/compiler-ssr": "3.2.45",
+        "@vue/reactivity-transform": "3.2.45",
+        "@vue/shared": "3.2.45",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.25.7",
+        "postcss": "^8.1.10",
+        "source-map": "^0.6.1"
+      }
+    },
+    "@vue/compiler-ssr": {
+      "version": "3.2.45",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.2.45.tgz",
+      "integrity": "sha512-6BRaggEGqhWht3lt24CrIbQSRD5O07MTmd+LjAn5fJj568+R9eUD2F7wMQJjX859seSlrYog7sUtrZSd7feqrQ==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@vue/compiler-dom": "3.2.45",
+        "@vue/shared": "3.2.45"
+      }
+    },
+    "@vue/reactivity-transform": {
+      "version": "3.2.45",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity-transform/-/reactivity-transform-3.2.45.tgz",
+      "integrity": "sha512-BHVmzYAvM7vcU5WmuYqXpwaBHjsS8T63jlKGWVtHxAHIoMIlmaMyurUSEs1Zcg46M4AYT5MtB1U274/2aNzjJQ==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "@babel/parser": "^7.16.4",
+        "@vue/compiler-core": "3.2.45",
+        "@vue/shared": "3.2.45",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.25.7"
+      }
+    },
+    "@vue/shared": {
+      "version": "3.2.45",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.45.tgz",
+      "integrity": "sha512-Ewzq5Yhimg7pSztDV+RH1UDKBzmtqieXQlpTVm2AwraoRL/Rks96mvd8Vgi7Lj+h+TH8dv7mXD3FRZR3TUvbSg==",
+      "dev": true,
+      "peer": true
     },
     "abab": {
       "version": "2.0.6",
@@ -17907,6 +18298,13 @@
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
       "dev": true
     },
+    "estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true,
+      "peer": true
+    },
     "esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -19117,6 +19515,12 @@
         "html-escaper": "^2.0.0",
         "istanbul-lib-report": "^3.0.0"
       }
+    },
+    "javascript-natural-sort": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/javascript-natural-sort/-/javascript-natural-sort-0.7.1.tgz",
+      "integrity": "sha512-nO6jcEfZWQXDhOiBtG2KvKyEptz7RVbpGP4vTD2hLBdmNQSsCiicO2Ioinv6UI4y9ukqnBpy+XZ9H6uLNgJTlw==",
+      "dev": true
     },
     "jest": {
       "version": "29.4.1",
@@ -21200,6 +21604,16 @@
       "integrity": "sha512-0ckx7ZHRPqb0oUm8zNr+90mtf9DQB60H1wMCjBtfi62Kl3a7JbHob6gA2bC+xRvZoOL+1hzUK8jeuEIQE8svEQ==",
       "dev": true
     },
+    "magic-string": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
+      "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
+      "dev": true,
+      "peer": true,
+      "requires": {
+        "sourcemap-codec": "^1.4.8"
+      }
+    },
     "make-dir": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -23144,6 +23558,13 @@
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
       }
+    },
+    "sourcemap-codec": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+      "dev": true,
+      "peer": true
     },
     "split": {
       "version": "0.3.3",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "@testing-library/dom": "^8.20.0",
     "@testing-library/jest-dom": "^5.16.5",
     "@testing-library/react": "^13.4.0",
+    "@trivago/prettier-plugin-sort-imports": "^4.0.0",
     "@types/jest": "^29.4.0",
     "@types/jest-axe": "^3.5.5",
     "@types/node": "^18.11.18",

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -1,5 +1,6 @@
 import { NextSeo } from 'next-seo'
 import Link from 'next/link'
+
 import ErrorLayout from '../components/ErrorLayout'
 
 const Custom404 = () => {

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,11 +1,11 @@
-import { AppProps } from 'next/app'
-import { appWithTranslation } from 'next-i18next'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { appWithTranslation } from 'next-i18next'
 import { DefaultSeo } from 'next-seo'
-import { getNextSEOConfig } from '../next-seo.config'
-import Head from 'next/head'
+import { AppProps } from 'next/app'
 import getConfig from 'next/config'
+import Head from 'next/head'
 
+import { getNextSEOConfig } from '../next-seo.config'
 import '../styles/globals.css'
 
 // Create a react-query client

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -1,8 +1,8 @@
 import Document, {
   DocumentContext,
   DocumentInitialProps,
-  Html,
   Head,
+  Html,
   Main,
   NextScript,
 } from 'next/document'

--- a/pages/_error.tsx
+++ b/pages/_error.tsx
@@ -1,6 +1,7 @@
 import { NextPage } from 'next'
 import { NextSeo } from 'next-seo'
 import Link from 'next/link'
+
 import ErrorLayout from '../components/ErrorLayout'
 
 export interface ErrorProps {

--- a/pages/api/check-status.ts
+++ b/pages/api/check-status.ts
@@ -1,12 +1,13 @@
 import { NextApiRequest, NextApiResponse } from 'next'
-import { mapToCheckStatusApiResponse } from '../../lib/mappers/checkStatusApiResponseMapper'
-import { compareCIAndAI } from '../../lib/utils/compareCIAndAI'
-import {
-  PassportStatusesSearchResult,
-  CheckStatusApiResponse,
-  CheckStatusApiRequestQuery,
-} from '../../lib/types'
+
 import passportStatusesMock from '../../__mocks__/passportStatusesMock.json'
+import { mapToCheckStatusApiResponse } from '../../lib/mappers/checkStatusApiResponseMapper'
+import {
+  CheckStatusApiRequestQuery,
+  CheckStatusApiResponse,
+  PassportStatusesSearchResult,
+} from '../../lib/types'
+import { compareCIAndAI } from '../../lib/utils/compareCIAndAI'
 import { getLogger } from '../../logging/log-util'
 
 const logger = getLogger('check-status')

--- a/pages/api/email-esrf.ts
+++ b/pages/api/email-esrf.ts
@@ -1,4 +1,5 @@
 import { NextApiRequest, NextApiResponse } from 'next'
+
 import { EmailEsrfApiRequestBody } from '../../lib/types'
 import { getLogger } from '../../logging/log-util'
 

--- a/pages/api/health.ts
+++ b/pages/api/health.ts
@@ -1,4 +1,5 @@
 import { NextApiRequest, NextApiResponse } from 'next'
+
 import { HealthApiResponse } from '../../lib/types'
 
 export default async function handler(

--- a/pages/email.tsx
+++ b/pages/email.tsx
@@ -1,27 +1,29 @@
+import { FC, useCallback, useMemo, useRef, useState } from 'react'
+
 import { useFormik, validateYupSchema, yupToFormErrors } from 'formik'
-import * as Yup from 'yup'
 import { GetServerSideProps } from 'next'
-import { useRouter } from 'next/router'
 import { Trans, useTranslation } from 'next-i18next'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
-import Layout from '../components/Layout'
-import { FC, useCallback, useMemo, useRef, useState } from 'react'
+import { NextSeo } from 'next-seo'
+import { useRouter } from 'next/router'
+import * as Yup from 'yup'
+
+import ActionButton from '../components/ActionButton'
+import DateSelectField, {
+  DateSelectFieldOnChangeEvent,
+} from '../components/DateSelectField'
 import ErrorSummary, {
   ErrorSummaryItem,
   getErrorSummaryItems,
   goToErrorSummary,
 } from '../components/ErrorSummary'
-import InputField from '../components/InputField'
-import ActionButton from '../components/ActionButton'
-import Modal from '../components/Modal'
-import useEmailEsrf from '../lib/useEmailEsrf'
-import { EmailEsrfApiRequestBody } from '../lib/types'
-import IdleTimeout from '../components/IdleTimeout'
 import ExternalLink from '../components/ExternalLink'
-import DateSelectField, {
-  DateSelectFieldOnChangeEvent,
-} from '../components/DateSelectField'
-import { NextSeo } from 'next-seo'
+import IdleTimeout from '../components/IdleTimeout'
+import InputField from '../components/InputField'
+import Layout from '../components/Layout'
+import Modal from '../components/Modal'
+import { EmailEsrfApiRequestBody } from '../lib/types'
+import useEmailEsrf from '../lib/useEmailEsrf'
 
 const initialValues: EmailEsrfApiRequestBody = {
   dateOfBirth: '',

--- a/pages/expectations.tsx
+++ b/pages/expectations.tsx
@@ -1,12 +1,14 @@
 import { FC, MouseEventHandler, useCallback } from 'react'
+
+import { setCookie } from 'cookies-next'
 import { GetServerSideProps } from 'next'
-import Router from 'next/router'
 import { Trans, useTranslation } from 'next-i18next'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
-import Layout from '../components/Layout'
+import Router from 'next/router'
+
 import ActionButton from '../components/ActionButton'
-import { setCookie } from 'cookies-next'
 import ExternalLink from '../components/ExternalLink'
+import Layout from '../components/Layout'
 
 const Expectations: FC = () => {
   const { t } = useTranslation('expectations')

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,6 +1,7 @@
 import { GetServerSideProps } from 'next'
 import { NextSeo } from 'next-seo'
 import Image from 'next/image'
+
 import LinkButton from '../components/LinkButton'
 
 const Index = () => {

--- a/pages/landing.tsx
+++ b/pages/landing.tsx
@@ -1,12 +1,14 @@
 import { FC } from 'react'
+
 import { GetServerSideProps } from 'next'
 import { Trans, useTranslation } from 'next-i18next'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import { NextSeo } from 'next-seo'
-import Layout from '../components/Layout'
-import LinkButton from '../components/LinkButton'
+
 import Collapse from '../components/Collapse'
 import ExampleImage from '../components/ExampleImage'
+import Layout from '../components/Layout'
+import LinkButton from '../components/LinkButton'
 import LinkText from '../components/LinkText'
 
 const Landing: FC = () => {

--- a/pages/status.tsx
+++ b/pages/status.tsx
@@ -1,37 +1,39 @@
 import {
+  ChangeEventHandler,
   FC,
   MouseEventHandler,
-  ChangeEventHandler,
   useCallback,
   useMemo,
-  useState,
   useRef,
+  useState,
 } from 'react'
+
+import { useFormik, validateYupSchema, yupToFormErrors } from 'formik'
 import { GetServerSideProps } from 'next'
-import { useRouter } from 'next/router'
 import { Trans, useTranslation } from 'next-i18next'
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
-import { useFormik, validateYupSchema, yupToFormErrors } from 'formik'
+import { NextSeo } from 'next-seo'
+import { useRouter } from 'next/router'
 import * as Yup from 'yup'
-import { CheckStatusApiRequestQuery } from '../lib/types'
-import { useCheckStatus } from '../lib/useCheckStatus'
-import Layout from '../components/Layout'
-import InputField from '../components/InputField'
+
 import ActionButton from '../components/ActionButton'
+import CheckStatusInfo from '../components/CheckStatusInfo'
+import DateSelectField, {
+  DateSelectFieldOnChangeEvent,
+} from '../components/DateSelectField'
 import ErrorSummary, {
   ErrorSummaryItem,
   getErrorSummaryItems,
   goToErrorSummary,
 } from '../components/ErrorSummary'
-import CheckStatusInfo from '../components/CheckStatusInfo'
-import Modal from '../components/Modal'
-import IdleTimeout from '../components/IdleTimeout'
 import ExternalLink from '../components/ExternalLink'
-import DateSelectField, {
-  DateSelectFieldOnChangeEvent,
-} from '../components/DateSelectField'
-import { NextSeo } from 'next-seo'
+import IdleTimeout from '../components/IdleTimeout'
+import InputField from '../components/InputField'
+import Layout from '../components/Layout'
 import LinkText from '../components/LinkText'
+import Modal from '../components/Modal'
+import { CheckStatusApiRequestQuery } from '../lib/types'
+import { useCheckStatus } from '../lib/useCheckStatus'
 
 const initialValues: CheckStatusApiRequestQuery = {
   dateOfBirth: '',


### PR DESCRIPTION
### Description

List of proposed changes:

- Add prettier plugin sort imports

### What to test for/How to test

### Additional Notes

A prettier plugin to sort import declarations by provided Regular Expression order.
https://www.npmjs.com/package/@trivago/prettier-plugin-sort-imports
