### PR TITLE
[docker]: Add --ignore-scripts ci flag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,7 @@ COPY --from=builder /app/next-i18next.config.js ./next-i18next.config.js
 
 # install next.js
 COPY --from=builder /app/package*.json ./
-RUN npm ci --omit=dev
+RUN npm ci --omit=dev --ignore-scripts
 
 USER nextjs
 


### PR DESCRIPTION
### Description

List of proposed changes:

- [docker]: Add --ignore-scripts ci flag

### Additional Notes

ignore-scripts
https://docs.npmjs.com/cli/v7/commands/npm-ci#ignore-scripts

> Note that commands explicitly intended to run a particular script, such as npm start, npm stop, npm restart, npm test, and npm run-script will still run their intended script if ignore-scripts is set, but they will not run any pre- or post-scripts.