### PR TITLE
reset email file number form

### DIFF
--- a/cypress/e2e/email.cy.ts
+++ b/cypress/e2e/email.cy.ts
@@ -124,6 +124,20 @@ describe('responses', () => {
     cy.wait(500)
     cy.checkA11y()
   })
+
+  it('loads result click get another file number button should reset form', () => {
+    cy.get('#response-result').should('exist')
+    cy.focused().should('have.prop', 'tagName').should('eq', 'H1')
+    cy.get('button#get-another-file-number').click()
+    cy.wait(200)
+    cy.focused().should('have.prop', 'tagName').should('eq', 'H1')
+    cy.get('#email').invoke('val').should('be.empty')
+    cy.get('#givenName').invoke('val').should('be.empty')
+    cy.get('#surname').invoke('val').should('be.empty')
+    cy.get('#dateOfBirth-year').invoke('val').should('be.null')
+    cy.get('#dateOfBirth-month').invoke('val').should('be.null')
+    cy.get('#dateOfBirth-day').invoke('val').should('be.null')
+  })
 })
 
 describe('cancel email esrf', () => {

--- a/src/pages/email.tsx
+++ b/src/pages/email.tsx
@@ -1,4 +1,11 @@
-import { FC, useCallback, useMemo, useRef, useState } from 'react'
+import {
+  FC,
+  MouseEventHandler,
+  useCallback,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
 
 import { useFormik, validateYupSchema, yupToFormErrors } from 'formik'
 import { GetServerSideProps } from 'next'
@@ -59,6 +66,7 @@ const Email: FC = () => {
     isLoading: isEmailEsrfLoading,
     isSuccess: isEmailEsrfSuccess,
     mutate: emailEsrf,
+    reset: resetEmailEsrf,
   } = useEmailEsrf({ onSuccess: () => scrollToHeading() })
 
   const {
@@ -66,6 +74,7 @@ const Email: FC = () => {
     handleChange: handleFormikChange,
     handleSubmit: handleFormikSubmit,
     setFieldValue: setFormikFieldValue,
+    resetForm: resetFormik,
     values: formikValues,
   } = useFormik<EmailEsrfApiRequestBody>({
     initialValues,
@@ -113,7 +122,16 @@ const Email: FC = () => {
     [router]
   )
 
-  const handleOnNewFileRequest = useCallback(() => router.reload(), [router])
+  const handleOnNewFileRequest: MouseEventHandler<HTMLButtonElement> =
+    useCallback(
+      (e) => {
+        e.preventDefault()
+        resetFormik()
+        resetEmailEsrf()
+        scrollToHeading()
+      },
+      [resetEmailEsrf, resetFormik, scrollToHeading]
+    )
 
   //if the api failed, fail hard to show error page
   if (emailEsrfError) throw emailEsrfError
@@ -139,7 +157,7 @@ const Email: FC = () => {
           </p>
           <div className="my-8">
             <ActionButton
-              id="getAnotherFileNumber"
+              id="get-another-file-number"
               type="button"
               text={t('request-another')}
               onClick={handleOnNewFileRequest}


### PR DESCRIPTION
## [ADO-2252](https://dev.azure.com/DTS-STN/passport-status/_workitems/edit/2252) - 🐛

### Description

List of proposed changes:

- Reset email my file number form instead of a page reload

### What to test for/How to test

Build and start the application. Go to request my file number page, fill and submit the form. Then click `Request another file number` button. The form should be resetted and the focus should be the Heading-1.

### Additional Notes
