### PR TITLE
feat: add missing information status handling and localization

### DIFF
--- a/cypress/e2e/status.cy.ts
+++ b/cypress/e2e/status.cy.ts
@@ -205,6 +205,12 @@ const statusCodes: ReadonlyArray<CheckStatusApiResponse> = [
     serviceLevel: ServiceLevelCode.TWENTY_DAYS,
   },
   {
+    status: StatusCode.MISSING_INFORMATION,
+    receivedDate: receivedDate,
+    deliveryMethod: DeliveryMethodCode.MAIL,
+    serviceLevel: ServiceLevelCode.TWENTY_DAYS,
+  },
+  {
     status: StatusCode.APPLICATION_NO_LONGER_MEETS_CRITERIA,
     receivedDate: receivedDate,
     deliveryMethod: DeliveryMethodCode.MAIL,
@@ -214,6 +220,8 @@ const statusCodes: ReadonlyArray<CheckStatusApiResponse> = [
 statusCodes.forEach((response) => {
   describe(`responses- loads result - '${response.status}'`, () => {
     beforeEach(() => {
+      cy.get('[data-cy=toggle-language-link]').click()
+      cy.wait(750)
       const esrf = faker.helpers.replaceSymbols('?#######')
       const givenName = faker.person.firstName()
       const surname = faker.person.lastName()
@@ -252,6 +260,10 @@ statusCodes.forEach((response) => {
 
     it(`loads result for status '${response.status}'`, () => {
       cy.get('#response-result').should('exist')
+
+      cy.screenshot(`results-status-${response.status}`, {
+        capture: 'fullPage',
+      })
     })
 
     it(`loads result for status '${response.status}' has no detectable a11y violations`, () => {

--- a/public/locales/en/status.json
+++ b/public/locales/en/status.json
@@ -86,6 +86,34 @@
       "print-update": "Once your passport has been printed, the status of your application will be updated accordingly."
     }
   },
+  "missing-information": {
+    "header": "We need more information",
+    "received-date": "We received your application on {{receivedDate}}. A passport employee is currently reviewing it, but we need more information to continue processing it.",
+    "received-contact": "<strong>We will contact you by telephone or by email.</strong> If we are unable to reach you, we will send you a letter by mail.",
+    "received-note": "<strong>Please note:</strong> our phone number may appear as blocked on your caller ID.",
+    "service-standards": {
+      "heading": "Our service standards",
+      "statement": "Our <Link>service standard</Link> is {{serviceLevel}} business days. However, missing information may delay your application.",
+      "statement-mail": "Our <Link>service standard</Link> is {{serviceLevel}} business days plus mailing time. However, missing information may delay your application."
+    },
+    "why-message": {
+      "heading": "Why you're seeing this message",
+      "description": "You're seeing this message because.",
+      "list": {
+        "item-1": "we need more information or documentation, or",
+        "item-2": "some details in your application don't match our records"
+      },
+      "conclusion": "We need this information to verify your identity and ensure that your application is processed correctly."
+    },
+    "hear-from-us": {
+      "heading": "If you don't hear from us",
+      "description": "If you haven't been contacted yet, please call the Passport Call Centre at <strong>1-800-567-6868</strong>. A representative can help you with your application."
+    },
+    "already-spoken": {
+      "heading": "If you've already spoken to us",
+      "description": "If you've already spoken to a passport employee and you're still seeing this message, don't worry. It may take a few days for this page to update."
+    }
+  },
   "no-record": {
     "can-review": "You can review the information you entered and try again.",
     "cannot-give-status": {

--- a/public/locales/fr/status.json
+++ b/public/locales/fr/status.json
@@ -86,6 +86,34 @@
       "print-update": "Une fois votre passeport imprimé, l'état de votre demande sera mis à jour en conséquence."
     }
   },
+  "missing-information": {
+    "header": "Nous avons besoin de plus d'informations",
+    "received-date": "Nous avons reçu votre demande le {{receivedDate}}. Un employé des passeports est en train de l'examiner, mais nous avons besoin de plus d'informations pour continuer à la traiter.",
+    "received-contact": "<strong>Nous vous contacterons par téléphone ou par courriel.</strong> Si nous ne pouvons pas vous joindre, nous vous enverrons une lettre par la poste.",
+    "received-note": "<strong>Veuillez noter :</strong> notre numéro de téléphone peut apparaître comme bloqué sur votre afficheur.",
+    "service-standards": {
+      "heading": "Nos normes de service",
+      "statement": "Notre <Link>norme de service</Link> est {{serviceLevel}} jours ouvrables. Cependant, des informations manquantes peuvent retarder votre demande.",
+      "statement-mail": "Notre <Link>norme de service</Link> est {{serviceLevel}} jours ouvrables, plus le délai de livraison. Cependant, des informations manquantes peuvent retarder votre demande."
+    },
+    "why-message": {
+      "heading": "Pourquoi voyez-vous ce message",
+      "description": "Vous voyez ce message parce que :",
+      "list": {
+        "item-1": "nous avons besoin de plus d'informations ou de documents, ou",
+        "item-2": "certains détails dans votre demande ne correspondent pas à nos dossiers"
+      },
+      "conclusion": "Dans la plupart des cas, il s'agit d'un problème simple qui peut être résolu rapidement."
+    },
+    "hear-from-us": {
+      "heading": "Si vous ne recevez pas de nos nouvelles",
+      "description": "Si vous n'avez pas encore été contacté, veuillez appeler le Centre d'appels des passeports au <strong>1-800-567-6868</strong>. Un représentant pourra vous aider avec votre demande."
+    },
+    "already-spoken": {
+      "heading": "Si vous nous avez déjà parlé",
+      "description": "Si vous avez déjà parlé à un employé du service des passeports et que vous voyez toujours ce message, ne vous inquiétez pas. La mise à jour de cette page peut prendre quelques jours."
+    }
+  },
   "no-record": {
     "can-review": "Vous pouvez revérifier vos renseignements et essayer à nouveau.",
     "cannot-give-status": {

--- a/src/components/check-status-responses/CheckStatusMissingInformation.tsx
+++ b/src/components/check-status-responses/CheckStatusMissingInformation.tsx
@@ -1,0 +1,139 @@
+import { Trans, useTranslation } from 'next-i18next'
+
+import { DeliveryMethodCode, ServiceLevelCode } from '../../lib/types'
+import { formatDateShort } from '../../lib/utils/dates'
+import { StatusResultProps } from '../../pages/status'
+import ActionButton from '../ActionButton'
+import AlertBlock from '../AlertBlock'
+import ExternalLink from '../ExternalLink'
+import Timeline from '../Timeline'
+
+export const CheckStatusMissingInformation = ({
+  displayData,
+  checkAnotherHandler,
+}: StatusResultProps) => {
+  const { t, i18n } = useTranslation(['status', 'common'])
+
+  const {
+    deliveryMethod,
+    receivedDate,
+    serviceLevel,
+    timelineExists,
+    timelineData,
+  } = displayData
+
+  const serviceDays = serviceLevel === ServiceLevelCode.TEN_DAYS ? '10' : '20'
+
+  const formattedDate = formatDateShort(receivedDate, i18n.language)
+
+  return (
+    <div id="response-result">
+      <AlertBlock page="status-processing" />
+      <h1
+        id="main-header"
+        data-testid="being-processed"
+        className="h1"
+        tabIndex={-1}
+      >
+        {t('missing-information.header')}
+      </h1>
+      <div className="flex flex-col md:flex-row md:gap-x-30 lg:gap-x-40 xl:gap-x-50">
+        <div className="max-w-prose">
+          <p>
+            <Trans
+              i18nKey={'missing-information.received-date'}
+              ns="status"
+              values={{
+                receivedDate: formattedDate,
+              }}
+            />
+          </p>
+          <p>
+            <Trans
+              i18nKey={'missing-information.received-contact'}
+              ns="status"
+            />
+          </p>
+          <p>
+            <Trans i18nKey={'missing-information.received-note'} ns="status" />
+          </p>
+
+          <h2
+            id="service-standards-header"
+            data-testid="service-standards"
+            className="h2"
+          >
+            {t('missing-information.service-standards.heading')}
+          </h2>
+          <Trans
+            i18nKey={
+              deliveryMethod === DeliveryMethodCode.MAIL
+                ? 'missing-information.service-standards.statement-mail'
+                : 'missing-information.service-standards.statement'
+            }
+            ns="status"
+            values={{
+              serviceLevel: serviceDays,
+            }}
+            components={{
+              Link: (
+                <ExternalLink
+                  href={t('status-check-contact.service-standard-href')}
+                />
+              ),
+            }}
+          />
+
+          <h2 id="why-message-header" data-testid="why-message" className="h2">
+            {t('missing-information.why-message.heading')}
+          </h2>
+          <p>{t('missing-information.why-message.description')}</p>
+          <ul className="mb-5 list-disc space-y-2 pl-10">
+            <li>{t('missing-information.why-message.list.item-1')}</li>
+            <li>{t('missing-information.why-message.list.item-2')}</li>
+          </ul>
+
+          <h2
+            id="hear-from-us-header"
+            data-testid="hear-from-us"
+            className="h2"
+          >
+            {t('missing-information.hear-from-us.heading')}
+          </h2>
+          <p>
+            <Trans
+              i18nKey={'missing-information.hear-from-us.description'}
+              ns="status"
+            />
+          </p>
+
+          <h2
+            id="already-spoken-header"
+            data-testid="already-spoken"
+            className="h2"
+          >
+            {t('missing-information.already-spoken.heading')}
+          </h2>
+          <p>{t('missing-information.already-spoken.description')}</p>
+
+          <div className="mt-8">
+            <ActionButton
+              onClick={checkAnotherHandler}
+              text={t('status:check-another')}
+              style="primary"
+            />
+          </div>
+        </div>
+        {timelineExists && (
+          <div className="hidden w-full md:flex">
+            <div className="-mt-6">
+              <Timeline entries={timelineData} />
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export default CheckStatusMissingInformation

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -136,6 +136,7 @@ export enum StatusCode {
   NOT_ACCEPTABLE_FOR_PROCESSING = '5',
   PASSPORT_IS_PRINTING = '6',
   FILE_BEING_PROCESSED_OVERDUE = '7',
+  MISSING_INFORMATION = '8',
 }
 
 export type TimelineEntryStatus = 'done' | 'current' | 'future'

--- a/src/pages/status.tsx
+++ b/src/pages/status.tsx
@@ -32,6 +32,7 @@ import InputField from '../components/InputField'
 import Layout from '../components/Layout'
 import Modal from '../components/Modal'
 import CheckStatusFileBeingProcessed from '../components/check-status-responses/CheckStatusFileBeingProcessed'
+import CheckStatusMissingInformation from '../components/check-status-responses/CheckStatusMissingInformation'
 import CheckStatusNoRecord from '../components/check-status-responses/CheckStatusNoRecord'
 import CheckStatusNotAcceptable from '../components/check-status-responses/CheckStatusNotAcceptable'
 import CheckStatusPrinting from '../components/check-status-responses/CheckStatusPrinting'
@@ -206,6 +207,8 @@ const Status = () => {
         return t('shipped-fedex.header')
       case StatusCode.NOT_ACCEPTABLE_FOR_PROCESSING:
         return t('not-acceptable.header')
+      case StatusCode.MISSING_INFORMATION:
+        return t('missing-information.header')
       default:
         return t('no-record.cannot-give-status.description')
     }
@@ -226,6 +229,7 @@ const Status = () => {
     const processingStatuses = [
       StatusCode.FILE_BEING_PROCESSED,
       StatusCode.FILE_BEING_PROCESSED_OVERDUE,
+      StatusCode.MISSING_INFORMATION,
     ]
 
     const printingStatuses = [StatusCode.PASSPORT_IS_PRINTING]
@@ -390,6 +394,13 @@ const Status = () => {
         case StatusCode.NOT_ACCEPTABLE_FOR_PROCESSING:
           return (
             <CheckStatusNotAcceptable
+              checkAnotherHandler={handleCheckAnotherClick}
+            />
+          )
+        case StatusCode.MISSING_INFORMATION:
+          return (
+            <CheckStatusMissingInformation
+              displayData={displayData}
               checkAnotherHandler={handleCheckAnotherClick}
             />
           )


### PR DESCRIPTION
## [ADO-4734](https://dev.azure.com/DTS-STN/passport-status/_workitems/edit/4734)

Please create a new status page: 'We need more information'. This is for clients whose applications have been identified as being incomplete or missing information. Please use the same font, formatting, and spacing as existing status pages.
