### PR TITLE
Add Adobe Analytics

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,8 @@
-NEXT_PUBLIC_BUILD_DATE = 12345
+NEXT_PUBLIC_BUILD_DATE = 20000101
 LOGGING_LEVEL = "debug"
+
+# Adobe Analytics Script Source
+NEXT_PUBLIC_ADOBE_ANALYTICS_SCRIPT_SRC=https://assets.adobedtm.com/be5dfd287373/1e84b99f81fb/launch-ffa1e01dbeab-staging.min.js
 
 # Base URI for the Application
 NEXT_PUBLIC_APP_BASE_URI=https://example.com

--- a/__tests__/pages/_app.test.tsx
+++ b/__tests__/pages/_app.test.tsx
@@ -4,9 +4,19 @@
 import '@testing-library/jest-dom'
 import { render, screen } from '@testing-library/react'
 
-import { Router } from 'next/router'
-
 import App from '../../pages/_app'
+
+const adobeAnalyticsScriptSrc =
+  'https://assets.adobedtm.com/be5dfd287373/1e84b99f81fb/launch-ffa1e01dbeab-staging.min.js'
+const jQueryScriptSrc = 'https://code.jquery.com/jquery-3.6.3.min.js'
+
+const mockGetConfig = jest.fn().mockImplementation(() => ({
+  publicRuntimeConfig: {
+    adobeAnalyticsScriptSrc: undefined,
+  },
+}))
+
+jest.mock('next/config', () => () => mockGetConfig())
 
 const MockComponent = jest
   .fn()
@@ -25,10 +35,56 @@ describe('custom `app`', () => {
             userConfig: null,
           },
         }}
-        router={{} as Router}
+        router={{ events: { on: jest.fn(), off: jest.fn() } } as any}
       />
     )
+
     const heading = screen.getByRole('heading', { level: 1 })
+    const aaScript = document.querySelector(
+      `script[src="${adobeAnalyticsScriptSrc}"]`
+    )
+    const jQueryScript = document.querySelector(
+      `script[src="${jQueryScriptSrc}"]`
+    )
     expect(heading).toBeInTheDocument()
+    expect(aaScript).not.toBeInTheDocument()
+    expect(jQueryScript).not.toBeInTheDocument()
+    expect(MockComponent).toHaveBeenCalled()
+    expect(mockGetConfig).toHaveBeenCalled()
+  })
+
+  it('should render the page with adobe analytics', () => {
+    mockGetConfig.mockReturnValueOnce({
+      publicRuntimeConfig: {
+        adobeAnalyticsScriptSrc,
+      },
+    })
+    render(
+      <App
+        Component={MockComponent}
+        pageProps={{
+          _nextI18Next: {
+            initialI18nStore: '',
+            initialLocale: 'en',
+            ns: ['common'],
+            userConfig: null,
+          },
+        }}
+        router={{ events: { on: jest.fn(), off: jest.fn() } } as any}
+      />
+    )
+
+    const heading = screen.getByRole('heading', { level: 1 })
+    const aaScript = document.querySelector(
+      `script[src="${adobeAnalyticsScriptSrc}"]`
+    )
+    const jQueryScript = document.querySelector(
+      `script[src="${jQueryScriptSrc}"]`
+    )
+    expect(heading).toBeInTheDocument()
+    expect(aaScript).toBeInTheDocument()
+    expect(jQueryScript).toBeInTheDocument()
+    expect(MockComponent).toHaveBeenCalled()
+    expect(mockGetConfig).toHaveBeenCalled()
   })
 })

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -1,3 +1,7 @@
+export type AdobeDataLayer = { push?: (object: Record<string, string>) => void }
+export type AppWindow = Window &
+  typeof globalThis & { adobeDataLayer?: AdobeDataLayer }
+
 export interface CheckStatusApiRequestQuery {
   dateOfBirth: string
   esrf: string

--- a/next.config.js
+++ b/next.config.js
@@ -42,7 +42,7 @@ const securityHeaders = [
   {
     key: 'Content-Security-Policy',
     value:
-      "default-src 'self'; base-uri 'self'; frame-ancestors 'self'; form-action 'self'; object-src 'none'; script-src-elem 'self'; script-src 'self' 'unsafe-eval'; connect-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:",
+      "default-src 'self'; base-uri 'self'; frame-ancestors 'self'; form-action 'self'; object-src 'none'; script-src 'self' 'unsafe-eval' 'unsafe-inline' https://code.jquery.com https://*.demdex.net https://cm.everesttech.net https://assets.adobedtm.com https://www.youtube.com; connect-src 'self' https://*.demdex.net https://cm.everesttech.net https://assets.adobedtm.com https://*.omtrdc.net; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https://*.demdex.net https://cm.everesttech.net https://assets.adobedtm.com https://*.omtrdc.net; frame-src 'self' https://*.demdex.net;",
   },
 ]
 
@@ -55,6 +55,8 @@ const nextConfig = {
     LOGGING_LEVEL: process.env.LOGGING_LEVEL ?? 'info',
   },
   publicRuntimeConfig: {
+    adobeAnalyticsScriptSrc:
+      process.env.NEXT_PUBLIC_ADOBE_ANALYTICS_SCRIPT_SRC ?? undefined,
     appBaseUri: process.env.NEXT_PUBLIC_APP_BASE_URI ?? '',
     environment: process.env.NEXT_PUBLIC_ENVIRONMENT ?? '',
   },

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,20 +1,50 @@
+import { useEffect } from 'react'
+
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { appWithTranslation } from 'next-i18next'
 import { DefaultSeo } from 'next-seo'
 import { AppProps } from 'next/app'
 import getConfig from 'next/config'
 import Head from 'next/head'
+import Script from 'next/script'
 
+import { AppWindow } from '../lib/types'
 import { getNextSEOConfig } from '../next-seo.config'
 import '../styles/globals.css'
 
 // Create a react-query client
 const queryClient = new QueryClient()
 
+// help to prevent double firing of adobe analytics pageLoad event
+let appPreviousLocationPathname = ''
+
 const MyApp = ({ Component, pageProps, router }: AppProps) => {
   const config = getConfig()
+  const adobeAnalyticsScriptSrc =
+    config?.publicRuntimeConfig?.adobeAnalyticsScriptSrc
   const appBaseUri = config?.publicRuntimeConfig?.appBaseUri
   const nextSEOConfig = getNextSEOConfig(appBaseUri, router)
+
+  /** Web Analytics - taken from Google Analytics example
+   *  @see https://github.com/vercel/next.js/blob/canary/examples/with-google-analytics
+   * */
+  useEffect(() => {
+    const handleRouteChange = () => {
+      // only push event if pathname is different
+      if (window.location.pathname !== appPreviousLocationPathname) {
+        ;(window as AppWindow).adobeDataLayer?.push?.({ event: 'pageLoad' })
+        appPreviousLocationPathname = window.location.pathname
+      }
+    }
+
+    handleRouteChange()
+    router.events.on('routeChangeComplete', handleRouteChange)
+    router.events.on('hashChangeComplete', handleRouteChange)
+    return () => {
+      router.events.off('routeChangeComplete', handleRouteChange)
+      router.events.off('hashChangeComplete', handleRouteChange)
+    }
+  }, [router.events])
 
   return (
     <>
@@ -23,6 +53,14 @@ const MyApp = ({ Component, pageProps, router }: AppProps) => {
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <link rel="icon" href="/favicon.ico" />
       </Head>
+
+      {adobeAnalyticsScriptSrc && (
+        <>
+          <Script src="https://code.jquery.com/jquery-3.6.3.min.js" />
+          <Script src={adobeAnalyticsScriptSrc} />
+        </>
+      )}
+
       <DefaultSeo {...nextSEOConfig} />
       <QueryClientProvider client={queryClient}>
         <Component {...pageProps} />


### PR DESCRIPTION
## [ADO-1867](https://dev.azure.com/DTS-STN/passport-status/_workitems/edit/1867)

### Description

List of proposed changes:

- Add Adobe Analytics

### What to test for/How to test

By default Adobe Analytics scripts is not added. To enable it, you need to add the following env. variable:

```
NEXT_PUBLIC_ADOBE_ANALYTICS_SCRIPT_SRC=https://assets.adobedtm.com/be5dfd287373/1e84b99f81fb/launch-ffa1e01dbeab-staging.min.js
````

The above script is for non-prod environments.

### Additional Notes

GOVERNMENT OF CANADA  - ADOBE ANALYTICS - SINGLE PAGE APPLICATION - INSTALLATION MANUAL 
Version 7 of the Analytics Code for Non-Canada.ca Websites
[1Single_Page_Application_Event_Driven_Data_Layer_(ACDL)_Implementation_V7_(1).pdf](https://github.com/DTS-STN/passport-status/files/10678348/1Single_Page_Application_Event_Driven_Data_Layer_.ACDL._Implementation_V7_.1.pdf)

Next.js - Example app with analytics
https://github.com/vercel/next.js/tree/canary/examples/with-google-analytics

