### PR TITLE
Add dependabot groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,21 @@ updates:
     open-pull-requests-limit: 3
     pull-request-branch-name:
       separator: "_"
+    groups:
+      dev-minor-versions:
+        dependency-type: development
+        update-types:
+          - minor
+          - patch
+        patterns:
+          - '*'
+      prod-minor-versions:
+        dependency-type: production
+        update-types:
+          - minor
+          - patch
+        patterns:
+          - '*'
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
This PR introduces Dependabot grouping, enabling Dependabot to consolidate updates into a single pull request for all dependencies, rather than creating multiple separate PRs. This approach simplifies dependency management and reduces noise from multiple PRs.