### PR TITLE
Updated DoB field to use fieldset, updated htmlFor for year input

### DIFF
--- a/components/DateSelectField.tsx
+++ b/components/DateSelectField.tsx
@@ -178,12 +178,12 @@ const DateSelectField: FC<DateSelectFieldProps> = ({
           message={errorMessage}
         />
       )}
-      <div className="flex flex-col space-y-2 sm:flex-row sm:space-x-2 sm:space-y-0">
+      <fieldset className="flex flex-col space-y-2 sm:flex-row sm:space-x-2 sm:space-y-0">
         <DateSelect
           ariaDescribedby={getAriaDescribedby()}
           dateSelectLabelId={dateSelectLabelId}
           error={!!errorMessage}
-          id={id}
+          id={`${id}-year`}
           label={t('common:date-select-field.year')}
           onChange={handleOnDateSelectChange}
           options={yearOptions}
@@ -215,7 +215,7 @@ const DateSelectField: FC<DateSelectFieldProps> = ({
           type="day"
           value={state.dayValue}
         />
-      </div>
+      </fieldset>
       {helpMessage && (
         <div
           className="mt-1.5 max-w-prose text-base text-gray-600"

--- a/components/DateSelectField.tsx
+++ b/components/DateSelectField.tsx
@@ -167,7 +167,7 @@ const DateSelectField: FC<DateSelectFieldProps> = ({
     <div className="mb-4" id={dateSelectWrapperId} data-testid={id}>
       <InputLabel
         id={dateSelectLabelId}
-        htmlFor={id}
+        htmlFor={`${id}-year`}
         required={required}
         label={label}
         textRequired={textRequired}

--- a/cypress/e2e/email.cy.js
+++ b/cypress/e2e/email.cy.js
@@ -49,7 +49,7 @@ describe('responses', ()=>{
     cy.get('#email').type('yanis.pierre@example.com')
     cy.get('#givenName').type('Yanis')
     cy.get('#surname').type('Piérre')
-    cy.get('#dateOfBirth').select('1972')
+    cy.get('#dateOfBirth-year').select('1972')
     cy.get('#dateOfBirth-month').select('07')
     cy.get('#dateOfBirth-day').select('29')
     cy.get('#btn-submit').click()

--- a/cypress/e2e/status.cy.js
+++ b/cypress/e2e/status.cy.js
@@ -85,7 +85,7 @@ describe('surname field validation', ()=>{
 
 describe('Date of Birth field validation', ()=>{
   it('validates valid dateOfBirth',()=>{
-    cy.get('#dateOfBirth').select('1982')
+    cy.get('#dateOfBirth-year').select('1982')
     cy.get('#dateOfBirth-month').select('12')
     cy.get('#dateOfBirth-day').select('08')
     cy.get('#btn-submit').click()
@@ -100,7 +100,7 @@ describe('Date of Birth field validation', ()=>{
   it('validates Date of Birth in the future',()=>{
     const futureDate = new Date()
     futureDate.setDate( futureDate.getDate() + 1)
-    cy.get('#dateOfBirth').select(futureDate.getFullYear().toString())
+    cy.get('#dateOfBirth-year').select(futureDate.getFullYear().toString())
     cy.get('#dateOfBirth-month').select((futureDate.getMonth() + 1).toString().padStart(2, '0'))
     cy.get('#dateOfBirth-day').select(futureDate.getDate().toString().padStart(2, '0'))
     cy.get('#btn-submit').click()
@@ -113,7 +113,7 @@ describe('responses - loads result', ()=>{
     cy.get('#esrf').type('A02D85ED')
     cy.get('#givenName').type('Yanis')
     cy.get('#surname').type('Piérre')
-    cy.get('#dateOfBirth').select('1972')
+    cy.get('#dateOfBirth-year').select('1972')
     cy.get('#dateOfBirth-month').select('07')
     cy.get('#dateOfBirth-day').select('29')
     cy.get('#btn-submit').click()
@@ -136,7 +136,7 @@ describe('responses - loads no result', ()=>{
     cy.get('#esrf').type('A1234567')
     cy.get('#givenName').type('John')
     cy.get('#surname').type('Doe')
-    cy.get('#dateOfBirth').select('1990')
+    cy.get('#dateOfBirth-year').select('1990')
     cy.get('#dateOfBirth-month').select('12')
     cy.get('#dateOfBirth-day').select('01')
     cy.get('#btn-submit').click()

--- a/pages/email.tsx
+++ b/pages/email.tsx
@@ -89,7 +89,12 @@ const Email: FC = () => {
   })
 
   const errorSummaryItems = useMemo<ErrorSummaryItem[]>(
-    () => getErrorSummaryItems(formikErrors, t),
+    () =>
+      getErrorSummaryItems(formikErrors, t).map((item) => {
+        if (item.feildId !== 'dateOfBirth') return item
+        // field id should target the year select input
+        return { ...item, feildId: 'dateOfBirth-year' }
+      }),
     [formikErrors, t]
   )
 

--- a/pages/status.tsx
+++ b/pages/status.tsx
@@ -105,7 +105,12 @@ const Status: FC = () => {
   )
 
   const errorSummaryItems = useMemo<ErrorSummaryItem[]>(
-    () => getErrorSummaryItems(formikErrors, t),
+    () =>
+      getErrorSummaryItems(formikErrors, t).map((item) => {
+        if (item.feildId !== 'dateOfBirth') return item
+        // field id should target the year select input
+        return { ...item, feildId: 'dateOfBirth-year' }
+      }),
     [formikErrors, t]
   )
 


### PR DESCRIPTION
## [ADO-2016](https://dev.azure.com/DTS-STN/passport-status/_workitems/edit/2016)

### Description

This PR addresses the issues from the a11y audit item linked in the above ADO task. Item 3 was already done in a previous PR so this really just addresses item 1 since item 2 makes no sense (asking us to put the feedback section inside a `<p>`  would place the `<h2>` inside the `<p>` tag which is not allowed; maybe they just want the link inside? More clarity needed here).

Item 2 was to place the date of birth fields inside a `<fieldset>` and to fix the label for the year input since there was a typo.

### What to test for/How to test
1. Pull in branch
2. Type `npm run dev`
3. Navigate to `/status`
4.  Boot up NVDA (or another screen reader) and tab to the DoB field ensuring that you hear something like `Applicant date of birth, combo box year` when tabbing through the inputs

### Additional Notes
Currently we're using CSS to prepend required fields with `*`. If we're going to maintain this pattern then we will need to eventually scrap the CSS and manually add a span with `aria-hidden=true` where needed instead since with our current implementation, the star gets announced by screen readers, which isn't a good experience.