### PR TITLE
add data-gc-analytics-exempt link attribute

### DIFF
--- a/public/locales/en/status.json
+++ b/public/locales/en/status.json
@@ -127,7 +127,7 @@
   },
   "status-check-tracking": {
     "number": "Your tracking number is <strong>{{trackingNumber}}</strong>.",
-    "can-track": "You can <Link>track the package online</Link>",
+    "can-track": "You can track the package online",
     "link": {
       "canada-post": "https://www.canadapost-postescanada.ca/track-reperage/en#/details/{{trackingNumber}}",
       "fedex": "https://www.fedex.com/fedextrack/?action=track&cntry_code=ca&locale=en_ca&trackingnumber={{trackingNumber}}"

--- a/public/locales/fr/status.json
+++ b/public/locales/fr/status.json
@@ -127,7 +127,7 @@
   },
   "status-check-tracking": {
     "number": "Votre numéro de repérage est <strong>{{trackingNumber}}</strong>.",
-    "can-track": "Vous pouvez faire le <Link>suivi de l'envoi en ligne</Link>",
+    "can-track": "Vous pouvez faire le suivi de l'envoi en ligne",
     "link": {
       "canada-post": "https://www.canadapost-postescanada.ca/track-reperage/fr#/details/{{trackingNumber}}",
       "fedex": "https://www.fedex.com/fedextrack/?action=track&cntry_code=ca&locale=fr_ca&trackingnumber={{trackingNumber}}"

--- a/src/components/ExternalLink.tsx
+++ b/src/components/ExternalLink.tsx
@@ -1,15 +1,29 @@
-import { FC, PropsWithChildren } from 'react'
+import {
+  AnchorHTMLAttributes,
+  DetailedHTMLProps,
+  FC,
+  PropsWithChildren,
+} from 'react'
 
 import { useTranslation } from 'next-i18next'
 
-export interface ExternalLinkProps extends PropsWithChildren {
+export interface ExternalLinkProps
+  extends DetailedHTMLProps<
+      AnchorHTMLAttributes<HTMLAnchorElement>,
+      HTMLAnchorElement
+    >,
+    PropsWithChildren {
   href: string
 }
 
-export const ExternalLink: FC<ExternalLinkProps> = ({ children, href }) => {
+export const ExternalLink: FC<ExternalLinkProps> = ({
+  children,
+  href,
+  ...rest
+}) => {
   const { t } = useTranslation(['common'])
   return (
-    <a href={href} target="_blank" rel="noopener noreferrer">
+    <a {...rest} href={href} target="_blank" rel="noopener noreferrer">
       {children}
       <span className="sr-only">{t('opens-in-new-tab')}</span>
     </a>

--- a/src/components/check-status-responses/CheckStatusShippingCanadaPost.tsx
+++ b/src/components/check-status-responses/CheckStatusShippingCanadaPost.tsx
@@ -34,6 +34,7 @@ export const CheckStatusShippingCanadaPost: FC<
             </p>
             <p>
               <ExternalLink
+                data-gc-analytics-exempt={true}
                 href={t('status-check-tracking.link.canada-post', {
                   trackingNumber: encodeURIComponent(trackingNumber),
                 })}

--- a/src/components/check-status-responses/CheckStatusShippingFedex.tsx
+++ b/src/components/check-status-responses/CheckStatusShippingFedex.tsx
@@ -33,6 +33,7 @@ export const CheckStatusShippingFedex: FC<CheckStatusShippingFedexProps> = ({
             </p>
             <p>
               <ExternalLink
+                data-gc-analytics-exempt={true}
                 href={t('status-check-tracking.link.fedex', {
                   trackingNumber: encodeURIComponent(trackingNumber),
                 })}


### PR DESCRIPTION
## [ADO-XXX](https://dev.azure.com/DTS-STN/passport-status/_workitems/edit/xxx)

### Description

List of proposed changes:

- add data-gc-analytics-exempt link attribute in order to exempt outbound link clicks from analytics tracking

### What to test for/How to test

### Additional Notes
