### PR TITLE
Make timeline accessible for screen readers

### DIFF
--- a/public/locales/en/timeline.json
+++ b/public/locales/en/timeline.json
@@ -1,12 +1,17 @@
 {
+  "application-steps-list-title": "Application steps.",
+  "mail-done": "Passport mailed out",
+  "mail-future": "Passport mailed out",
+  "pickup-done": "Ready for pick-up",
+  "pickup-future": "Ready for pick-up",
+  "print-current": "Print",
+  "print-done": "Print complete",
+  "print-future": "Print",
   "received": "Received",
   "review-current": "Review in progress",
   "review-done": "Review complete",
-  "print-future": "Print",
-  "print-current": "Print",
-  "print-done": "Print complete",
-  "mail-future": "Passport mailed out",
-  "mail-done": "Passport mailed out",
-  "pickup-future": "Ready for pick-up",
-  "pickup-done": "Ready for pick-up"
+  "step-aria-label": "Step {{index}}: {{type}}. {{step}}.",
+  "type-current": "in progress",
+  "type-done": "completed",
+  "type-future": "incomplete"
 }

--- a/public/locales/fr/timeline.json
+++ b/public/locales/fr/timeline.json
@@ -1,12 +1,17 @@
 {
+  "application-steps-list-title": "Étapes de la demande.",
+  "mail-done": "Passeport envoyé par la poste",
+  "mail-future": "Passeport envoyé par la poste",
+  "pickup-done": "Prêt pour le retrait",
+  "pickup-future": "Prêt pour le retrait",
+  "print-current": "Impression",
+  "print-done": "Impression terminée",
+  "print-future": "Impression",
   "received": "Reçue",
   "review-current": "Examen en cours",
   "review-done": "Examen terminé",
-  "print-future": "Impression",
-  "print-current": "Impression",
-  "print-done": "Impression terminée",
-  "mail-future": "Passeport envoyé par la poste",
-  "mail-done": "Passeport envoyé par la poste",
-  "pickup-future": "Prêt pour le retrait",
-  "pickup-done": "Prêt pour le retrait"
+  "step-aria-label": "Étape {{index}}: {{type}}. {{step}}.",
+  "type-current": "en cours",
+  "type-done": "terminée",
+  "type-future": "incomplète"
 }

--- a/src/components/Timeline.tsx
+++ b/src/components/Timeline.tsx
@@ -1,5 +1,7 @@
 import { PropsWithChildren } from 'react'
 
+import { useTranslation } from 'react-i18next'
+
 import { TimelineEntryData, TimelinePosition } from '../lib/types'
 import TimelineEntry from './TimelineEntry'
 
@@ -10,9 +12,14 @@ export interface TimelineProps extends PropsWithChildren {
 }
 
 const Timeline = ({ entries, className }: TimelineProps) => {
+  const { t } = useTranslation()
+
   return (
     <div className={className}>
-      <div className="flex flex-col">
+      <ul
+        aria-label={t('timeline:application-steps-list-title')}
+        className="flex flex-col"
+      >
         {entries.map((entry, index) => {
           let position: TimelinePosition = 'last'
           if (index === 0) {
@@ -20,6 +27,7 @@ const Timeline = ({ entries, className }: TimelineProps) => {
           } else if (index < entries.length - 1) {
             position = 'middle'
           }
+
           return (
             <TimelineEntry
               key={entry.step}
@@ -28,10 +36,11 @@ const Timeline = ({ entries, className }: TimelineProps) => {
               step={entry.step}
               date={entry.date}
               subtext={entry.subtext}
+              stepIndex={index + 1} // index is zero based
             />
           )
         })}
-      </div>
+      </ul>
     </div>
   )
 }

--- a/src/components/TimelineEntry.tsx
+++ b/src/components/TimelineEntry.tsx
@@ -11,6 +11,7 @@ export interface TimelineEntryProps extends PropsWithChildren {
   position: TimelinePosition
   className?: string
   background?: boolean
+  stepIndex: number
 }
 
 const topBorderStyle = (
@@ -44,7 +45,7 @@ const SVG = (type: TimelineEntryStatus, background: boolean | undefined) => {
     case 'done': {
       return (
         <svg
-          className={`${background ? 'bg-slate-100' : 'bg-white'} h-9 w-9 fill-accent-success`}
+          className={`${background ? 'bg-slate-100' : 'bg-white'} fill-accent-success h-9 w-9`}
           viewBox="0 0 64 64"
           xmlns="http://www.w3.org/2000/svg"
           aria-hidden="true"
@@ -125,23 +126,24 @@ const TimelineEntry = ({
   subtext,
   className,
   background,
+  stepIndex,
 }: TimelineEntryProps) => {
   const topBorderComputedStyle = topBorderStyle(type, position)
   const bottomBorderComputedStyle = bottomBorderStyle(type, position)
 
   return (
-    <div className={className}>
+    <li className={className}>
       <div className="flex flex-row">
         <div className="align-center mr-2 flex flex-col justify-between">
           <div className="flex h-full w-full justify-center">
             <div
-              className={`h-full w-0 border-l-2 border-r-2 ${topBorderComputedStyle}`}
+              className={`h-full w-0 border-r-2 border-l-2 ${topBorderComputedStyle}`}
             />
           </div>
           <div className={svgStyles[type]}>{SVG(type, background)}</div>
           <div className="flex h-full w-full justify-center">
             <div
-              className={`h-full w-0 border-l-2 border-r-2 ${bottomBorderComputedStyle}`}
+              className={`h-full w-0 border-r-2 border-l-2 ${bottomBorderComputedStyle}`}
             />
           </div>
         </div>
@@ -152,10 +154,11 @@ const TimelineEntry = ({
             topText={step}
             bottomDate={date}
             bottomText={subtext}
+            stepIndex={stepIndex}
           />
         </div>
       </div>
-    </div>
+    </li>
   )
 }
 

--- a/src/components/TimelineEntryContent.tsx
+++ b/src/components/TimelineEntryContent.tsx
@@ -11,6 +11,7 @@ export interface TimelineEntryContentProps extends PropsWithChildren {
   bottomText?: string
   bottomDate?: string
   className?: string
+  stepIndex: number
 }
 
 const TimelineEntryContent = ({
@@ -20,30 +21,43 @@ const TimelineEntryContent = ({
   bottomText,
   bottomDate,
   className,
+  stepIndex,
 }: TimelineEntryContentProps) => {
-  const { i18n } = useTranslation()
+  const { i18n, t } = useTranslation()
   const isCurrent = type === 'current'
   const hasDate = bottomDate !== null
   const isDoneWithBottom = type === 'done' && (hasDate || bottomText !== null)
   const isLast = position === 'last'
 
+  const stepAriaLabel = (() => {
+    const bottomLine = bottomText ?? bottomDate ?? undefined
+    return t('timeline:step-aria-label', {
+      index: stepIndex,
+      type: t(`timeline:type-${type}`),
+      step: `${topText}${bottomLine ? `, ${bottomLine}` : ''}`,
+    })
+  })()
+
   return (
-    <div className={`flex flex-col gap-2`}>
-      {isCurrent || (isDoneWithBottom && isLast) ? (
-        <span>
-          <strong>{topText}</strong>
-        </span>
-      ) : (
-        <span>{topText}</span>
-      )}
-      {type === 'done' && hasDate
-        ? bottomDate && (
-            <time dateTime={bottomDate}>
-              {formatDateLong(bottomDate, i18n.language)}
-            </time>
-          )
-        : bottomText && <span>{bottomText}</span>}
-    </div>
+    <>
+      <span className="sr-only">{stepAriaLabel}</span>
+      <div aria-hidden="true" className={`flex flex-col gap-2`}>
+        {isCurrent || (isDoneWithBottom && isLast) ? (
+          <span>
+            <strong>{topText}</strong>
+          </span>
+        ) : (
+          <span>{topText}</span>
+        )}
+        {type === 'done' && hasDate
+          ? bottomDate && (
+              <time dateTime={bottomDate}>
+                {formatDateLong(bottomDate, i18n.language)}
+              </time>
+            )
+          : bottomText && <span>{bottomText}</span>}
+      </div>
+    </>
   )
 }
 


### PR DESCRIPTION
## [ADO-5652](https://dev.azure.com/DTS-STN/passport-status/_workitems/edit/5652)

### Description
Improved time line accessibility for screen readers.

* Use an unordered list and list items for the time line
* Added aria label to list (Application steps / Étapes de la demande)
* Hide visual content from the screen reader
* Added hidden descriptive content of the steps for the screen readers