### PR TITLE
Move 404 error page to server-side rendering

### DIFF
--- a/__tests__/components/error-pages/Error404Page.test.tsx
+++ b/__tests__/components/error-pages/Error404Page.test.tsx
@@ -4,11 +4,11 @@
 import '@testing-library/jest-dom'
 import { render, screen } from '@testing-library/react'
 
-import Custom404 from '../../pages/404'
+import Error404Page from '../../../components/error-pages/Error404Page'
 
-describe('404', () => {
+describe('Error 404 Page', () => {
   it('renders 404 without crashing', () => {
-    render(<Custom404 />)
+    render(<Error404Page />)
     expect(screen.getByText('Error 404')).toBeInTheDocument()
   })
 })

--- a/__tests__/components/error-pages/ErrorPage.test.tsx
+++ b/__tests__/components/error-pages/ErrorPage.test.tsx
@@ -1,0 +1,19 @@
+/**
+ * @jest-environment jsdom
+ */
+import '@testing-library/jest-dom'
+import { render, screen } from '@testing-library/react'
+
+import ErrorPage from '../../../components/error-pages/ErrorPage'
+
+describe('Error Page', () => {
+  it('renders custom statusCode without crashing', () => {
+    render(<ErrorPage statusCode={500} />)
+    expect(screen.getByText('Error 500')).toBeInTheDocument()
+  })
+
+  it('renders no statusCode without crashing', () => {
+    render(<ErrorPage />)
+    expect(screen.getByText('An error occurred on client')).toBeInTheDocument()
+  })
+})

--- a/__tests__/pages/_error.test.tsx
+++ b/__tests__/pages/_error.test.tsx
@@ -6,14 +6,48 @@ import { render, screen } from '@testing-library/react'
 
 import CustomError from '../../pages/_error'
 
+jest.mock('../../components/error-pages/Error404Page', () => ({
+  __esModule: true,
+  default: () => {
+    return <div data-testid="mock-error-404-page"></div>
+  },
+}))
+
+jest.mock('../../components/error-pages/ErrorPage', () => ({
+  __esModule: true,
+  default: (props: { statusCode?: number }) => {
+    return (
+      <div data-testid="mock-error-page">
+        Error {props.statusCode ? props.statusCode : 'client'}
+      </div>
+    )
+  },
+}))
+
 describe('custom error', () => {
-  it('renders custom statusCode without crashing', () => {
-    render(<CustomError statusCode={500} />)
-    expect(screen.getByText('Error 500')).toBeInTheDocument()
+  it('renders custom error 404 page', () => {
+    render(<CustomError statusCode={404} />)
+    const mockError404Page = screen.getByTestId('mock-error-404-page')
+    const mockErrorPage = screen.queryByTestId('mock-error-page')
+    expect(mockError404Page).toBeInTheDocument()
+    expect(mockErrorPage).toBeNull()
   })
 
-  it('renders no statusCode without crashing', () => {
+  it('renders custom error page with 500 status code', () => {
+    render(<CustomError statusCode={500} />)
+    const mockErrorPage = screen.getByTestId('mock-error-page')
+    const mockError404Page = screen.queryByTestId('mock-error-404-page')
+    expect(mockErrorPage).toBeInTheDocument()
+    expect(mockErrorPage.innerHTML).toBe('Error 500')
+    expect(mockError404Page).toBeNull()
+  })
+
+  it("renders custom error page with 'undefined' status code", () => {
     render(<CustomError />)
-    expect(screen.getByText('An error occurred on client')).toBeInTheDocument()
+    const mockErrorPage = screen.getByTestId('mock-error-page')
+    const mockError404Page = screen.queryByTestId('mock-error-404-page')
+    expect(mockErrorPage).toBeInTheDocument()
+    expect(mockErrorPage.innerHTML).toBe('Error client')
+    expect(mockError404Page).toBeNull()
   })
 })

--- a/components/error-pages/Error404Page.tsx
+++ b/components/error-pages/Error404Page.tsx
@@ -1,9 +1,11 @@
+import { FC } from 'react'
+
 import { NextSeo } from 'next-seo'
 import Link from 'next/link'
 
-import ErrorLayout from '../components/ErrorLayout'
+import ErrorLayout from '../ErrorLayout'
 
-const Custom404 = () => {
+const Error404Page: FC = () => {
   return (
     <ErrorLayout>
       <NextSeo
@@ -70,4 +72,4 @@ const Custom404 = () => {
   )
 }
 
-export default Custom404
+export default Error404Page

--- a/components/error-pages/ErrorPage.tsx
+++ b/components/error-pages/ErrorPage.tsx
@@ -1,0 +1,98 @@
+import { FC } from 'react'
+
+import { NextSeo } from 'next-seo'
+import Link from 'next/link'
+
+import ErrorLayout from '../ErrorLayout'
+
+export interface ErrorPageProps {
+  statusCode?: number
+}
+
+const ErrorPage: FC<ErrorPageProps> = ({ statusCode }) => {
+  return (
+    <ErrorLayout>
+      <NextSeo
+        description="Error message stating that the server is down, or the URL is incorrect or expired | Message d'erreur indiquant que le serveur est hors service, que l'URL est incorrecte ou qu'elle a expiré."
+        title={
+          statusCode === 500
+            ? 'Internal Server Error | Erreur de serveur interne'
+            : 'Service Unavailable | Service indisponible'
+        }
+        titleTemplate="%s - Canada.ca"
+      />
+      <h1 className="sr-only" lang="en">
+        {statusCode === 500 ? 'Internal Server Error' : 'Service Unavailable'}
+      </h1>
+      <span className="sr-only">
+        {' '}
+        /{' '}
+        <span lang="fr">
+          {statusCode === 500
+            ? 'Erreur de serveur interne'
+            : 'Service indisponible'}
+        </span>
+      </span>
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-2 lg:gap-8">
+        <div lang="en">
+          <h2 className="h1">We&#39;re having a problem with that page</h2>
+          <p className="h2">
+            {statusCode ? `Error ${statusCode}` : 'An error occurred on client'}
+          </p>
+          <p>
+            We expect the problem to be fixed shortly. It&#39;s not your
+            computer or Internet connection but a problem with our website&#39;s
+            server. What next?
+          </p>
+          <ul className="mb-5 list-disc space-y-2 pl-10">
+            <li>Try refreshing the page or try again later;</li>
+            <li>
+              Return to the{' '}
+              <Link href="/">
+                <a>home page</a>
+              </Link>
+              ;
+            </li>
+            <li>
+              <a href="https://www.canada.ca/en/contact.html">Contact us</a>
+              &nbsp;and we&#39;ll help you out
+            </li>
+          </ul>
+          <p>Thank you for your patience.</p>
+        </div>
+        <div lang="fr">
+          <h2 className="h1">Nous éprouvons des difficultés avec cette page</h2>
+          <p className="h2">
+            {statusCode
+              ? `Erreur ${statusCode}`
+              : 'Erreur produite sur le client'}
+          </p>
+          <p>
+            Nous espérons résoudre le problème sous peu. Il ne s&#39;agit pas
+            d&#39;un problème avec votre ordinateur ou Internet, mais plutôt
+            avec le serveur de notre site Web. Que faire?
+          </p>
+          <ul className="mb-5 list-disc space-y-2 pl-10">
+            <li>Actualisez la page ou réessayez plus tard;</li>
+            <li>
+              Retournez à la{' '}
+              <Link href="/">
+                <a>page d&#39;accueil</a>
+              </Link>
+              ;
+            </li>
+            <li>
+              <a href="https://www.canada.ca/fr/contact.html">
+                Communiquez avec nous
+              </a>{' '}
+              pour obtenir de l&#39;aide.
+            </li>
+          </ul>
+          <p>Merci de votre patience.</p>
+        </div>
+      </div>
+    </ErrorLayout>
+  )
+}
+
+export default ErrorPage

--- a/pages/_error.tsx
+++ b/pages/_error.tsx
@@ -1,97 +1,15 @@
 import { NextPage } from 'next'
-import { NextSeo } from 'next-seo'
-import Link from 'next/link'
 
-import ErrorLayout from '../components/ErrorLayout'
+import Error404Page from '../components/error-pages/Error404Page'
+import ErrorPage from '../components/error-pages/ErrorPage'
 
 export interface ErrorProps {
   statusCode?: number
 }
 
 const Error: NextPage<ErrorProps> = ({ statusCode }) => {
-  return (
-    <ErrorLayout>
-      <NextSeo
-        description="Error message stating that the server is down, or the URL is incorrect or expired | Message d'erreur indiquant que le serveur est hors service, que l'URL est incorrecte ou qu'elle a expiré."
-        title={
-          statusCode === 500
-            ? 'Internal Server Error | Erreur de serveur interne'
-            : 'Service Unavailable | Service indisponible'
-        }
-        titleTemplate="%s - Canada.ca"
-      />
-      <h1 className="sr-only" lang="en">
-        {statusCode === 500 ? 'Internal Server Error' : 'Service Unavailable'}
-      </h1>
-      <span className="sr-only">
-        {' '}
-        /{' '}
-        <span lang="fr">
-          {statusCode === 500
-            ? 'Erreur de serveur interne'
-            : 'Service indisponible'}
-        </span>
-      </span>
-      <div className="grid grid-cols-1 gap-4 lg:grid-cols-2 lg:gap-8">
-        <div lang="en">
-          <h2 className="h1">We&#39;re having a problem with that page</h2>
-          <p className="h2">
-            {statusCode ? `Error ${statusCode}` : 'An error occurred on client'}
-          </p>
-          <p>
-            We expect the problem to be fixed shortly. It&#39;s not your
-            computer or Internet connection but a problem with our website&#39;s
-            server. What next?
-          </p>
-          <ul className="mb-5 list-disc space-y-2 pl-10">
-            <li>Try refreshing the page or try again later;</li>
-            <li>
-              Return to the{' '}
-              <Link href="/">
-                <a>home page</a>
-              </Link>
-              ;
-            </li>
-            <li>
-              <a href="https://www.canada.ca/en/contact.html">Contact us</a>
-              &nbsp;and we&#39;ll help you out
-            </li>
-          </ul>
-          <p>Thank you for your patience.</p>
-        </div>
-        <div lang="fr">
-          <h2 className="h1">Nous éprouvons des difficultés avec cette page</h2>
-          <p className="h2">
-            {statusCode
-              ? `Erreur ${statusCode}`
-              : 'Erreur produite sur le client'}
-          </p>
-          <p>
-            Nous espérons résoudre le problème sous peu. Il ne s&#39;agit pas
-            d&#39;un problème avec votre ordinateur ou Internet, mais plutôt
-            avec le serveur de notre site Web. Que faire?
-          </p>
-          <ul className="mb-5 list-disc space-y-2 pl-10">
-            <li>Actualisez la page ou réessayez plus tard;</li>
-            <li>
-              Retournez à la{' '}
-              <Link href="/">
-                <a>page d&#39;accueil</a>
-              </Link>
-              ;
-            </li>
-            <li>
-              <a href="https://www.canada.ca/fr/contact.html">
-                Communiquez avec nous
-              </a>{' '}
-              pour obtenir de l&#39;aide.
-            </li>
-          </ul>
-          <p>Merci de votre patience.</p>
-        </div>
-      </div>
-    </ErrorLayout>
-  )
+  if (statusCode === 404) return <Error404Page />
+  return <ErrorPage statusCode={statusCode} />
 }
 
 Error.getInitialProps = async ({ res, err }) => {


### PR DESCRIPTION
## [ADO-2086](https://dev.azure.com/DTS-STN/passport-status/_workitems/edit/2086)

### Description

List of proposed changes:

- Move 404 error page to server-side rendering

### What to test for/How to test

Build the application and `/404` route should show in the load as SSR `λ  (Server)  server-side renders at runtime`.

### Additional Notes

![image](https://user-images.githubusercontent.com/114004123/219121325-0d126e2a-d86b-4c58-9eed-b098ddac7d5e.png)

