### PR TITLE
Remove pick up date when in person pickup

### DIFF
--- a/src/pages/status.tsx
+++ b/src/pages/status.tsx
@@ -300,7 +300,10 @@ const Status = () => {
 
     entries.push({
       status: completedStatus,
-      date: response.completedDate,
+      date:
+        response.deliveryMethod === DeliveryMethodCode.MAIL // Work item #5650 - Explicitly show  date for mail delivery method
+          ? response.completedDate
+          : undefined,
       step: completedText,
     })
 


### PR DESCRIPTION
## [ADO-5650](https://dev.azure.com/DTS-STN/passport-status/_workitems/edit/5650)

### Description

Remove date from ready for pickup step in the timeline when delivery method is in person.