### PR TITLE
Hide timeline for old statuses / previously existing

### DIFF
--- a/src/pages/status.tsx
+++ b/src/pages/status.tsx
@@ -237,7 +237,11 @@ const Status = () => {
     ]
 
     // First check for situations where we don't want to return a timeline.
-    if (noTimelineStatuses.includes(status) || !response.receivedDate) {
+    if (
+      noTimelineStatuses.includes(status) ||
+      !response.receivedDate ||
+      new Date(response.receivedDate) <= new Date('1900-01-01') // No timeline for old statuses
+    ) {
       return entries
     }
 
@@ -326,7 +330,7 @@ const Status = () => {
       // get sent across without a receivedDate somehow. So that it will display
       // the original pages for them instead of the pages that require that data.
       const legacyStatus =
-        displayData.receivedDate === '0001-01-01' ||
+        new Date(displayData.receivedDate) <= new Date('1900-01-01') ||
         displayData.serviceLevel === ServiceLevelCode.NOT_AVAILABLE ||
         displayData.deliveryMethod === DeliveryMethodCode.NOT_AVAILABLE
 


### PR DESCRIPTION
## [ADO-6178](https://dev.azure.com/DTS-STN/passport-status/_workitems/edit/6178)

### Description

Hotfix for hiding timeline component for pre-existing data. 

Using 0001-01-01 is not accurate because the API date parses and ends up at 0001-01-03 because of a time skew. Relying on 1900-01-01 is OK for hiding old statuses.


### What to test for/How to test

### Additional Notes
