### PR TITLE
Change feedback-link text in both languages

### DIFF
--- a/public/locales/en/common.json
+++ b/public/locales/en/common.json
@@ -53,7 +53,7 @@
   },
   "phone-number": "1\u2011800\u2011567\u20116868",
   "feedback-link-header": "We want to improve this tool",
-  "feedback-link": "Give us your feedback on the Passport Application Status Checker tool",
+  "feedback-link": "Give us your feedback on the Passport Application Status Checker",
   "feedback-link-url": "https://www.canada.ca/en/employment-social-development/services/passport/application-status-feedback.html",
   "opens-in-new-tab": "(opens in a new tab)",
   "banner": {

--- a/public/locales/fr/common.json
+++ b/public/locales/fr/common.json
@@ -53,7 +53,7 @@
   },
   "phone-number": "1\u2011800\u2011567\u20116868",
   "feedback-link-header": "Nous voulons améliorer cet outil",
-  "feedback-link": "Donnez-nous votre avis sur l'outil Vérificateur de l'état d'une demande de passeport",
+  "feedback-link": "Donnez-nous votre avis sur le Vérificateur de l'état d'une demande de passeport",
   "feedback-link-url": "https://www.canada.ca/fr/emploi-developpement-social/services/passeport/retroaction-etat-demande.html",
   "opens-in-new-tab": "(s'ouvre dans un nouvel onglet)",
   "banner": {


### PR DESCRIPTION
## [ADO-2075](https://dev.azure.com/DTS-STN/passport-status/_workitems/edit/2075)

### Description

List of proposed changes:

- Change feedback-link text in both languages (remove `tool` and `outil`)

### What to test for/How to test

Build and run the application. Ensure the text is properly changes in both languages.

### Additional Notes
