### PR TITLE
Fixed the "Update information and try again" button

### DIFF
--- a/src/pages/status.tsx
+++ b/src/pages/status.tsx
@@ -158,15 +158,11 @@ const Status = () => {
   const handleTryAgainClick: MouseEventHandler<HTMLButtonElement> = useCallback(
     async (e) => {
       e.preventDefault()
-      if (checkStatusResponse) {
-        await router.push('/landing')
-        return
-      }
       setFormikStatus(undefined)
       removeCheckStatus(queryClient)
       scrollToHeading()
     },
-    [checkStatusResponse, setFormikStatus, queryClient, router],
+    [setFormikStatus, queryClient],
   )
 
   const handleOnESRFChange: ChangeEventHandler<HTMLInputElement> = useCallback(


### PR DESCRIPTION
## [ADO-5597](https://dev.azure.com/DTS-STN/passport-status/_workitems/edit/5597)

### Description

On the 99 status page, APPLICATION_NO_LONGER_MEETS_CRITERIA, the "Update information and try again" was returning the user to the landing page.

That button is displayed in the CheckStatusNoRecord component, which is used in two scenarios: Then there is an actual 99 code or when invalid data was entered and no status was returned. In both those case, if the user clicks that button, it should return the user to the form.
