### PR TITLE
Change application name in both languages

### DIFF
--- a/cypress/e2e/app.cy.js
+++ b/cypress/e2e/app.cy.js
@@ -20,7 +20,7 @@ describe('app page loads', () => {
   })
 
   it('should have correct title', () => {
-    cy.title().should("eq", "Passport application status checker | Outil de vérification de l'état de la demande de passeport - Canada.ca");
+    cy.title().should("eq", "Passport Application Status Checker | Vérificateur de l'état d'une demande de passeport - Canada.ca");
   })
 
   it('has no detectable a11y violations on load', () => {

--- a/cypress/e2e/email.cy.js
+++ b/cypress/e2e/email.cy.js
@@ -13,7 +13,7 @@ describe('email page loads', () => {
 
   it('should have correct title in English', () => {
     cy.get("h1").filter(':visible').invoke('text').then((text) => {
-      cy.title().should("eq", `${text} - Passport application status checker - Canada.ca`);
+      cy.title().should("eq", `${text} - Passport Application Status Checker - Canada.ca`);
     });
   })
 
@@ -21,7 +21,7 @@ describe('email page loads', () => {
     cy.get('[data-cy=toggle-language-link]').click()
     cy.wait(200)
     cy.get("h1").filter(':visible').invoke('text').then((text) => {
-      cy.title().should("eq", `${text} - Outil de vérification de l'état de la demande de passeport - Canada.ca`);
+      cy.title().should("eq", `${text} - Vérificateur de l'état d'une demande de passeport - Canada.ca`);
     });
   })
 

--- a/cypress/e2e/landing.cy.js
+++ b/cypress/e2e/landing.cy.js
@@ -13,7 +13,7 @@ describe('landing page loads', () => {
 
   it('should have correct title in English', () => {
     cy.get("h1").filter(':visible').invoke('text').then((text) => {
-      cy.title().should("eq", `${text} - Passport application status checker - Canada.ca`);
+      cy.title().should("eq", `${text} - Passport Application Status Checker - Canada.ca`);
     });
   })
 
@@ -21,7 +21,7 @@ describe('landing page loads', () => {
     cy.get('[data-cy=toggle-language-link]').click()
     cy.wait(200)
     cy.get("h1").filter(':visible').invoke('text').then((text) => {
-      cy.title().should("eq", `${text} - Outil de vérification de l'état de la demande de passeport - Canada.ca`);
+      cy.title().should("eq", `${text} - Vérificateur de l'état d'une demande de passeport - Canada.ca`);
     });
   })
 

--- a/cypress/e2e/status.cy.js
+++ b/cypress/e2e/status.cy.js
@@ -13,7 +13,7 @@ describe('status page loads', () => {
 
   it('should have correct title in English', () => {
     cy.get("h1").filter(':visible').invoke('text').then((text) => {
-      cy.title().should("eq", `${text} - Passport application status checker - Canada.ca`);
+      cy.title().should("eq", `${text} - Passport Application Status Checker - Canada.ca`);
     });
   })
 
@@ -21,7 +21,7 @@ describe('status page loads', () => {
     cy.get('[data-cy=toggle-language-link]').click()
     cy.wait(200)
     cy.get("h1").filter(':visible').invoke('text').then((text) => {
-      cy.title().should("eq", `${text} - Outil de vérification de l'état de la demande de passeport - Canada.ca`);
+      cy.title().should("eq", `${text} - Vérificateur de l'état d'une demande de passeport - Canada.ca`);
     });
   })
 

--- a/next-seo.config.ts
+++ b/next-seo.config.ts
@@ -47,7 +47,7 @@ export type GetNextSEOConfig = (
 export const getDefaultConfig: GetNextSEOConfig = (appBaseUri, router) => ({
   titleTemplate: '%s - Canada.ca',
   defaultTitle:
-    "Passport application status checker | Outil de vérification de l'état de la demande de passeport",
+    "Passport Application Status Checker | Vérificateur de l'état d'une demande de passeport",
   description:
     "Avoid waiting on the phone and request the status of your application online. | Évitez d'attendre au téléphone et demandez l'état de votre demande en ligne.",
   additionalMetaTags: [
@@ -96,7 +96,7 @@ export const getDefaultConfig: GetNextSEOConfig = (appBaseUri, router) => ({
     images: getOpenGraphImages(appBaseUri),
     locale: 'en_CA',
     siteName:
-      "Passport application status checker | Outil de vérification de l'état de la demande de passeport - Canada.ca",
+      "Passport Application Status Checker | Vérificateur de l'état d'une demande de passeport - Canada.ca",
     type: 'website',
   },
   twitter: {
@@ -106,8 +106,8 @@ export const getDefaultConfig: GetNextSEOConfig = (appBaseUri, router) => ({
 })
 
 export const getEnglishConfig: GetNextSEOConfig = (appBaseUri, router) => ({
-  titleTemplate: '%s - Passport application status checker - Canada.ca',
-  defaultTitle: 'Passport application status checker - Canada.ca',
+  titleTemplate: '%s - Passport Application Status Checker - Canada.ca',
+  defaultTitle: 'Passport Application Status Checker - Canada.ca',
   description:
     'Avoid waiting on the phone and request the status of your application online.',
   additionalMetaTags: [
@@ -131,7 +131,7 @@ export const getEnglishConfig: GetNextSEOConfig = (appBaseUri, router) => ({
   openGraph: {
     images: getOpenGraphImages(appBaseUri),
     locale: 'en_CA',
-    siteName: 'Passport application status checker - Canada.ca',
+    siteName: 'Passport Application Status Checker - Canada.ca',
     type: 'website',
   },
   twitter: {
@@ -142,9 +142,8 @@ export const getEnglishConfig: GetNextSEOConfig = (appBaseUri, router) => ({
 
 export const getFrenchConfig: GetNextSEOConfig = (appBaseUri, router) => ({
   titleTemplate:
-    "%s - Outil de vérification de l'état de la demande de passeport - Canada.ca",
-  defaultTitle:
-    "Outil de vérification de l'état de la demande de passeport - Canada.ca",
+    "%s - Vérificateur de l'état d'une demande de passeport - Canada.ca",
+  defaultTitle: "Vérificateur de l'état d'une demande de passeport - Canada.ca",
   description:
     "Évitez d'attendre au téléphone et demandez l'état de votre demande en ligne.",
   additionalMetaTags: [
@@ -168,8 +167,7 @@ export const getFrenchConfig: GetNextSEOConfig = (appBaseUri, router) => ({
   openGraph: {
     images: getOpenGraphImages(appBaseUri),
     locale: 'fr_CA',
-    siteName:
-      "Outil de vérification de l'état de la demande de passeport - Canada.ca",
+    siteName: "Vérificateur de l'état d'une demande de passeport - Canada.ca",
     type: 'website',
   },
   twitter: {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -9,7 +9,7 @@ const Index = () => {
     <>
       <NextSeo
         noindex
-        title="Passport application status checker | Outil de vérification de l'état de la demande de passeport"
+        title="Passport Application Status Checker | Vérificateur de l'état d'une demande de passeport"
         titleTemplate="%s - Canada.ca"
       />
       <main
@@ -19,8 +19,8 @@ const Index = () => {
         <div className="m-auto w-[300px] bg-gray-lighter md:w-[400px] lg:w-[500px]">
           <div className="p-8">
             <h1 className="sr-only">
-              Passport application status checker | Outil de vérification de
-              l&#39;état de la demande de passeport
+              Passport Application Status Checker | Vérificateur de l&#39;état
+              d&#39;une demande de passeport
             </h1>
             <div className="w-11/12 lg:w-8/12">
               <Image

--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -53,7 +53,7 @@
   },
   "phone-number": "1\u2011800\u2011567\u20116868",
   "feedback-link-header": "We want to improve this tool",
-  "feedback-link": "Give us your feedback on the Passport application status checker tool",
+  "feedback-link": "Give us your feedback on the Passport Application Status Checker tool",
   "feedback-link-url": "https://www.canada.ca/en/employment-social-development/services/passport/application-status-feedback.html",
   "opens-in-new-tab": "(opens in a new tab)",
   "banner": {

--- a/public/locales/en/expectations.json
+++ b/public/locales/en/expectations.json
@@ -1,5 +1,5 @@
 {
-  "header": "Passport application status checker",
+  "header": "Passport Application Status Checker",
   "header-avoid-waiting": "Avoid waiting on the phone and get the status of your application online",
   "header-who-can-check": "Who can check their status online",
   "header-privacy": "Privacy notice statement",

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -53,7 +53,7 @@
   },
   "phone-number": "1\u2011800\u2011567\u20116868",
   "feedback-link-header": "Nous voulons améliorer cet outil",
-  "feedback-link": "Donnez-nous votre avis sur l'Outil de vérification de l'état de la demande de passeport",
+  "feedback-link": "Donnez-nous votre avis sur l'outil Vérificateur de l'état d'une demande de passeport",
   "feedback-link-url": "https://www.canada.ca/fr/emploi-developpement-social/services/passeport/retroaction-etat-demande.html",
   "opens-in-new-tab": "(s'ouvre dans un nouvel onglet)",
   "banner": {

--- a/public/locales/fr/expectations.json
+++ b/public/locales/fr/expectations.json
@@ -1,5 +1,5 @@
 {
-  "header": "Outil de vérification de l'état de la demande de passeport",
+  "header": "Vérificateur de l'état d'une demande de passeport",
   "header-avoid-waiting": "Évitez d'attendre au téléphone et obtenez l'état de votre demande en ligne",
   "header-who-can-check": "Qui peut vérifier l'état de sa demande en ligne",
   "header-privacy": "Avis de confidentialité",


### PR DESCRIPTION
### Description

List of proposed changes:

- Change application name in both languages

### What to test for/How to test

Build and run the application, ensure the displayed application name match the requirement.

English: Passport Application Status Checker
French: Vérificateur de l’état d’une demande de passeport

### Additional Notes

![image](https://user-images.githubusercontent.com/114004123/216403063-a72624aa-f7e7-4165-af7a-83ed84972b05.png)
