### PR TITLE
Add h2 heading to application name and underline.

### DIFF
--- a/src/components/ApplicationNameBar.tsx
+++ b/src/components/ApplicationNameBar.tsx
@@ -9,12 +9,14 @@ const ApplicationNameBar = ({ text, href }: ApplicationNameBarProps) => {
   return (
     <div id="app-bar" className="bg-blue-dark">
       <section className="container mx-auto p-4">
-        <Link
-          href={href}
-          className="font-body text-lg font-bold text-white hover:underline md:text-[28px]"
-        >
-          {text}
-        </Link>
+        <h2>
+          <Link
+            href={href}
+            className="font-body text-lg font-bold text-white underline md:text-[28px]"
+          >
+            {text}
+          </Link>
+        </h2>
       </section>
     </div>
   )


### PR DESCRIPTION
## [ADO-4871](https://dev.azure.com/DTS-STN/passport-status/_workitems/edit/4871)

### Description

List of proposed changes:

- Make application name heading H2
- Underline application name link

Also resolves  [ADO-4869](https://dev.azure.com/DTS-STN/passport-status/_workitems/edit/4869)

### What to test for/How to test

### Additional Notes
