### PR TITLE
unilingual dcterms.title

### DIFF
--- a/src/lib/utils/seo-utils.ts
+++ b/src/lib/utils/seo-utils.ts
@@ -1,8 +1,8 @@
 import { MetaTag } from 'next-seo/lib/types'
 
-export type GetDCTermsTitle = (contentEn: string, contentFr: string) => MetaTag
+export type GetDCTermsTitle = (content: string) => MetaTag
 
-export const getDCTermsTitle: GetDCTermsTitle = (contentEn, contentFr) => ({
+export const getDCTermsTitle: GetDCTermsTitle = (content) => ({
   name: 'dcterms.title',
-  content: `${contentEn} - ${contentFr}`,
+  content,
 })

--- a/src/pages/email.tsx
+++ b/src/pages/email.tsx
@@ -54,9 +54,7 @@ const validationSchema = Yup.object({
 })
 
 const Email: FC = () => {
-  const { t, i18n } = useTranslation('email')
-  const en = i18n.getFixedT('en', 'email')
-  const fr = i18n.getFixedT('fr', 'email')
+  const { t } = useTranslation('email')
 
   const router = useRouter()
   const headingRef = useRef<HTMLHeadingElement>(null)
@@ -123,10 +121,9 @@ const Email: FC = () => {
 
   const handleOnModalClose = useCallback(() => setModalOpen(false), [])
 
-  const handleOnModalYesButtonClick = useCallback(
-    () => router.push('/landing'),
-    [router]
-  )
+  const handleOnModalYesButtonClick = useCallback(() => {
+    router.push('/landing')
+  }, [router])
 
   const handleOnNewFileRequest: MouseEventHandler<HTMLButtonElement> =
     useCallback(
@@ -146,7 +143,7 @@ const Email: FC = () => {
     <Layout>
       <NextSeo
         title={t('header')}
-        additionalMetaTags={[getDCTermsTitle(en('header'), fr('header'))]}
+        additionalMetaTags={[getDCTermsTitle(t('header'))]}
       />
       <IdleTimeout />
 
@@ -329,12 +326,7 @@ const Email: FC = () => {
 
 export const getServerSideProps: GetServerSideProps = async ({ locale }) => ({
   props: {
-    ...(await serverSideTranslations(
-      locale ?? 'default',
-      ['common', 'email'],
-      null,
-      ['en', 'fr']
-    )),
+    ...(await serverSideTranslations(locale ?? 'default', ['common', 'email'])),
   },
 })
 

--- a/src/pages/expectations.tsx
+++ b/src/pages/expectations.tsx
@@ -14,9 +14,7 @@ import Layout from '../components/Layout'
 import { getDCTermsTitle } from '../lib/utils/seo-utils'
 
 const Expectations: FC = () => {
-  const { t, i18n } = useTranslation('expectations')
-  const en = i18n.getFixedT('en', 'expectations')
-  const fr = i18n.getFixedT('fr', 'expectations')
+  const { t } = useTranslation('expectations')
 
   const handleOnAgreeClick: MouseEventHandler<HTMLButtonElement> = useCallback(
     (e) => {
@@ -31,7 +29,7 @@ const Expectations: FC = () => {
     <>
       <NextSeo
         description={t('meta.description')}
-        additionalMetaTags={[getDCTermsTitle(en('header'), fr('header'))]}
+        additionalMetaTags={[getDCTermsTitle(t('header'))]}
       />
       <Layout>
         <h1 className="h1">{t('header')}</h1>
@@ -115,12 +113,10 @@ const Expectations: FC = () => {
 
 export const getServerSideProps: GetServerSideProps = async ({ locale }) => ({
   props: {
-    ...(await serverSideTranslations(
-      locale ?? 'default',
-      ['common', 'expectations'],
-      null,
-      ['en', 'fr']
-    )),
+    ...(await serverSideTranslations(locale ?? 'default', [
+      'common',
+      'expectations',
+    ])),
   },
 })
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -13,8 +13,7 @@ const Index = () => {
         titleTemplate="%s - Canada.ca"
         additionalMetaTags={[
           getDCTermsTitle(
-            'Passport Application Status Checker',
-            "Vérificateur de l'état d'une demande de passeport"
+            "Passport Application Status Checker - Vérificateur de l'état d'une demande de passeport"
           ),
         ]}
       />

--- a/src/pages/landing.tsx
+++ b/src/pages/landing.tsx
@@ -13,15 +13,13 @@ import LinkButton from '../components/LinkButton'
 import { getDCTermsTitle } from '../lib/utils/seo-utils'
 
 const Landing: FC = () => {
-  const { t, i18n } = useTranslation('landing')
-  const en = i18n.getFixedT('en', 'landing')
-  const fr = i18n.getFixedT('fr', 'landing')
+  const { t } = useTranslation('landing')
 
   return (
     <Layout>
       <NextSeo
         title={t('header')}
-        additionalMetaTags={[getDCTermsTitle(en('header'), fr('header'))]}
+        additionalMetaTags={[getDCTermsTitle(t('header'))]}
       />
       <h1 className="h1">{t('header')}</h1>
       <p>{t('description')}</p>
@@ -128,12 +126,10 @@ const Landing: FC = () => {
 
 export const getServerSideProps: GetServerSideProps = async ({ locale }) => ({
   props: {
-    ...(await serverSideTranslations(
-      locale ?? 'default',
-      ['common', 'landing'],
-      null,
-      ['en', 'fr']
-    )),
+    ...(await serverSideTranslations(locale ?? 'default', [
+      'common',
+      'landing',
+    ])),
   },
 })
 

--- a/src/pages/status.tsx
+++ b/src/pages/status.tsx
@@ -53,9 +53,7 @@ const validationSchema = Yup.object({
 })
 
 const Status: FC = () => {
-  const { t, i18n } = useTranslation('status')
-  const en = i18n.getFixedT('en', 'status')
-  const fr = i18n.getFixedT('fr', 'status')
+  const { t } = useTranslation('status')
 
   const router = useRouter()
   const headingRef = useRef<HTMLHeadingElement>(null)
@@ -156,10 +154,9 @@ const Status: FC = () => {
 
   const handleOnModalClose = useCallback(() => setModalOpen(false), [])
 
-  const handleOnModalYesButtonClick = useCallback(
-    () => router.push('/landing'),
-    [router]
-  )
+  const handleOnModalYesButtonClick = useCallback(() => {
+    router.push('/landing')
+  }, [router])
 
   //if the api failed, fail hard to show error page
   if (checkStatusError) throw checkStatusError
@@ -168,7 +165,7 @@ const Status: FC = () => {
     <Layout>
       <NextSeo
         title={t('header')}
-        additionalMetaTags={[getDCTermsTitle(en('header'), fr('header'))]}
+        additionalMetaTags={[getDCTermsTitle(t('header'))]}
       />
       <IdleTimeout />
       {checkStatusResponse !== undefined ? (
@@ -310,12 +307,10 @@ const Status: FC = () => {
 
 export const getServerSideProps: GetServerSideProps = async ({ locale }) => ({
   props: {
-    ...(await serverSideTranslations(
-      locale ?? 'default',
-      ['common', 'status'],
-      null,
-      ['en', 'fr']
-    )),
+    ...(await serverSideTranslations(locale ?? 'default', [
+      'common',
+      'status',
+    ])),
   },
 })
 


### PR DESCRIPTION
### Description

List of proposed changes:

- unilingual dcterms.title

### Additional Notes

This change is semething that was done on Senior Journey. AA team requested us to not put binlingual title as it can be a "risk" because the field have a max lenght of 255 characters. I think it's good to implement the same recommendation in Passport Status.

> It is not recommended to use dual language page title tags because there are string length limits for each dimension variable in AA. The title tag limit is approx.. 255 characters long (most others are 100 characters or less). Combing title values increases the chances of truncation and data loss or entangling. It can offer some positive impacts for the presentation of the values in reports. But those benefits are almost always out weighed by the negatives.  Its not a “deal breaker” as long as all the other variables that get tracked are standard and uncompromised. YDG for its own reasons decided to ignore the recommendation and assume the risk.
>
> -- Docemo, Sean S [NC]