### PR TITLE
Replace promptTimeout with promptBeforeIdle

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,6 +2,12 @@
 . "$(dirname "$0")/_/husky.sh"
 
 # https://github.com/okonet/lint-staged/issues/1164
-exec >/dev/console 2>&1;
+if sh -c ": >/dev/tty" >/dev/null 2>/dev/null; then
+exec >/dev/tty 2>&1
+elif sh -c ": >/dev/console" >/dev/null 2>/dev/null; then
+exec >/dev/console 2>&1
+elif sh -c ": >/dev/tty0" >/dev/null 2>/dev/null; then
+exec >/dev/tty0 2>&1
+fi
 
 npx lint-staged

--- a/__tests__/components/IdleTimeout.test.tsx
+++ b/__tests__/components/IdleTimeout.test.tsx
@@ -1,7 +1,7 @@
 import { FC } from 'react'
 
 import '@testing-library/jest-dom/extend-expect'
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 
 import IdleTimeout from '../../components/IdleTimeout'
 import { ModalProps } from '../../components/Modal'
@@ -13,18 +13,22 @@ const ModalMock: FC<ModalProps> = ({ open }: ModalProps) => {
 jest.mock('../../components/Modal', () => ModalMock)
 
 describe('IdleTimeout', () => {
-  let modal: HTMLElement
-
   it('renders with modal closed', () => {
-    render(<IdleTimeout timeout={1000} />)
-    modal = screen.getByTestId('modal')
+    render(<IdleTimeout />)
+    const modal = screen.getByTestId('modal')
     expect(modal).toBeInTheDocument()
     expect(modal.textContent).toMatch('modal-closed')
   })
 
-  it('renders with modal opened after 1 second timeout', () => {
-    setTimeout(function () {
-      expect(modal.textContent).toMatch('modal-opened')
-    }, 2000)
+  it('renders with modal opened after 1 second timeout', async () => {
+    render(<IdleTimeout promptBeforeIdle={4000} timeout={5000} />)
+    await waitFor(
+      () => {
+        const modal = screen.getByTestId('modal')
+        expect(modal).toBeInTheDocument()
+        expect(modal.textContent).toMatch('modal-opened')
+      },
+      { timeout: 3000 }
+    )
   })
 })

--- a/__tests__/pages/email.test.tsx
+++ b/__tests__/pages/email.test.tsx
@@ -12,6 +12,7 @@ jest.mock('../../components/ErrorSummary', () => ({
   default: jest.fn(),
   getErrorSummaryItems: jest.fn(() => []),
 }))
+jest.mock('../../components/IdleTimeout')
 jest.mock('../../components/InputField')
 jest.mock('../../components/Layout')
 jest.mock('../../components/Modal')

--- a/__tests__/pages/status.test.tsx
+++ b/__tests__/pages/status.test.tsx
@@ -14,6 +14,7 @@ jest.mock('../../components/ErrorSummary', () => ({
   default: jest.fn(),
   getErrorSummaryItems: jest.fn(() => []),
 }))
+jest.mock('../../components/IdleTimeout')
 jest.mock('../../components/InputField')
 jest.mock('../../components/Layout')
 jest.mock('../../components/Modal')

--- a/components/IdleTimeout.tsx
+++ b/components/IdleTimeout.tsx
@@ -8,10 +8,10 @@ import { IIdleTimerProps, useIdleTimer } from 'react-idle-timer'
 import Modal from './Modal'
 
 export interface IdleTimeoutProps
-  extends Pick<IIdleTimerProps, 'promptTimeout'>,
+  extends Pick<IIdleTimerProps, 'promptBeforeIdle'>,
     Pick<IIdleTimerProps, 'timeout'> {}
 
-const IdleTimeout: FC<IdleTimeoutProps> = ({ promptTimeout, timeout }) => {
+const IdleTimeout: FC<IdleTimeoutProps> = ({ promptBeforeIdle, timeout }) => {
   const { t } = useTranslation('common')
   const router = useRouter()
   const [modalOpen, setModalOpen] = useState(false)
@@ -30,8 +30,8 @@ const IdleTimeout: FC<IdleTimeoutProps> = ({ promptTimeout, timeout }) => {
   const { reset, getRemainingTime } = useIdleTimer({
     onIdle: handleOnIdle,
     onPrompt: () => setModalOpen(true),
-    promptTimeout: promptTimeout ?? 5 * 60 * 1000, //5 minutes
-    timeout: timeout ?? 10 * 60 * 1000, //10 minutes
+    promptBeforeIdle: promptBeforeIdle ?? 5 * 60 * 1000, //5 minutes
+    timeout: timeout ?? 15 * 60 * 1000, //15 minutes
   })
 
   const tick = useCallback(() => {


### PR DESCRIPTION
### Description

List of proposed changes:

- Fix the IdleTimer deprecated promptTimeout prop warning

### What to test for/How to test

### Additional Notes

Deprecations in v5.5.0
https://idletimer.dev/docs/getting-started/new#deprecations-in-v550
