### PR TITLE
chore(mocks): add mock Link component for testing

### DIFF
--- a/__mocks__/next/link.tsx
+++ b/__mocks__/next/link.tsx
@@ -1,0 +1,11 @@
+import { PropsWithChildren } from 'react'
+
+interface LinkProps extends PropsWithChildren {
+  href: string
+}
+
+const Link = ({ children, href }: LinkProps) => {
+  return <a href={href}>{children}</a>
+}
+
+export default Link


### PR DESCRIPTION
Add mock Link component for testing to avoid the act warning.

An update to ForwardRef(LinkComponent) inside a test was not wrapped in act(...).

next/link internally uses React state and hooks (use-intersection and requestIdleCallback) to prefetch links.