### PR TITLE
Use next/future/image for images

### DIFF
--- a/__tests__/components/Footer.test.tsx
+++ b/__tests__/components/Footer.test.tsx
@@ -13,8 +13,12 @@ describe('Footer', () => {
     render(
       <Footer
         dateModifiedText="testDateModified"
-        footerLogoAltText="testAltText"
-        footerLogoImage="testImage"
+        footerLogo={{
+          alt: 'testAltText',
+          src: '/testImage',
+          width: 1,
+          height: 1,
+        }}
         links={[
           {
             link: 'https://some-link-1.com',
@@ -43,8 +47,12 @@ describe('Footer', () => {
     const { container } = render(
       <Footer
         dateModifiedText="testDateModified"
-        footerLogoAltText="testAltText"
-        footerLogoImage="testImage"
+        footerLogo={{
+          alt: 'testAltText',
+          src: '/testImage',
+          width: 1,
+          height: 1,
+        }}
         links={[
           {
             link: 'https://some-link-1.com',

--- a/components/ErrorLayout.tsx
+++ b/components/ErrorLayout.tsx
@@ -1,5 +1,7 @@
 import { FC } from 'react'
 
+import Image from 'next/future/image'
+
 export interface ErrorLayoutProps {
   children?: React.ReactNode
 }
@@ -8,10 +10,13 @@ const ErrorLayout: FC<ErrorLayoutProps> = ({ children }) => {
   return (
     <div className="flex min-h-screen flex-col">
       <header className="container mx-auto my-6 px-4">
-        <img
+        <Image
           className="h-6 w-auto sm:h-8 md:h-8 lg:h-7 xl:h-8"
-          src={'/sig-blk-en.svg'}
           alt="Government of Canada - Gouvernement du Canada"
+          src="/sig-blk-en.svg"
+          width={300}
+          height={28}
+          priority
         />
       </header>
       <hr />
@@ -28,12 +33,13 @@ const ErrorLayout: FC<ErrorLayoutProps> = ({ children }) => {
             Top of page / Haut de la page&nbsp;
             <span className="font-extrabold">&#8963;</span>
           </a>
-          <img
+          <Image
             className="h-6 w-auto lg:h-auto lg:w-40"
-            src={'/wmms-blk.svg'}
-            alt={
-              'Symbol of the Government of Canada - Symbole du gouvernement du Canada'
-            }
+            alt="Symbol of the Government of Canada - Symbole du gouvernement du Canada"
+            src="/wmms-blk.svg"
+            width={300}
+            height={71}
+            priority
           />
         </div>
       </footer>

--- a/components/ExampleImage.tsx
+++ b/components/ExampleImage.tsx
@@ -8,6 +8,7 @@ export interface ImageProps {
   width: number
   height: number
 }
+
 export interface ExampleImageProps {
   title: string
   imageProps: ImageProps
@@ -26,11 +27,12 @@ const ExampleImage: FC<ExampleImageProps> = ({
       </p>
       <figure className="mb-6 rounded-lg border bg-white p-1 drop-shadow-lg md:w-3/5">
         <Image
-          src={imageProps.src}
+          key={imageProps.src}
+          className="w-full"
           alt={imageProps.alt}
+          src={imageProps.src}
           width={imageProps.width}
           height={imageProps.height}
-          className="w-full"
         />
         <figcaption className="px-5 py-3 text-lg">
           <strong>{description}</strong>

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,6 +1,15 @@
 import { FC } from 'react'
 
+import Image from 'next/future/image'
+
 import DateModified from './DateModified'
+
+export interface FooterLogo {
+  src: string
+  alt: string
+  width: number
+  height: number
+}
 
 export interface FooterLink {
   link: string
@@ -9,14 +18,10 @@ export interface FooterLink {
 
 export interface FooterProps {
   /**
-   * alt text for footer canada-ca logo
+   * footer canada-ca logo
    */
-  footerLogoAltText: string
+  footerLogo: FooterLogo
 
-  /**
-   * image path for footer logo
-   */
-  footerLogoImage: string
   /**
    * Screenreader section indicator
    */
@@ -38,8 +43,7 @@ export interface FooterProps {
  * footer element for all pages
  */
 const Footer: FC<FooterProps> = ({
-  footerLogoAltText,
-  footerLogoImage,
+  footerLogo,
   links,
   footerNav1,
   footerNav2,
@@ -82,10 +86,13 @@ const Footer: FC<FooterProps> = ({
               </ul>
             </div>
             <div>
-              <img
+              <Image
                 className="float-right mb-2.5 mt-8 h-6 w-auto md:h-10 xl:mt-0"
-                src={footerLogoImage}
-                alt={footerLogoAltText}
+                alt={footerLogo.alt}
+                src={footerLogo.src}
+                width={footerLogo.width}
+                height={footerLogo.height}
+                priority
               />
             </div>
           </div>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -2,6 +2,7 @@ import React, { FC } from 'react'
 
 import { useTranslation } from 'next-i18next'
 import getConfig from 'next/config'
+import Image from 'next/future/image'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 
@@ -49,14 +50,18 @@ const Header: FC<HeaderProps> = ({ gocLink, skipToMainText }) => {
         <div className="container mx-auto flex flex-col justify-between px-4 pt-2.5 md:flex md:flex-row">
           <div className="flex flex-row content-center items-center justify-between md:mt-7">
             <a href={gocLink}>
-              <img
+              <Image
+                key={locale}
                 className="h-7 w-auto lg:h-8"
-                src={locale === 'en' ? '/sig-blk-en.svg' : '/sig-blk-fr.svg'}
                 alt={
                   locale === 'en'
                     ? 'Government of Canada'
                     : 'Gouvernement du Canada'
                 }
+                src={locale === 'en' ? '/sig-blk-en.svg' : '/sig-blk-fr.svg'}
+                width={300}
+                height={28}
+                priority
               />
             </a>
 

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -27,8 +27,12 @@ const Layout: FC<LayoutProps> = ({ children }) => {
 
       <Footer
         dateModifiedText={t('footer.date-modified-text')}
-        footerLogoAltText="symbol2"
-        footerLogoImage="/wmms-blk.svg"
+        footerLogo={{
+          alt: t('footer.canada-ca-alt-text'),
+          src: '/wmms-blk.svg',
+          width: 300,
+          height: 71,
+        }}
         footerNav1="aboutGovernment"
         footerNav2="aboutThisSite"
         links={[

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,6 +1,6 @@
 import { GetServerSideProps } from 'next'
 import { NextSeo } from 'next-seo'
-import Image from 'next/image'
+import Image from 'next/future/image'
 
 import LinkButton from '../components/LinkButton'
 
@@ -24,14 +24,13 @@ const Index = () => {
             </h1>
             <div className="w-11/12 lg:w-8/12">
               <Image
-                alt="Government of Canada"
                 className="mb-1.5"
-                height={26}
-                layout="responsive"
-                objectFit="scale-down"
                 property="logo"
+                alt="Government of Canada"
                 src="/sig-blk-en.svg"
-                width={283}
+                width={300}
+                height={28}
+                priority
               />
               <span className="sr-only">
                 {' '}
@@ -82,9 +81,12 @@ const Index = () => {
               </a>
             </div>
             <div className="w-5/12 md:w-4/12">
-              <img
-                src="/wmms-blk.svg"
+              <Image
                 alt="Symbol of the Government of Canada"
+                src="/wmms-blk.svg"
+                width={300}
+                height={71}
+                priority
               />
               <span className="sr-only">
                 {' '}

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -27,7 +27,6 @@
     "goc-link": "https://www.canada.ca/en.html",
     "skip-to-main": "Skip to main content"
   },
-  "header-canada-ca-alt-text": "Symbol of the Government of Canada",
   "language-selection": "Language selection",
   "login": "Login",
   "required": "(required)",

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -27,7 +27,6 @@
     "goc-link": "https://www.canada.ca/fr.html",
     "skip-to-main": "Passer au contenu principal"
   },
-  "header-canada-ca-alt-text": "Symbole du gouvernement du Canada",
   "language-selection": "Sélection de la langue",
   "login": "Connexion",
   "required": "(obligatoire)",


### PR DESCRIPTION
### Description

List of proposed changes:

- Use next/future/image for images

### What to test for/How to test

Build and start the applicatin. Ensure the images render correctly.

### Additional Notes

The main motivation is to get ridd of the warnings `No img element` and also be ready to upgrade to Next.js v13.
https://nextjs.org/docs/messages/no-img-element
https://beta.nextjs.org/docs/upgrade-guide#image-component