### PR TITLE
Updated react-query options to fix caching issue in useCheckStatus

### DIFF
--- a/lib/useCheckStatus.ts
+++ b/lib/useCheckStatus.ts
@@ -31,7 +31,7 @@ export const useCheckStatus = (
   >(
     ['ps:api:check-status', checkStatusApiRequestQuery],
     ({ signal }) => fetchCheckStatus(checkStatusApiRequestQuery, { signal }),
-    { refetchOnWindowFocus: false, ...(queryOptions ?? {}) }
+    { ...(queryOptions ?? {}) }
   )
 
   // fix isLoading with disabled: false

--- a/lib/useCheckStatus.ts
+++ b/lib/useCheckStatus.ts
@@ -31,7 +31,7 @@ export const useCheckStatus = (
   >(
     ['ps:api:check-status', checkStatusApiRequestQuery],
     ({ signal }) => fetchCheckStatus(checkStatusApiRequestQuery, { signal }),
-    { staleTime: 5 * 60 * 1000, ...(queryOptions ?? {}) }
+    { refetchOnWindowFocus: false, ...(queryOptions ?? {}) }
   )
 
   // fix isLoading with disabled: false

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -13,7 +13,9 @@ import { getNextSEOConfig } from '../next-seo.config'
 import '../styles/globals.css'
 
 // Create a react-query client
-const queryClient = new QueryClient()
+const queryClient = new QueryClient({
+  defaultOptions: { queries: { refetchOnWindowFocus: false } },
+})
 
 // help to prevent double firing of adobe analytics pageLoad event
 let appPreviousLocationPathname = ''


### PR DESCRIPTION
## [ADO-2046](https://dev.azure.com/DTS-STN/passport-status/_workitems/edit/2046)

### Description
This PR fixes an issue where `onSuccess` wasn't being called after entering the same data into the check status form a second time. While this wouldn't change the on screen result for the user since it's cached, it wouldn't call `scrollToHeading()` so the user's scroll position would be halfway down the screen on mobile viewports (or if zoomed in enough to have a scrollbar).

Credit to @sebastien-comeau for the fix 😄 

### What to test for/How to test
1. Pull in branch
2. Type `npm run dev`
3. Navigate to `/status`
4. Hit F12 and select a mobile viewport
5. Type in valid data and click `Check Status`
6. Click `Check the status of another application`
7. Enter the same data again and click `Check Status`
8. Confirm that you are still scrolled to the h1

### Additional Notes
https://tanstack.com/query/v4/docs/react/guides/caching
