### PR TITLE
Misc

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -58,6 +58,7 @@ export interface EmailEsrfApiRequestBody {
 }
 
 export interface HealthApiResponse {
+  adobeAnalyticsScriptSrc: string | null
   appBaseUri: string | null
   buildDate: string | null
   environment: string | null

--- a/src/pages/api/alerts.ts
+++ b/src/pages/api/alerts.ts
@@ -10,16 +10,17 @@ export default async function handler(
   res: NextApiResponse<Alert[] | string>,
 ) {
   try {
-    if (!process.env.ALERT_JSON_URI) {
-      logger.error('ALERT_JSON_URI must not be undefined, null or empty')
-      throw Error(
-        'process.env.ALERT_JSON_URI must not be undefined, null or empty',
-      )
-    }
-
     if (req.method !== 'GET') {
       logger.debug(`error 405: Invalid request method ${req.method}`)
       return res.status(405).send(`Invalid request method ${req.method}`)
+    }
+
+    if (!process.env.ALERT_JSON_URI?.trim()) {
+      logger.warn(
+        'ALERT_JSON_URI is either undefined, null, or an empty string. Consequently, an empty array is being returned.',
+      )
+      res.status(200).json([])
+      return
     }
 
     const query = req.query
@@ -52,10 +53,10 @@ export default async function handler(
       type: alert.type,
     }))
 
-    return res.status(200).json(alerts)
+    res.status(200).json(alerts)
   } catch (error) {
     // If there's a problem with the alerts, we return 500 but with an empty list
     logger.error(error, 'Failed to fetch alerts')
-    return res.status(500).json([])
+    res.status(500).json([])
   }
 }

--- a/src/pages/api/health.ts
+++ b/src/pages/api/health.ts
@@ -16,6 +16,7 @@ export default async function handler(
   }
 
   res.status(200).json({
+    adobeAnalyticsScriptSrc: process.env.ADOBE_ANALYTICS_SCRIPT_SRC ?? null,
     appBaseUri: process.env.APP_BASE_URI ?? null,
     buildDate: process.env.NEXT_PUBLIC_BUILD_DATE ?? null,
     environment: process.env.ENVIRONMENT ?? null,


### PR DESCRIPTION
### Description

List of proposed changes:

- Warn when ALERT_JSON_URI doesn't exists
- Add adobeAnalyticsScriptSrc to heath endpoint

### Additional Notes

Warn when ALERT_JSON_URI doesn't exists instead of throwing an exception. Some environments and local devellopement have not that variable set and it's not a required variable.

```shell
{"level":50,"time":"2023-11-15T18:38:00.696Z","pid":25,"hostname":"passport-status-frontend-dev-7fc57779c-fm9bw","name":"get-alerts","msg":"ALERT_JSON_URI must not be undefined, null or empty"}
{"level":50,"time":"2023-11-15T18:38:00.697Z","pid":25,"hostname":"passport-status-frontend-dev-7fc57779c-fm9bw","name":"get-alerts","err":{"type":"Error","message":"process.env.ALERT_JSON_URI must not be undefined, null or empty","stack":"Error: process.env.ALERT_JSON_URI must not be undefined, null or empty\n    at handler (/app/.next/server/pages/api/alerts.js:1:473)\n    at /app/node_modules/next/dist/compiled/next-server/pages-api.runtime.prod.js:20:16566\n    at /app/node_modules/next/dist/server/lib/trace/tracer.js:131:36\n    at NoopContextManager.with (/app/node_modules/next/dist/compiled/@opentelemetry/api/index.js:1:7057)\n    at ContextAPI.with (/app/node_modules/next/dist/compiled/@opentelemetry/api/index.js:1:516)\n    at NoopTracer.startActiveSpan (/app/node_modules/next/dist/compiled/@opentelemetry/api/index.js:1:18086)\n    at ProxyTracer.startActiveSpan (/app/node_modules/next/dist/compiled/@opentelemetry/api/index.js:1:18847)\n    at /app/node_modules/next/dist/server/lib/trace/tracer.js:120:103\n    at NoopContextManager.with (/app/node_modules/next/dist/compiled/@opentelemetry/api/index.js:1:7057)\n    at ContextAPI.with (/app/node_modules/next/dist/compiled/@opentelemetry/api/index.js:1:516)"},"msg":"Failed to fetch alerts"}
{"level":50,"time":"2023-11-15T18:38:00.771Z","pid":25,"hostname":"passport-status-frontend-dev-7fc57779c-fm9bw","name":"get-alerts","msg":"ALERT_JSON_URI must not be undefined, null or empty"}
{"level":50,"time":"2023-11-15T18:38:00.771Z","pid":25,"hostname":"passport-status-frontend-dev-7fc57779c-fm9bw","name":"get-alerts","err":{"type":"Error","message":"process.env.ALERT_JSON_URI must not be undefined, null or empty","stack":"Error: process.env.ALERT_JSON_URI must not be undefined, null or empty\n    at handler (/app/.next/server/pages/api/alerts.js:1:473)\n    at /app/node_modules/next/dist/compiled/next-server/pages-api.runtime.prod.js:20:16566\n    at /app/node_modules/next/dist/server/lib/trace/tracer.js:131:36\n    at NoopContextManager.with (/app/node_modules/next/dist/compiled/@opentelemetry/api/index.js:1:7057)\n    at ContextAPI.with (/app/node_modules/next/dist/compiled/@opentelemetry/api/index.js:1:516)\n    at NoopTracer.startActiveSpan (/app/node_modules/next/dist/compiled/@opentelemetry/api/index.js:1:18086)\n    at ProxyTracer.startActiveSpan (/app/node_modules/next/dist/compiled/@opentelemetry/api/index.js:1:18847)\n    at /app/node_modules/next/dist/server/lib/trace/tracer.js:120:103\n    at NoopContextManager.with (/app/node_modules/next/dist/compiled/@opentelemetry/api/index.js:1:7057)\n    at ContextAPI.with (/app/node_modules/next/dist/compiled/@opentelemetry/api/index.js:1:516)"},"msg":"Failed to fetch alerts"}
{"level":50,"time":"2023-11-15T18:38:01.787Z","pid":25,"hostname":"passport-status-frontend-dev-7fc57779c-fm9bw","name":"get-alerts","msg":"ALERT_JSON_URI must not be undefined, null or empty"}
```