### PR TITLE
Update asterisk in InputLabel and add aria-labelled-by to InputField

### DIFF
--- a/__tests__/components/InputField.test.tsx
+++ b/__tests__/components/InputField.test.tsx
@@ -21,7 +21,7 @@ describe('InputField', () => {
   it('renders', () => {
     const sut = screen.getByTestId('id')
     expect(sut).toBeInTheDocument()
-    expect(sut.querySelector(`#id`)).toHaveAccessibleName('input-id-label')
+    expect(sut.querySelector(`#id`)).toHaveAccessibleName('label')
     expect(sut.querySelector(`#id`)).not.toHaveAccessibleDescription()
   })
 

--- a/components/InputField.tsx
+++ b/components/InputField.tsx
@@ -57,7 +57,7 @@ const InputField: FC<InputFieldProps> = ({
       <input
         aria-describedby={getAriaDescribedby()}
         aria-invalid={errorMessage ? true : undefined}
-        aria-label={inputLabelId}
+        aria-labelledby={inputLabelId}
         aria-required={required ? true : undefined}
         className={`block h-9 rounded border py-1.5 px-3 ${
           errorMessage ? 'border-accent-error' : 'border-neutral-400'

--- a/components/InputLabel.tsx
+++ b/components/InputLabel.tsx
@@ -17,9 +17,11 @@ const InputLabel: FC<InputLabelProps> = ({
 }) => {
   return (
     <label id={id} htmlFor={htmlFor} className="mb-2 block font-bold">
-      <b className="text-accent-error mr-0.5" aria-hidden="true">
-        *
-      </b>
+      {required && (
+        <b className="text-accent-error mr-0.5" aria-hidden="true">
+          *
+        </b>
+      )}
       {label}
       {required && (
         <strong className="text-accent-error">&nbsp;{textRequired}</strong>

--- a/components/InputLabel.tsx
+++ b/components/InputLabel.tsx
@@ -16,11 +16,10 @@ const InputLabel: FC<InputLabelProps> = ({
   textRequired,
 }) => {
   return (
-    <label
-      id={id}
-      htmlFor={htmlFor}
-      className={`mb-2 block font-bold ${required ? 'required' : ''}`}
-    >
+    <label id={id} htmlFor={htmlFor} className="mb-2 block font-bold">
+      <b className="text-accent-error mr-0.5" aria-hidden="true">
+        *
+      </b>
       {label}
       {required && (
         <strong className="text-accent-error">&nbsp;{textRequired}</strong>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -83,10 +83,4 @@
     width: 1em;
     text-align: center;
   }
-
-  label.required::before {
-    content: '* ';
-    margin-left: -0.665em;
-    @apply text-accent-error;
-  }
 }


### PR DESCRIPTION
### Description
This PR updates the `InputLabel` component to have a conditional that renders an asterisk if the input is required instead of using CSS and uses `aria-hidden="true"` to hide this from the screen reader so it doesn't get announced. I've also updated `aria-label` to `aria-labelledby` in `InputField` so the other fields get properly announced.

### What to test for/How to test
1. Pull in branch
2. Type `npm run dev`
3. Start up NVDA (or another screen reader)
4. Navigate to `/status` and tab through all the inputs, confirming that the labels are properly announced and the asterisk is ignored.

### Additional Notes
We should be taking notes from [this site ](https://a11y-101.com/development/required), specifically the second or third option since having both the asterisk and the word `(required)` isn't really necessary or, well, required.
